### PR TITLE
Remove link to unused feedback board

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -14,7 +14,7 @@ Release Notes
     * Testing Changes
 
     Thanks to the following people for contributing to this release:
-    :user:`frances-h`, :user:`kmax12`
+    :user:`frances-h`, :user:`kmax12` 
 
 **v0.21.0 Oct 30, 2020**
     * Enhancements

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -14,7 +14,7 @@ Release Notes
     * Testing Changes
 
     Thanks to the following people for contributing to this release:
-    :user:`frances-h`, :user:`kmax12` 
+    :user:`frances-h`, :user:`kmax12`
 
 **v0.21.0 Oct 30, 2020**
     * Enhancements

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -10,10 +10,11 @@ Release Notes
     * Fixes
     * Changes
     * Documentation Changes
+        * Removed link to unused feedback board (:pr:`1220`)
     * Testing Changes
 
     Thanks to the following people for contributing to this release:
-    :user:`frances-h`
+    :user:`frances-h`, :user:`kmax12`
 
 **v0.21.0 Oct 30, 2020**
     * Enhancements

--- a/docs/source/resources/help.rst
+++ b/docs/source/resources/help.rst
@@ -11,10 +11,9 @@ Discussion
 Conversation happens in the following places:
 
 1.  **General usage questions** are directed to `StackOverflow`_ with the #featuretools tag.
-2.  **Feature requests** can be made on the `Feature Request Board <http://feedback.featurelabs.com>`__.
-3.  **Bug reports** are managed on the `GitHub issue
+2.  **Bug reports** are managed on the `GitHub issue
     tracker`_.
-4.  **Chat** and collaboration within the community occurs on `Slack`_. For general usage questions, please post on
+3.  **Chat** and collaboration within the community occurs on `Slack`_. For general usage questions, please post on
     Stack Overflow where answers are more searchable by other users.
 
 .. _`StackOverflow`: http://stackoverflow.com/questions/tagged/featuretools


### PR DESCRIPTION
Removing link to our feedback board which isn't used