### PR TITLE
Update dependency check with new version 

### DIFF
--- a/.github/workflows/dependency_check.yml
+++ b/.github/workflows/dependency_check.yml
@@ -20,11 +20,12 @@ jobs:
         make installdeps
         make checkdeps OUTPUT_PATH=featuretools/tests/latest_dependencies.txt
     - name: Create Pull Request
-      uses: Featurelabs/create-pull-request@v2
+      uses: FeatureLabs/create-pull-request@v3
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         commit-message: Update latest_dependencies.txt
         title: Automated Update to latest_dependencies.txt
+        author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
         body: "This is an auto-generated PR with updates to latest_dependencies.txt."
         branch: dep-update
         branch-suffix: short-commit-hash

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -16,6 +16,7 @@ Release Notes
         * Update links to repo in documentation to use alteryx org url (:pr:`1224`)
     * Testing Changes
         * Update release notes check to use new repo url (:pr:`1222`)
+        * Use new version of pull request Github Action (:pr:`1234`)
 
     Thanks to the following people for contributing to this release:
     :user:`frances-h`, :user:`gsheni`, :user:`kmax12`, :user:`rwedge`, :user:`thehomebrewnerd`


### PR DESCRIPTION
- The dependency action will start failing with the following message:
```text
The set-env command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by 
setting the ACTIONS_ALLOW_UNSECURE_COMMANDS environment variable to true. For more information see: 
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```
- The fix updates the version of the create-pull-request action we use. We updated our fork to include v3.