### PR TITLE
Set token via action input instead of env variable

### DIFF
--- a/.github/workflows/dependency_check.yml
+++ b/.github/workflows/dependency_check.yml
@@ -21,8 +21,6 @@ jobs:
         make checkdeps OUTPUT_PATH=featuretools/tests/latest_dependencies.txt
     - name: Create Pull Request
       uses: FeatureLabs/create-pull-request@v3
-      env:
-        GITHUB_TOKEN: ${{ secrets.REPO_SCOPED_TOKEN }}
       with:
         commit-message: Update latest_dependencies.txt
         title: Automated Update to latest_dependencies.txt
@@ -32,3 +30,4 @@ jobs:
         branch-suffix: short-commit-hash
         base: main
         reviewers: rwedge, thehomebrewnerd, frances-h
+        token: ${{ secrets.REPO_SCOPED_TOKEN }}

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -8,7 +8,7 @@ Release Notes
     * Changes
     * Documentation Changes
     * Testing Changes
-        * Use repository-scoped token for dependency check (:pr:`1245`:)
+        * Use repository-scoped token for dependency check (:pr:`1245`:, :pr:`1248`)
         * Fix install error during docs CI test (:pr:`1250`)
 
     Thanks to the following people for contributing to this release:


### PR DESCRIPTION
Most recent dependency check still had the issue where actions would not trigger other actions

This PR tries to fix by telling make-pr action to use the PAT specifically instead of temporarily replacing the default github token with the PAT
