### PR TITLE
Update Dependency Check

### DIFF
--- a/.github/workflows/dependency_check.yml
+++ b/.github/workflows/dependency_check.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Create Pull Request
       uses: FeatureLabs/create-pull-request@v3
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
         commit-message: Update latest_dependencies.txt
         title: Automated Update to latest_dependencies.txt
         author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>

--- a/.github/workflows/dependency_check.yml
+++ b/.github/workflows/dependency_check.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Create Pull Request
       uses: FeatureLabs/create-pull-request@v3
       with:
-        ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
+        GITHUB_TOKEN: ${{ secrets.REPO_SCOPED_TOKEN }}
         commit-message: Update latest_dependencies.txt
         title: Automated Update to latest_dependencies.txt
         author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>

--- a/.github/workflows/dependency_check.yml
+++ b/.github/workflows/dependency_check.yml
@@ -21,8 +21,9 @@ jobs:
         make checkdeps OUTPUT_PATH=featuretools/tests/latest_dependencies.txt
     - name: Create Pull Request
       uses: FeatureLabs/create-pull-request@v3
-      with:
+      env:
         GITHUB_TOKEN: ${{ secrets.REPO_SCOPED_TOKEN }}
+      with:
         commit-message: Update latest_dependencies.txt
         title: Automated Update to latest_dependencies.txt
         author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,15 +2,6 @@
 
 Release Notes
 -------------
-.. **Future Release**
-    * Enhancements
-    * Fixes
-    * Changes
-    * Documentation Changes
-    * Testing Changes
-
-.. Thanks to the following people for contributing to this release:
-
 **Future Release**
     * Enhancements
     * Fixes

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -5,8 +5,8 @@ Release Notes
 **Future Release**
     * Enhancements
     * Fixes
-        * Use deploy keys for dependency check (:pr:`1245`:)
     * Changes
+        * Use deploy keys for dependency check (:pr:`1245`:)
     * Documentation Changes
     * Testing Changes
 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -8,7 +8,7 @@ Release Notes
     * Changes
     * Documentation Changes
     * Testing Changes
-        * Use deploy keys for dependency check (:pr:`1245`:)
+        * Use repository-scoped token for dependency check (:pr:`1245`:)
 
 Thanks to the following people for contributing to this release:
 :user:`jeff-hernandez`

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -11,6 +11,17 @@ Release Notes
 
 .. Thanks to the following people for contributing to this release:
 
+**Future Release**
+    * Enhancements
+    * Fixes
+        * Use deploy keys for dependency check (:pr:`1245`:)
+    * Changes
+    * Documentation Changes
+    * Testing Changes
+
+Thanks to the following people for contributing to this release:
+:user:`jeff-hernandez`
+
 **v0.22.0 Nov 30, 2020**
     * Enhancements
         * Allow variable descriptions to be set directly on variable (:pr:`1207`)

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -10,8 +10,8 @@ Release Notes
     * Testing Changes
         * Use repository-scoped token for dependency check (:pr:`1245`:)
 
-Thanks to the following people for contributing to this release:
-:user:`jeff-hernandez`
+    Thanks to the following people for contributing to this release:
+    :user:`jeff-hernandez`
 
 **v0.22.0 Nov 30, 2020**
     * Enhancements

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -6,9 +6,9 @@ Release Notes
     * Enhancements
     * Fixes
     * Changes
-        * Use deploy keys for dependency check (:pr:`1245`:)
     * Documentation Changes
     * Testing Changes
+        * Use deploy keys for dependency check (:pr:`1245`:)
 
 Thanks to the following people for contributing to this release:
 :user:`jeff-hernandez`


### PR DESCRIPTION
Pushes to the created PR use deploy keys for triggering other workflows.