### PR TITLE
Move query_by_values to EntitySet

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -17,7 +17,7 @@ Release Notes
 
 **Breaking Changes**
 
-* ``Entity.query_by_values`` has been removed and replaced with ``EntitySet.query_by_values``, with an
+* ``Entity.query_by_values`` has been removed and replaced by ``EntitySet.query_by_values`` with an
     added ``entity_id`` parameter to specify which entity in the entityset should be used for the query.
 
 **v0.22.0 Nov 30, 2020**

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -15,6 +15,11 @@ Release Notes
     Thanks to the following people for contributing to this release:
     :user:`jeff-hernandez`, :user:`rwedge`, :user:`thehomebrewnerd`
 
+**Breaking Changes**
+
+* ``Entity.query_by_values`` has been removed and replaced with ``EntitySet.query_by_values``, with an
+    added ``entity_id`` parameter to specify which entity in the entityset should be used for the query.
+
 **v0.22.0 Nov 30, 2020**
     * Enhancements
         * Allow variable descriptions to be set directly on variable (:pr:`1207`)

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -6,12 +6,13 @@ Release Notes
     * Enhancements
     * Fixes
     * Changes
+        * Move ``query_by_values`` method from ``Entity`` to ``EntitySet`` (:pr:`1251`)
     * Documentation Changes
     * Testing Changes
         * Use repository-scoped token for dependency check (:pr:`1245`:)
 
     Thanks to the following people for contributing to this release:
-    :user:`jeff-hernandez`
+    :user:`jeff-hernandez`, :user:`thehomebrewnerd`
 
 **v0.22.0 Nov 30, 2020**
     * Enhancements

--- a/featuretools/computational_backends/feature_set_calculator.py
+++ b/featuretools/computational_backends/feature_set_calculator.py
@@ -209,8 +209,7 @@ class FeatureSetCalculator(object):
         need_full_entity, full_entity_features, not_full_entity_features = feature_trie.value
 
         all_features = full_entity_features | not_full_entity_features
-        entity = self.entityset[entity_id]
-        columns = self._necessary_columns(entity, all_features)
+        columns = self._necessary_columns(entity_id, all_features)
 
         # If we need the full entity then don't filter by filter_values.
         if need_full_entity:
@@ -220,12 +219,13 @@ class FeatureSetCalculator(object):
             query_variable = filter_variable
             query_values = filter_values
 
-        df = entity.query_by_values(query_values,
-                                    variable_id=query_variable,
-                                    columns=columns,
-                                    time_last=self.time_last,
-                                    training_window=self.training_window,
-                                    include_cutoff_time=include_cutoff_time)
+        df = self.entityset.query_by_values(entity_id=entity_id,
+                                            instance_vals=query_values,
+                                            variable_id=query_variable,
+                                            columns=columns,
+                                            time_last=self.time_last,
+                                            training_window=self.training_window,
+                                            include_cutoff_time=include_cutoff_time)
 
         # call to update timer
         progress_callback(0)
@@ -740,9 +740,10 @@ class FeatureSetCalculator(object):
 
         return frame
 
-    def _necessary_columns(self, entity, feature_names):
+    def _necessary_columns(self, entity_id, feature_names):
         # We have to keep all Id columns because we don't know what forward
         # relationships will come from this node.
