### PR TITLE
Check argument types for .normalize_entity

### DIFF
--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -802,11 +802,11 @@ class EntitySet(object):
         copy_variables = copy_variables or []
 
         if not isinstance(additional_variables, list):
-            raise TypeError("'additional_variables' must be a list, but received type {}"\
+            raise TypeError("'additional_variables' must be a list, but received type {}"
                             .format(type(additional_variables)))
 
         if not isinstance(copy_variables, list):
-            raise TypeError("'copy_variables' must be a list, but received type {}"\
+            raise TypeError("'copy_variables' must be a list, but received type {}"
                             .format(type(copy_variables)))
 
         for v in additional_variables + copy_variables:

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -733,10 +733,11 @@ def test_add_link_vars(entityset):
 def test_normalize_entity(entityset):
     with pytest.raises(TypeError):
         entityset.normalize_entity('sessions', 'device_types', 'device_type',
-                                   additional_variables = 'log')
+                                   additional_variables='log')
+
     with pytest.raises(TypeError):
         entityset.normalize_entity('sessions', 'device_types', 'device_type',
-                                   copy_variables = 'log')
+                                   copy_variables='log')
 
     entityset.normalize_entity('sessions', 'device_types', 'device_type',
                                additional_variables=['device_name'],


### PR DESCRIPTION
Add exception handling to check argument types of `copy_variables` and `addtional_variables` for `es.normalize_entity`. #194 