### PR TITLE
DFS string support for custom primitives closes #1077

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -7,13 +7,14 @@ Release Notes
     * Enhancements
         * Allow variable descriptions to be set directly on variable (:pr:`1207`)
         * Add ability to add feature description captions to feature lineage graphs (:pr:`1212`)
+        * Allows user to pass in the snakecase string of a custom primitive's class name into DFS(:pr:`1218`)
     * Fixes
     * Changes
     * Documentation Changes
     * Testing Changes
 
     Thanks to the following people for contributing to this release:
-    :user:`frances-h`
+    :user:`tuethan1999`, :user:`frances-h`
 
 **v0.21.0 Oct 30, 2020**
     * Enhancements

--- a/featuretools/primitives/base/primitive_base.py
+++ b/featuretools/primitives/base/primitive_base.py
@@ -6,8 +6,8 @@ import pandas as pd
 from featuretools import config
 from featuretools.primitives.base.utils import signature
 from featuretools.utils.description_utils import convert_to_nth
-from featuretools.utils.gen_utils import Library
-from featuretools.utils.gen_utils import ClassNameDescriptor
+from featuretools.utils.gen_utils import ClassNameDescriptor, Library
+
 
 class PrimitiveBase(object):
     """Base class for all primitives."""

--- a/featuretools/primitives/base/primitive_base.py
+++ b/featuretools/primitives/base/primitive_base.py
@@ -7,7 +7,7 @@ from featuretools import config
 from featuretools.primitives.base.utils import signature
 from featuretools.utils.description_utils import convert_to_nth
 from featuretools.utils.gen_utils import Library
-
+from featuretools.utils.gen_utils import ClassNameDescriptor
 
 class PrimitiveBase(object):
     """Base class for all primitives."""
@@ -41,6 +41,8 @@ class PrimitiveBase(object):
     # `nth_slice` keyword argument. Multi-output primitives can use a list to
     # differentiate between the base description and a slice description.
     description_template = None
+    #: (string): type string of primitive derived from class name.
+    type_string = ClassNameDescriptor()
 
     def __init__(self):
         pass