+        entity = self.entityset[entity_id]
         index_columns = {v.id for v in entity.variables
                          if isinstance(v, (variable_types.Index,
                                            variable_types.Id,

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -996,7 +996,7 @@ class EntitySet(object):
         if not variable_id:
             variable_id = entity.index
 
-        instance_vals = self._vals_to_series(instance_vals, variable_id)
+        instance_vals = _vals_to_series(instance_vals, variable_id)
 
         training_window = _check_timedelta(training_window)
 
@@ -1037,30 +1037,31 @@ class EntitySet(object):
 
         return df
 
-    def _vals_to_series(self, instance_vals, variable_id):
-        """
-        instance_vals may be a pd.Dataframe, a pd.Series, a list, a single
-        value, or None. This function always returns a Series or None.
-        """
-        if instance_vals is None:
-            return None
 
-        # If this is a single value, make it a list
-        if not hasattr(instance_vals, '__iter__'):
-            instance_vals = [instance_vals]
+def _vals_to_series(self, instance_vals, variable_id):
+    """
+    instance_vals may be a pd.Dataframe, a pd.Series, a list, a single
+    value, or None. This function always returns a Series or None.
+    """
+    if instance_vals is None:
+        return None
 
-        # convert iterable to pd.Series
-        if isinstance(instance_vals, pd.DataFrame):
-            out_vals = instance_vals[variable_id]
-        elif is_instance(instance_vals, (pd, dd, ks), 'Series'):
-            out_vals = instance_vals.rename(variable_id)
-        else:
-            out_vals = pd.Series(instance_vals)
+    # If this is a single value, make it a list
+    if not hasattr(instance_vals, '__iter__'):
+        instance_vals = [instance_vals]
 
-        # no duplicates or NaN values
-        out_vals = out_vals.drop_duplicates().dropna()
+    # convert iterable to pd.Series
+    if isinstance(instance_vals, pd.DataFrame):
+        out_vals = instance_vals[variable_id]
+    elif is_instance(instance_vals, (pd, dd, ks), 'Series'):
+        out_vals = instance_vals.rename(variable_id)
+    else:
+        out_vals = pd.Series(instance_vals)
 
-        # want index to have no name for the merge in query_by_values
-        out_vals.index.name = None
+    # no duplicates or NaN values
+    out_vals = out_vals.drop_duplicates().dropna()
 
-        return out_vals
+    # want index to have no name for the merge in query_by_values
+    out_vals.index.name = None
+
+    return out_vals

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -1038,7 +1038,7 @@ class EntitySet(object):
         return df
 
 
-def _vals_to_series(self, instance_vals, variable_id):
+def _vals_to_series(instance_vals, variable_id):
     """
     instance_vals may be a pd.Dataframe, a pd.Series, a list, a single
     value, or None. This function always returns a Series or None.

--- a/featuretools/tests/entityset_tests/test_entity.py
+++ b/featuretools/tests/entityset_tests/test_entity.py
@@ -138,33 +138,6 @@ def test_update_data(es):
         assert es['customers'].df["id"].iloc[0] == 0
 
 
-def test_query_by_values_returns_rows_in_given_order():
-    data = pd.DataFrame({
-        "id": [1, 2, 3, 4, 5],
-        "value": ["a", "c", "b", "a", "a"],
-        "time": [1000, 2000, 3000, 4000, 5000]
-    })
-
-    es = ft.EntitySet()
-    es = es.entity_from_dataframe(entity_id="test", dataframe=data, index="id",
-                                  time_index="time", variable_types={
-                                            "value": ft.variable_types.Categorical
-                                  })
-    query = es['test'].query_by_values(['b', 'a'], variable_id='value')
-    assert np.array_equal(query['id'], [1, 3, 4, 5])
-
-
-def test_query_by_values_secondary_time_index(es):
-    end = np.datetime64(datetime(2011, 10, 1))
-    all_instances = [0, 1, 2]
-    result = es['customers'].query_by_values(all_instances, time_last=end)
-    result = to_pandas(result, index='id')
-
-    for col in ["cancel_date", "cancel_reason"]:
-        nulls = result.loc[all_instances][col].isnull() == [False, True, True]
-        assert nulls.all(), "Some instance has data it shouldn't for column %s" % col
-
-
 def test_delete_variables(es):
     entity = es['customers']
     to_delete = ['age', 'cohort', 'email']

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -208,6 +208,18 @@ def test_query_by_id(es):
     assert df['id'].values[0] == 0
 
 
+def test_query_by_single_value(es):
+    df = to_pandas(es.query_by_values('log', instance_vals=0))
+    assert df['id'].values[0] == 0
+
+
+def test_query_by_df(es):
+    instance_df = pd.DataFrame({'id': [1, 3], 'vals': [0, 1]})
+    df = to_pandas(es.query_by_values('log', instance_vals=instance_df))
+
+    assert np.array_equal(df['id'], [1, 3])
+
+
 def test_query_by_id_with_time(es):
     df = es.query_by_values(
         entity_id='log',

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -176,13 +176,41 @@ def test_add_relationship_empty_child_convert_dtype(es):
     assert es['log'].df['session_id'].dtype == 'int64'
 
 
+def test_query_by_values_returns_rows_in_given_order():
+    data = pd.DataFrame({
+        "id": [1, 2, 3, 4, 5],
+        "value": ["a", "c", "b", "a", "a"],
+        "time": [1000, 2000, 3000, 4000, 5000]
+    })
+
+    es = ft.EntitySet()
+    es = es.entity_from_dataframe(entity_id="test", dataframe=data, index="id",
+                                  time_index="time", variable_types={
+                                            "value": ft.variable_types.Categorical
+                                  })
+    query = es.query_by_values('test', ['b', 'a'], variable_id='value')
+    assert np.array_equal(query['id'], [1, 3, 4, 5])
+
+
+def test_query_by_values_secondary_time_index(es):
+    end = np.datetime64(datetime(2011, 10, 1))
+    all_instances = [0, 1, 2]
+    result = es.query_by_values('customers', all_instances, time_last=end)
+    result = to_pandas(result, index='id')
+
+    for col in ["cancel_date", "cancel_reason"]:
+        nulls = result.loc[all_instances][col].isnull() == [False, True, True]
+        assert nulls.all(), "Some instance has data it shouldn't for column %s" % col
+
+
 def test_query_by_id(es):
-    df = to_pandas(es['log'].query_by_values(instance_vals=[0]))
+    df = to_pandas(es.query_by_values('log', instance_vals=[0]))
     assert df['id'].values[0] == 0
 
 
 def test_query_by_id_with_time(es):
-    df = es['log'].query_by_values(
+    df = es.query_by_values(
+        entity_id='log',
         instance_vals=[0, 1, 2, 3, 4],
         time_last=datetime(2011, 4, 9, 10, 30, 2 * 6))
     df = to_pandas(df)
@@ -194,7 +222,8 @@ def test_query_by_id_with_time(es):
 
 
 def test_query_by_variable_with_time(es):
-    df = es['log'].query_by_values(
+    df = es.query_by_values(
+        entity_id='log',
         instance_vals=[0, 1, 2], variable_id='session_id',
         time_last=datetime(2011, 4, 9, 10, 50, 0))
     df = to_pandas(df)
@@ -210,7 +239,8 @@ def test_query_by_variable_with_time(es):
 
 
 def test_query_by_variable_with_training_window(es):
-    df = es['log'].query_by_values(
+    df = es.query_by_values(
+        entity_id='log',
         instance_vals=[0, 1, 2], variable_id='session_id',
         time_last=datetime(2011, 4, 9, 10, 50, 0),
         training_window='15m')
@@ -221,7 +251,8 @@ def test_query_by_variable_with_training_window(es):
 
 
 def test_query_by_indexed_variable(es):
-    df = es['log'].query_by_values(
+    df = es.query_by_values(
+        entity_id='log',
         instance_vals=['taco clock'],
         variable_id='product_id')
     df = to_pandas(df)
@@ -748,7 +779,7 @@ def test_concat_entitysets(es):
     assert not es.__eq__(es_2, deep=True)
 
     # make sure internal indexes work before concat
-    regions = es_1['customers'].query_by_values(['United States'], variable_id=u'région_id')
+    regions = es_1.query_by_values('customers', ['United States'], variable_id=u'région_id')
     assert regions.index.isin(es_1['customers'].df.index).all()
 
     assert es_1.__eq__(es_2)


### PR DESCRIPTION
### Move query_by_values to EntitySet
Moves the `query_by_values` method from `Entity` to `EntitySet`. Also moves the method `_vals_to_series` to `EntitySet` as this method was only called from inside `query_by_values`.

Closes #1244 

