### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/docs/source/upload.py
+++ b/docs/source/upload.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import sys
 from subprocess import call
 
@@ -43,11 +44,11 @@ def query_yes_no(question, default="yes"):
 def upload(root=False):
     # build html
     if not query_yes_no("Upload Release: %s" % str(release)):
-        print "Not uploading"
+        print("Not uploading")
         return
 
     if root and not query_yes_no("Upload to root?"):
-        print "Not uploading"
+        print("Not uploading")
         return
 
     call(["make", "clean", "html"])

--- a/featuretools/__init__.py
+++ b/featuretools/__init__.py
@@ -1,7 +1,8 @@
+from __future__ import absolute_import
 # flake8: noqa
-import config
+from . import config
 from .core import *
-import variable_types
+from . import variable_types
 from .entityset.api import *
 from . import primitives
 from .synthesis.api import *

--- a/featuretools/entityset/base_entity.py
+++ b/featuretools/entityset/base_entity.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import logging
 
 import pandas as pd
@@ -228,14 +229,14 @@ class BaseEntity(FTBase):
                 value = self.get_column_stat(var_id, stat)
                 setattr(self._get_variable(var_id), stat, value)
             except TypeError as e:
-                print e
+                print(e)
 
         stats = vartype._computed_stats
         for stat in stats:
             try:
                 setattr(self._get_variable(var_id), stat, value)
             except TypeError as e:
-                print e
+                print(e)
 
     def get_column_stat(self, variable_id, stat):
         raise NotImplementedError()

--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import copy
 import logging
 import time
@@ -297,7 +298,7 @@ class Entity(BaseEntity):
             self.indexed_by[relation_var_id] = {}
         else:
             if self._verbose:
-                print 'Re-indexing %s by %s' % (self.id, parent_entity.id)
+                print('Re-indexing %s by %s' % (self.id, parent_entity.id))
 
         self.index_by_variable(relation_var_id)
 
@@ -311,16 +312,16 @@ class Entity(BaseEntity):
         index = self.indexed_by[variable_id]
 
         if self._verbose:
-            print "Indexing '%s' in %d groups by variable '%s'" %\
-                (self.id, len(gb.groups), variable_id)
+            print("Indexing '%s' in %d groups by variable '%s'" %\
+                (self.id, len(gb.groups), variable_id))
 
         # index by each parent instance separately
         for i in gb.groups:
             index[i] = np.array(gb.groups[i])
 
         if self._verbose:
-            print "...%d child instances took %.2f seconds" %\
-                (len(self.df.index), time.time() - ts)
+            print("...%d child instances took %.2f seconds" %\
+                (len(self.df.index), time.time() - ts))
 
     def infer_variable_types(self, ignore=None, link_vars=None):
         """Extracts the variables from a dataframe

--- a/featuretools/entityset/print.py
+++ b/featuretools/entityset/print.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 def print_graph(self, start_eid):
     """
     Print a representation of the entityset with parents & children, like
@@ -22,7 +23,7 @@ def print_graph(self, start_eid):
     top_strings = self._build_strings(back_graph[start_eid])[::-1]
     bot_strings = self._build_strings(forward_graph[start_eid])
 
-    print '\n'.join(reversed(top_strings + [start_eid] + bot_strings))
+    print('\n'.join(reversed(top_strings + [start_eid] + bot_strings)))
 
 
 def _build_fwd_graph(self, graph, eid):