--- a/featuretools/primitives/standard/transform_primitive.py
+++ b/featuretools/primitives/standard/transform_primitive.py
@@ -428,7 +428,7 @@ class IsIn(TransformPrimitive):
         >>> is_in(['string', 10.5, False]).tolist()
         [True, False, True]
     """
-    name = "isin"
+    name = "is_in"
     input_types = [Variable]
     return_type = Boolean
     compatibility = [Library.PANDAS, Library.DASK, Library.KOALAS]

--- a/featuretools/primitives/utils.py
+++ b/featuretools/primitives/utils.py
@@ -11,6 +11,7 @@ from featuretools.primitives.base import (
     TransformPrimitive
 )
 from featuretools.utils.gen_utils import Library, find_descendents
+
 # returns all aggregation primitives, regardless of compatibility
 
 

--- a/featuretools/primitives/utils.py
+++ b/featuretools/primitives/utils.py
@@ -11,32 +11,18 @@ from featuretools.primitives.base import (
     TransformPrimitive
 )
 from featuretools.utils.gen_utils import Library, find_descendents
-
+from featuretools.primitives.base import AggregationPrimitive, TransformPrimitive
 
 # returns all aggregation primitives, regardless of compatibility
 def get_aggregation_primitives():
-    aggregation_primitives = set([])
-    for attribute_string in dir(featuretools.primitives):
-        attribute = getattr(featuretools.primitives, attribute_string)
-        if isclass(attribute):
-            if issubclass(attribute,
-                          featuretools.primitives.AggregationPrimitive):
-                if attribute.name:
-                    aggregation_primitives.add(attribute)
-    return {prim.name.lower(): prim for prim in aggregation_primitives}
+    return {primitive.type_string: primitive for primitive in find_descendents(AggregationPrimitive)
+            if primitive != AggregationPrimitive}
 
 
 # returns all transform primitives, regardless of compatibility
 def get_transform_primitives():
-    transform_primitives = set([])
-    for attribute_string in dir(featuretools.primitives):
-        attribute = getattr(featuretools.primitives, attribute_string)
-        if isclass(attribute):
-            if issubclass(attribute,
-                          featuretools.primitives.TransformPrimitive):
-                if attribute.name:
-                    transform_primitives.add(attribute)
-    return {prim.name.lower(): prim for prim in transform_primitives}
+    return {primitive.type_string: primitive for primitive in find_descendents(TransformPrimitive)
+            if primitive != TransformPrimitive}
 
 
 def list_primitives():

--- a/featuretools/primitives/utils.py
+++ b/featuretools/primitives/utils.py
@@ -11,9 +11,9 @@ from featuretools.primitives.base import (
     TransformPrimitive
 )
 from featuretools.utils.gen_utils import Library, find_descendents
-from featuretools.primitives.base import AggregationPrimitive, TransformPrimitive
-
 # returns all aggregation primitives, regardless of compatibility
+
+
 def get_aggregation_primitives():
     return {primitive.type_string: primitive for primitive in find_descendents(AggregationPrimitive)
             if primitive != AggregationPrimitive}

--- a/featuretools/tests/synthesis/test_dfs_method.py
+++ b/featuretools/tests/synthesis/test_dfs_method.py
@@ -479,6 +479,34 @@ def test_warns_with_unused_custom_primitives(pd_es):
             agg_primitives=agg_primitives,
             max_depth=1)
 
+def test_type_string_custom_primitives(pd_es):
+    def above_ten(column):
+        return column > 10
+
+    AboveTen = make_trans_primitive(function=above_ten,
+                                    name='above_ten',
+                                    input_types=[Numeric],
+                                    return_type=Numeric)
+    trans_primitives = ['above_ten']
+    dfs(entityset=pd_es,
+        target_entity='stores',
+        trans_primitives=trans_primitives,
+        max_depth=1)
+
+    def max_above_ten(column):
+        return max(column) > 10
+
+    MaxAboveTen = make_agg_primitive(function=max_above_ten,
+                                     input_types=[Numeric],
+                                     return_type=Numeric)
+
+    agg_primitives = ['max_above_ten']
+
+    dfs(entityset=pd_es,
+        target_entity='stores',
+        agg_primitives=agg_primitives,
+        max_depth=1)
+
 
 def test_calls_progress_callback(entities, relationships):
     class MockProgressCallback:

--- a/featuretools/tests/synthesis/test_dfs_method.py
+++ b/featuretools/tests/synthesis/test_dfs_method.py
@@ -25,7 +25,8 @@ from featuretools.primitives import (
 from featuretools.synthesis import dfs
 from featuretools.tests.testing_utils import to_pandas
 from featuretools.utils.gen_utils import import_or_none
-from featuretools.variable_types import Numeric
+from featuretools.variable_types import Numeric, Discrete
+from featuretools.primitives.base import AggregationPrimitive
 
 ks = import_or_none('databricks.koalas')
 
@@ -505,8 +506,25 @@ def test_type_string_custom_primitives(pd_es):
     dfs(entityset=pd_es,
         target_entity='stores',
         agg_primitives=agg_primitives,
-        max_depth=1)
+        max_depth=2)
 
+    class TestAggregationPrimitive(AggregationPrimitive):
+        name = "test_aggregation_primitive"
+        input_types = [Discrete]
+        return_type = Numeric
+        default_value = 0
+        def __init__(self, skipna=True):
+            self.skipna = skipna
+        def get_function(self):
+            def average_count_per_unique(x):
+                return 1
+            return average_count_per_unique
+    
+    dfs(entityset=pd_es,
+        target_entity='stores',
+        agg_primitives=['test_aggregation_primitive'],
+        max_depth=2)
+    
 
 def test_calls_progress_callback(entities, relationships):
     class MockProgressCallback:

--- a/featuretools/tests/synthesis/test_dfs_method.py
+++ b/featuretools/tests/synthesis/test_dfs_method.py
@@ -22,11 +22,11 @@ from featuretools.primitives import (
     make_agg_primitive,
     make_trans_primitive
 )
+from featuretools.primitives.base import AggregationPrimitive
 from featuretools.synthesis import dfs
 from featuretools.tests.testing_utils import to_pandas
 from featuretools.utils.gen_utils import import_or_none
-from featuretools.variable_types import Numeric, Discrete
-from featuretools.primitives.base import AggregationPrimitive
+from featuretools.variable_types import Discrete, Numeric
 
 ks = import_or_none('databricks.koalas')
 

--- a/featuretools/tests/synthesis/test_dfs_method.py
+++ b/featuretools/tests/synthesis/test_dfs_method.py
@@ -480,14 +480,15 @@ def test_warns_with_unused_custom_primitives(pd_es):
             agg_primitives=agg_primitives,
             max_depth=1)
 
+
 def test_type_string_custom_primitives(pd_es):
     def above_ten(column):
         return column > 10
 
-    AboveTen = make_trans_primitive(function=above_ten,
-                                    name='above_ten',
-                                    input_types=[Numeric],
-                                    return_type=Numeric)
+    make_trans_primitive(function=above_ten,
+                         name='above_ten',
+                         input_types=[Numeric],
+                         return_type=Numeric)
     trans_primitives = ['above_ten']
     dfs(entityset=pd_es,
         target_entity='stores',
@@ -497,9 +498,9 @@ def test_type_string_custom_primitives(pd_es):
     def max_above_ten(column):
         return max(column) > 10
 
-    MaxAboveTen = make_agg_primitive(function=max_above_ten,
-                                     input_types=[Numeric],
-                                     return_type=Numeric)
+    make_agg_primitive(function=max_above_ten,
+                       input_types=[Numeric],
+                       return_type=Numeric)
 
     agg_primitives = ['max_above_ten']
 
@@ -513,18 +514,20 @@ def test_type_string_custom_primitives(pd_es):
         input_types = [Discrete]
         return_type = Numeric
         default_value = 0
+
         def __init__(self, skipna=True):
             self.skipna = skipna
+
         def get_function(self):
             def average_count_per_unique(x):
                 return 1
             return average_count_per_unique
-    
+
     dfs(entityset=pd_es,
         target_entity='stores',
         agg_primitives=['test_aggregation_primitive'],
         max_depth=2)
-    
+
 
 def test_calls_progress_callback(entities, relationships):
     class MockProgressCallback:

--- a/featuretools/tests/utils_tests/test_primitives_utils.py
+++ b/featuretools/tests/utils_tests/test_primitives_utils.py
@@ -27,6 +27,8 @@ from featuretools.primitives import (
 )
 from featuretools.primitives.utils import _get_descriptions
 from featuretools.utils.gen_utils import Library
+from featuretools.primitives.base import make_agg_primitive, make_trans_primitive
+from featuretools.variable_types import Numeric, Datetime, DatetimeTimeIndex, Timedelta
 
 
 def test_list_primitives_order():
@@ -46,6 +48,22 @@ def test_list_primitives_order():
     assert 'aggregation' in types
     assert 'transform' in types
 
+def test_custom_primitives():
+    def pd_time_since(array, moment):
+        return (moment - pd.DatetimeIndex(array)).values
+
+    CustomMax = make_agg_primitive(lambda x: max(x),
+                               name="CustomMax",
+                               input_types=[Numeric],
+                               return_type=Numeric)
+    TimeSince = make_trans_primitive(function=pd_time_since,
+                                    input_types=[[DatetimeTimeIndex], [Datetime]],
+                                    return_type=Timedelta,
+                                    uses_calc_time=True,
+                                    name="time_since")
+    breakpoint()
+    assert 'custom_max' in get_aggregation_primitives()
+    assert 'time_since' in get_transform_primitives()
 
 def test_descriptions():
     primitives = {NumCharacters: 'Calculates the number of characters in a string.',

--- a/featuretools/tests/utils_tests/test_primitives_utils.py
+++ b/featuretools/tests/utils_tests/test_primitives_utils.py
@@ -61,7 +61,6 @@ def test_custom_primitives():
                                     return_type=Timedelta,
                                     uses_calc_time=True,
                                     name="time_since")
-    breakpoint()
     assert 'custom_max' in get_aggregation_primitives()
     assert 'time_since' in get_transform_primitives()
 

--- a/featuretools/tests/utils_tests/test_primitives_utils.py
+++ b/featuretools/tests/utils_tests/test_primitives_utils.py
@@ -28,7 +28,7 @@ from featuretools.primitives import (
 from featuretools.primitives.utils import _get_descriptions
 from featuretools.utils.gen_utils import Library
 from featuretools.primitives.base import make_agg_primitive, make_trans_primitive
-from featuretools.variable_types import Numeric, Datetime, DatetimeTimeIndex, Timedelta
+from featuretools.variable_types import Numeric
 
 
 def test_list_primitives_order():
@@ -48,21 +48,20 @@ def test_list_primitives_order():
     assert 'aggregation' in types
     assert 'transform' in types
 
-def test_custom_primitives():
-    def pd_time_since(array, moment):
-        return (moment - pd.DatetimeIndex(array)).values
 
-    CustomMax = make_agg_primitive(lambda x: max(x),
-                               name="CustomMax",
-                               input_types=[Numeric],
-                               return_type=Numeric)
-    TimeSince = make_trans_primitive(function=pd_time_since,
-                                    input_types=[[DatetimeTimeIndex], [Datetime]],
-                                    return_type=Timedelta,
-                                    uses_calc_time=True,
-                                    name="time_since")
+def test_custom_primitives():
+    make_agg_primitive(lambda x: max(x),
+                       name="CustomMax",
+                       input_types=[Numeric],
+                       return_type=Numeric)
+    make_trans_primitive(function=lambda x: x,
+                         input_types=[Numeric],
+                         return_type=Numeric,
+                         uses_calc_time=True,
+                         name="IdentityFunction")
     assert 'custom_max' in get_aggregation_primitives()
-    assert 'time_since' in get_transform_primitives()
+    assert 'identity_function' in get_transform_primitives()
+
 
 def test_descriptions():
     primitives = {NumCharacters: 'Calculates the number of characters in a string.',

--- a/featuretools/tests/utils_tests/test_primitives_utils.py
+++ b/featuretools/tests/utils_tests/test_primitives_utils.py
@@ -25,9 +25,12 @@ from featuretools.primitives import (
     get_default_transform_primitives,
     get_transform_primitives
 )
+from featuretools.primitives.base import (
+    make_agg_primitive,
+    make_trans_primitive
+)
 from featuretools.primitives.utils import _get_descriptions
 from featuretools.utils.gen_utils import Library
-from featuretools.primitives.base import make_agg_primitive, make_trans_primitive
 from featuretools.variable_types import Numeric
 
 

--- a/featuretools/utils/gen_utils.py
+++ b/featuretools/utils/gen_utils.py
@@ -44,6 +44,12 @@ def find_descendents(cls):
         for c in find_descendents(sub):
             yield c
 
+class ClassNameDescriptor(object):
+    """Descriptor to convert a class's name from camelcase to snakecase
+    """
+
+    def __get__(self, instance, class_):
+        return camel_to_snake(class_.__name__)
 
 def check_schema_version(cls, cls_type):
     if isinstance(cls_type, str):

--- a/featuretools/utils/gen_utils.py
+++ b/featuretools/utils/gen_utils.py
@@ -44,12 +44,14 @@ def find_descendents(cls):
         for c in find_descendents(sub):
             yield c
 
+
 class ClassNameDescriptor(object):
     """Descriptor to convert a class's name from camelcase to snakecase
     """
 
     def __get__(self, instance, class_):
         return camel_to_snake(class_.__name__)
+
 
 def check_schema_version(cls, cls_type):
     if isinstance(cls_type, str):

--- a/featuretools/variable_types/variable.py
+++ b/featuretools/variable_types/variable.py
@@ -5,6 +5,7 @@ import pandas as pd
 
 from featuretools.utils.gen_utils import ClassNameDescriptor
 
+
 class Variable(object):
     """Represent a variable in an entity
 

--- a/featuretools/variable_types/variable.py
+++ b/featuretools/variable_types/variable.py
@@ -3,16 +3,7 @@ import warnings
 import numpy as np
 import pandas as pd
 
-from featuretools.utils.gen_utils import camel_to_snake
-
-
-class ClassNameDescriptor(object):
-    """Descriptor to convert a class's name from camelcase to snakecase
-    """
-
-    def __get__(self, instance, class_):
-        return camel_to_snake(class_.__name__)
-
+from featuretools.utils.gen_utils import ClassNameDescriptor
 
 class Variable(object):
     """Represent a variable in an entity


### PR DESCRIPTION
### Pull Request Description
Allows user to pass in the snakecase string of a custom primitive's class name into DFS instead of passing in the actual class. The implementation of this is similar to how variable typestrings are handled.
-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request.*
