### PR TITLE
Update PR url in release notes check-in test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -271,7 +271,7 @@ jobs:
           password: $DOCKERHUB_PASSWORD
     steps:
       - checkout
-      - run: cat docs/source/release_notes.rst | grep ":pr:\`${CIRCLE_PULL_REQUEST##https://github.com/FeatureLabs/featuretools/pull/}\`"
+      - run: cat docs/source/release_notes.rst | grep ":pr:\`${CIRCLE_PULL_REQUEST##https://github.com/alteryx/featuretools/pull/}\`"
 
 workflows:
   version: 2

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -12,9 +12,10 @@ Release Notes
     * Documentation Changes
         * Update footer with Alteryx Innovation Labs (:pr:`1221`)
     * Testing Changes
+        * Update release notes check to use new repo url (:pr:`1222`)
 
     Thanks to the following people for contributing to this release:
-    :user:`frances-h`, :user:`gsheni`
+    :user:`frances-h`, :user:`gsheni`, :user:`rwedge`
 
 **v0.21.0 Oct 30, 2020**
     * Enhancements

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -9,3 +9,4 @@ moto[all]>=1.3.15
 smart-open>=1.8.4
 boto3>=1.10.45
 composeml>=0.2.0
+urllib3>=1.25.10,<1.26


### PR DESCRIPTION
Update the url so that the check for users updating the release notes works with the new org

Also sets a specific version range for urllib3 to deal with conflicting requirements from other dependencies

Not sure why the ci checks are on the job level now