--- a/featuretools/primitives/aggregation_primitive_base.py
+++ b/featuretools/primitives/aggregation_primitive_base.py
@@ -141,7 +141,7 @@ def make_agg_primitive(function, input_types, return_type, name=None,
     cls = {"__doc__": description}
     if cls_attributes is not None:
         cls.update(cls_attributes)
-    name = name or function.func_name
+    name = name or function.__name__
     new_class = type(name, (AggregationPrimitive,), cls)
     new_class.name = name
     new_class.input_types = input_types

--- a/featuretools/primitives/primitive_base.py
+++ b/featuretools/primitives/primitive_base.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import copy
 import logging
 import pdb
@@ -188,7 +189,7 @@ class PrimitiveBase(FTBase):
         See also:
             :meth:`PrimitiveBase.equal_to`
         """
-        from binary_transform import Equals
+        from .binary_transform import Equals
         return Equals(self, other_feature_or_val)
 
     def __ne__(self, other_feature_or_val):
@@ -197,7 +198,7 @@ class PrimitiveBase(FTBase):
         See also:
             :meth:`PrimitiveBase.not_equal_to`
         """
-        from binary_transform import NotEquals
+        from .binary_transform import NotEquals
         return NotEquals(self, other_feature_or_val)
 
     def __gt__(self, other_feature_or_val):
@@ -206,7 +207,7 @@ class PrimitiveBase(FTBase):
         See also:
             :meth:`PrimitiveBase.GT`
         """
-        from binary_transform import GreaterThan
+        from .binary_transform import GreaterThan
         return GreaterThan(self, other_feature_or_val)
 
     def __ge__(self, other_feature_or_val):
@@ -215,7 +216,7 @@ class PrimitiveBase(FTBase):
         See also:
             :meth:`PrimitiveBase.greater_than_equal_to`
         """
-        from binary_transform import GreaterThanEqualTo
+        from .binary_transform import GreaterThanEqualTo
         return GreaterThanEqualTo(self, other_feature_or_val)
 
     def __lt__(self, other_feature_or_val):
@@ -224,7 +225,7 @@ class PrimitiveBase(FTBase):
         See also:
             :meth:`PrimitiveBase.less_than`
         """
-        from binary_transform import LessThan
+        from .binary_transform import LessThan
         return LessThan(self, other_feature_or_val)
 
     def __le__(self, other_feature_or_val):
@@ -233,16 +234,16 @@ class PrimitiveBase(FTBase):
         See also:
             :meth:`PrimitiveBase.less_than_equal_to`
         """
-        from binary_transform import LessThanEqualTo
+        from .binary_transform import LessThanEqualTo
         return LessThanEqualTo(self, other_feature_or_val)
 
     def __add__(self, other_feature_or_val):
         """Add other_feature_or_val"""
-        from binary_transform import Add
+        from .binary_transform import Add
         return Add(self, other_feature_or_val)
 
     def __radd__(self, other):
-        from binary_transform import Add
+        from .binary_transform import Add
         return Add(other, self)
 
     def __sub__(self, other_feature_or_val):
@@ -251,11 +252,11 @@ class PrimitiveBase(FTBase):
         See also:
             :meth:`PrimitiveBase.subtract`
         """
-        from binary_transform import Subtract
+        from .binary_transform import Subtract
         return Subtract(self, other_feature_or_val)
 
     def __rsub__(self, other):
-        from binary_transform import Subtract
+        from .binary_transform import Subtract
         return Subtract(other, self)
 
     def __div__(self, other_feature_or_val):
@@ -264,18 +265,18 @@ class PrimitiveBase(FTBase):
         See also:
             :meth:`PrimitiveBase.divide`
         """
-        from binary_transform import Divide
+        from .binary_transform import Divide
         return Divide(self, other_feature_or_val)
 
     def __truediv__(self, other_feature_or_val):
         return self.__div__(other_feature_or_val)
 
     def __rtruediv__(self, other_feature_or_val):
-        from binary_transform import Divide
+        from .binary_transform import Divide
         return Divide(other_feature_or_val, self)
 
     def __rdiv__(self, other_feature_or_val):
-        from binary_transform import Divide
+        from .binary_transform import Divide
         return Divide(other_feature_or_val, self)
 
     def __mul__(self, other_feature_or_val):
@@ -284,11 +285,11 @@ class PrimitiveBase(FTBase):
         See also:
             :meth:`PrimitiveBase.multiply`
         """
-        from binary_transform import Multiply
+        from .binary_transform import Multiply
         return Multiply(self, other_feature_or_val)
 
     def __rmul__(self, other):
-        from binary_transform import Multiply
+        from .binary_transform import Multiply
         return Multiply(other, self)
 
     def __mod__(self, other_feature_or_val):
@@ -297,21 +298,21 @@ class PrimitiveBase(FTBase):
         See also:
             :meth:`PrimitiveBase.modulo`
         """
-        from binary_transform import Mod
+        from .binary_transform import Mod
         return Mod(self, other_feature_or_val)
 
     def __and__(self, other):
         return self.AND(other)
 
     def __rand__(self, other):
-        from binary_transform import And
+        from .binary_transform import And
         return And(other, self)
 
     def __or__(self, other):
         return self.OR(other)
 
     def __ror__(self, other):
-        from binary_transform import Or
+        from .binary_transform import Or
         return Or(other, self)
 
     def __not__(self, other):
@@ -327,34 +328,34 @@ class PrimitiveBase(FTBase):
 
     def AND(self, other_feature):
         """Logical AND with other_feature"""
-        from binary_transform import And
+        from .binary_transform import And
         return And(self, other_feature)
 
     def OR(self, other_feature):
         """Logical OR with other_feature"""
-        from binary_transform import Or
+        from .binary_transform import Or
         return Or(self, other_feature)
 
     def NOT(self):
         """Creates inverse of feature"""
-        from transform_primitive import Not
-        from binary_transform import Compare
+        from .transform_primitive import Not
+        from .binary_transform import Compare
         if isinstance(self, Compare):
             return self.invert()
         return Not(self)
 
     def LIKE(self, like_string, case_sensitive=False):
-        from transform_primitive import Like
+        from .transform_primitive import Like
         return Like(self, like_string,
                     case_sensitive=case_sensitive)
 
     def isin(self, list_of_output):
-        from transform_primitive import IsIn
+        from .transform_primitive import IsIn
         return IsIn(self, list_of_outputs=list_of_output)
 
     def is_null(self):
         """Compares feature to null by equality"""
-        from transform_primitive import IsNull
+        from .transform_primitive import IsNull
         return IsNull(self)
 
     def __invert__(self):
@@ -497,7 +498,7 @@ class Feature(PrimitiveBase):
     """
 
     def __new__(self, feature_or_var, entity=None):
-        import direct_feature
+        from . import direct_feature
 
         if entity is None:
             assert isinstance(feature_or_var, (Variable))

--- a/featuretools/primitives/transform_primitive.py
+++ b/featuretools/primitives/transform_primitive.py
@@ -112,7 +112,7 @@ def make_trans_primitive(function, input_types, return_type, name=None,
         cls.update(cls_attributes)
 
     # creates the new class and set name and types
-    name = name or function.func_name
+    name = name or function.__name__
     new_class = type(name, (TransformPrimitive,), cls)
     new_class.name = name
     new_class.input_types = input_types

--- a/featuretools/synthesis/__init__.py
+++ b/featuretools/synthesis/__init__.py
@@ -1,2 +1,3 @@
+from __future__ import absolute_import
 # flake8: noqa
-from api import *
+from .api import *

--- a/featuretools/synthesis/api.py
+++ b/featuretools/synthesis/api.py
@@ -1,4 +1,5 @@
+from __future__ import absolute_import
 # flake8: noqa
-from deep_feature_synthesis import DeepFeatureSynthesis
-from dfs import dfs
-from encode_features import encode_features
+from .deep_feature_synthesis import DeepFeatureSynthesis
+from .dfs import dfs
+from .encode_features import encode_features

--- a/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
+++ b/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
@@ -150,7 +150,7 @@ def test_saveprogress(entityset):
                                        instance_ids=range(17),
                                        cutoff_time=times,
                                        save_progress=save_progress)
-    _, _, files = os.walk(save_progress).next()
+    _, _, files = next(os.walk(save_progress))
     files = [os.path.join(save_progress, file) for file in files]
     # there is 17 datetime files created above
     assert len(files) == 17

--- a/featuretools/tests/entityset_tests/test_pandas_es.py
+++ b/featuretools/tests/entityset_tests/test_pandas_es.py
@@ -679,16 +679,16 @@ class TestNormalizeEntity(object):
                 datetime(2011, 4, 9, 10, 31, 27),
                 datetime(2011, 4, 10, 10, 41, 3),
                 datetime(2011, 4, 10, 10, 41, 6),
-                datetime(2011, 4, 10, 11, 10, 03),
+                datetime(2011, 4, 10, 11, 10, 0o3),
             ],
             'customers': [
                 datetime(2011, 4, 9, 10, 40, 0),
                 datetime(2011, 4, 10, 10, 41, 6),
-                datetime(2011, 4, 10, 11, 10, 03),
+                datetime(2011, 4, 10, 11, 10, 0o3),
             ]
         }
         region_series = pd.Series({'United States':
-                                   datetime(2011, 4, 10, 11, 10, 03)})
+                                   datetime(2011, 4, 10, 11, 10, 0o3)})
         values_lti = es["values"].last_time_index.sort_index()
         customers_lti = es["customers"].last_time_index.sort_index()
         regions_lti = es["regions"].last_time_index.sort_index()
@@ -698,7 +698,7 @@ class TestNormalizeEntity(object):
 
         # add promotions entity
         promotions_df = pd.DataFrame({
-            "start_date": [datetime(2011, 4, 10, 11, 12, 06)],
+            "start_date": [datetime(2011, 4, 10, 11, 12, 0o6)],
             "store_id": [4],
             "product_id": ['coke zero']
         })
@@ -711,7 +711,7 @@ class TestNormalizeEntity(object):
                                     es['promotions']['store_id'])
         es.add_relationship(relationship)
         es.add_last_time_indexes()
-        region_series['Mexico'] = datetime(2011, 4, 10, 11, 12, 06)
+        region_series['Mexico'] = datetime(2011, 4, 10, 11, 12, 0o6)
         regions_lti = es["regions"].last_time_index.sort_index()
         assert (regions_lti == region_series.sort_index()).all()
 

--- a/featuretools/tests/testing_utils/__init__.py
+++ b/featuretools/tests/testing_utils/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # flake8: noqa
-from mock_ds import make_ecommerce_entityset, save_to_csv
-from features import feature_with_name
+from .mock_ds import make_ecommerce_entityset, save_to_csv
+from .features import feature_with_name


### PR DESCRIPTION
Make the minimal, safe changes required to convert the repo's code to be syntax compatible with both Python 2 and Python 3.  There are other changes required to complete a port to Python 3 but this PR is a minimal, safe first step.

Run: [futurize --stage1 -w **/*.py](http://python-future.org/futurize_cheatsheet.html)

    See Stage 1: "safe" fixes http://python-future.org/automatic_conversion.html#stage-1-safe-fixes
