### PR TITLE
Remove add interesting values from Entity

### DIFF
--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -325,7 +325,6 @@ Entity methods
     :toctree: generated/
 
     Entity.convert_variable_type
-    Entity.add_interesting_values
 
 Relationship attributes
 -----------------------

--- a/docs/source/guides/tuning_dfs.rst
+++ b/docs/source/guides/tuning_dfs.rst
@@ -37,7 +37,7 @@ Sometimes we want to create features that are conditioned on a second value befo
 By default, where clauses are built using the ``interesting_values`` of a variable.
 
 
-.. Interesting values can be automatically added to all variables by calling `EntitySet.add_interesting_values` or `Entity.add_interesting_values`. We can manually specify interesting values by directly as well.
+.. Interesting values can be automatically added to all variables by calling ``EntitySet.add_interesting_values``. We can manually specify interesting values by directly as well.
 
 .. Currently, interesting values are only considered for variables of type :class:`.variable_types.Categorical`, :class:`.variable_types.Ordinal`, and :class:`.variable_types.Boolean`.
 

--- a/docs/source/guides/using_dask_entitysets.rst
+++ b/docs/source/guides/using_dask_entitysets.rst
@@ -96,13 +96,11 @@ By default, Featuretools checks that entities created from pandas dataframes hav
 
 When an ``Entity`` is created from a pandas dataframe, the ordering of the underlying dataframe rows is maintained. For a Dask ``Entity``, the ordering of the dataframe rows is not guaranteed, and Featuretools does not attempt to maintain row order in a Dask ``Entity``. If ordering is important, close attention must be paid to any output to avoid issues.
 
-The ``Entity.add_interesting_values()`` method is not supported when using a Dask ``Entity``.  If needed, users can manually set ``interesting_values`` on entities by assigning them directly with syntax similar to this: ``es["entity_name"]["variable_name"].interesting_values = ["Value 1", "Value 2"]``.
-
 EntitySet Limitations
 *********************
 When creating a Featuretools ``EntitySet`` that will be made of Dask entities, all of the entities used to create the ``EntitySet`` must be of the same type, either all Dask entities or all pandas entities. Featuretools does not support creating an ``EntitySet`` containing a mix of Dask and pandas entities.
 
-Additionally, the ``EntitySet.add_interesting_values()`` method is not supported when using a Dask ``EntitySet``. Users can manually set ``interesting_values`` on entities, as described above.
+Additionally, the ``EntitySet.add_interesting_values()`` method is not supported when using a Dask ``EntitySet``. If needed, users can manually set ``interesting_values`` on entities by assigning them directly with syntax similar to this: ``es["entity_name"]["variable_name"].interesting_values = ["Value 1", "Value 2"]``.
 
 DFS Limitations
 ***************

--- a/docs/source/guides/using_koalas_entitysets.rst
+++ b/docs/source/guides/using_koalas_entitysets.rst
@@ -86,13 +86,11 @@ By default, Featuretools checks that entities created from pandas dataframes hav
 
 When an ``Entity`` is created from a pandas dataframe, the ordering of the underlying dataframe rows is maintained. For a Koalas ``Entity``, the ordering of the dataframe rows is not guaranteed, and Featuretools does not attempt to maintain row order in a Koalas ``Entity``. If ordering is important, close attention must be paid to any output to avoid issues.
 
-The ``Entity.add_interesting_values()`` method is not supported when using a Koalas ``Entity``.  If needed, users can manually set ``interesting_values`` on entities by assigning them directly with syntax similar to this: ``es["entity_name"]["variable_name"].interesting_values = ["Value 1", "Value 2"]``.
-
 EntitySet Limitations
 *********************
 When creating a Featuretools ``EntitySet`` that will be made of Koalas entities, all of the entities used to create the ``EntitySet`` must be of the same type, either all Koalas entities, all Dask entities, or all pandas entities. Featuretools does not support creating an ``EntitySet`` containing a mix of Koalas, Dask, and pandas entities.
 
-Additionally, the ``EntitySet.add_interesting_values()`` method is not supported when using a Koalas ``EntitySet``. Users can manually set ``interesting_values`` on entities, as described above.
+Additionally, the ``EntitySet.add_interesting_values()`` method is not supported when using a Koalas ``EntitySet``. If needed, users can manually set ``interesting_values`` on entities by assigning them directly with syntax similar to this: ``es["entity_name"]["variable_name"].interesting_values = ["Value 1", "Value 2"]``.
 
 DFS Limitations
 ***************

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -6,8 +6,8 @@ Release Notes
     * Enhancements
     * Fixes
     * Changes
-        * Remove ``add_interesting_values`` from ``Entity`` (:pr:`1269`)
         * Move ``query_by_values`` method from ``Entity`` to ``EntitySet`` (:pr:`1251`)
+        * Remove ``add_interesting_values`` from ``Entity`` (:pr:`1269`)
     * Documentation Changes
     * Testing Changes
         * Use repository-scoped token for dependency check (:pr:`1245`:, :pr:`1248`)
@@ -18,11 +18,11 @@ Release Notes
 
 **Breaking Changes**
 
+* ``Entity.query_by_values`` has been removed and replaced by ``EntitySet.query_by_values`` with an
+    added ``entity_id`` parameter to specify which entity in the entityset should be used for the query.
 * ``Entity.add_interesting_values`` has been removed. To add interesting values for a single
     entity, call ``EntitySet.add_interesting_values`` and pass the id of the entity for
     which to add interesting values in the ``entity_id`` parameter. 
-* ``Entity.query_by_values`` has been removed and replaced by ``EntitySet.query_by_values`` with an
-    added ``entity_id`` parameter to specify which entity in the entityset should be used for the query.
 
 **v0.22.0 Nov 30, 2020**
     * Enhancements

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -6,13 +6,20 @@ Release Notes
     * Enhancements
     * Fixes
     * Changes
+        * Remove ``add_interesting_values`` from ``Entity`` (:pr:`1269`)
     * Documentation Changes
     * Testing Changes
         * Use repository-scoped token for dependency check (:pr:`1245`:, :pr:`1248`)
         * Fix install error during docs CI test (:pr:`1250`)
 
     Thanks to the following people for contributing to this release:
-    :user:`jeff-hernandez`, :user:`rwedge`
+    :user:`jeff-hernandez`, :user:`rwedge`, :user:`thehomebrewnerd`
+
+**Breaking Changes**
+
+* ``Entity.add_interesting_values`` has been removed. To add interesting values for a single
+    entity, call `EntitySet.add_interesting_values` and pass the id of the entity for
+    which to add interesting values in the ``entity_id`` parameter. 
 
 **v0.22.0 Nov 30, 2020**
     * Enhancements

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -18,7 +18,7 @@ Release Notes
 **Breaking Changes**
 
 * ``Entity.add_interesting_values`` has been removed. To add interesting values for a single
-    entity, call `EntitySet.add_interesting_values` and pass the id of the entity for
+    entity, call ``EntitySet.add_interesting_values`` and pass the id of the entity for
     which to add interesting values in the ``entity_id`` parameter. 
 
 **v0.22.0 Nov 30, 2020**

--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -358,64 +358,6 @@ class Entity(object):
             self.entityset.add_last_time_indexes(updated_entities=[self.id])
         self.entityset.reset_data_description()
 
-    def add_interesting_values(self, max_values=5, verbose=False):
-        """
-        Find interesting values for categorical variables, to be used to
-            generate "where" clauses
-
-        Args:
-            max_values (int) : Maximum number of values per variable to add.
-            verbose (bool) : If True, print summary of interesting values found.
-
-        Returns:
-            None
-        """
-        for variable in self.variables:
-            # some heuristics to find basic 'where'-able variables
-            if isinstance(variable, vtypes.Discrete):
-                variable.interesting_values = pd.Series(dtype=variable.entity.df[variable.id].dtype)
-
-                # TODO - consider removing this constraints
-                # don't add interesting values for entities in relationships
-                skip = False
-                for r in self.entityset.relationships:
-                    if variable in [r.child_variable, r.parent_variable]:
-                        skip = True
-                        break
-                if skip:
-                    continue
-
-                counts = self.df[variable.id].value_counts()
-
-                # find how many of each unique value there are; sort by count,
-                # and add interesting values to each variable
-                total_count = np.sum(counts)
-                counts[:] = counts.sort_values()[::-1]
-                for i in range(min(max_values, len(counts.index))):
-                    idx = counts.index[i]
-
-                    # add the value to interesting_values if it represents more than
-                    # 25% of the values we have not seen so far
-                    if len(counts.index) < 25:
-                        if verbose:
-                            msg = "Variable {}: Marking {} as an "
-                            msg += "interesting value"
-                            logger.info(msg.format(variable.id, idx))
-                        variable.interesting_values = variable.interesting_values.append(pd.Series([idx]))
-                    else:
-                        fraction = counts[idx] / total_count
-                        if fraction > 0.05 and fraction < 0.95:
-                            if verbose:
-                                msg = "Variable {}: Marking {} as an "
-                                msg += "interesting value"
-                                logger.info(msg.format(variable.id, idx))
-                            variable.interesting_values = variable.interesting_values.append(pd.Series([idx]))
-                            # total_count -= counts[idx]
-                        else:
-                            break
-
-        self.entityset.reset_data_description()
-
     def delete_variables(self, variable_ids):
         """
         Remove variables from entity's dataframe and from

--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -1,4 +1,3 @@
-import logging
 import warnings
 
 import dask.dataframe as dd
@@ -23,8 +22,6 @@ from featuretools.utils.wrangle import (
 from featuretools.variable_types import Text, find_variable_types
 
 ks = import_or_none('databricks.koalas')
-
-logger = logging.getLogger('featuretools.entityset')
 
 _numeric_types = vtypes.PandasTypes._pandas_numerics
 _categorical_types = [vtypes.PandasTypes._categorical]

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -907,25 +907,25 @@ class EntitySet(object):
     #  Other ###############################################
     ###########################################################################
 
-    def add_interesting_values(self, max_values=5, verbose=False, entity_id=None):
+    def add_interesting_values(self, max_values=5, verbose=False, datatable_id=None):
         """Find interesting values for categorical variables, to be used to generate "where" clauses
 
         Args:
             max_values (int) : Maximum number of values per variable to add.
             verbose (bool) : If True, print summary of interesting values found.
-            entity_id (str) : The entity for which to add interesting values. If not specified
-                interesting values will be added for all entities.
+            datatable_id (str) : The DataTable for which to add interesting values. If not specified
+                interesting values will be added for all DataTables.
 
         Returns:
             None
 
         """
-        if entity_id:
-            entities = [self[entity_id]]
+        if datatable_id:
+            tables = [self[datatable_id]]
         else:
-            entities = self.entities
-        for entity in entities:
-            for variable in entity.variables:
+            tables = self.entities
+        for table in tables:
+            for variable in table.variables:
                 # some heuristics to find basic 'where'-able variables
                 if isinstance(variable, vtypes.Discrete):
                     variable.interesting_values = pd.Series(dtype=variable.entity.df[variable.id].dtype)
@@ -940,7 +940,7 @@ class EntitySet(object):
                     if skip:
                         continue
 
-                    counts = entity.df[variable.id].value_counts()
+                    counts = table.df[variable.id].value_counts()
 
                     # find how many of each unique value there are; sort by count,
                     # and add interesting values to each variable

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -907,19 +907,68 @@ class EntitySet(object):
     #  Other ###############################################
     ###########################################################################
 
-    def add_interesting_values(self, max_values=5, verbose=False):
+    def add_interesting_values(self, max_values=5, verbose=False, entity_id=None):
         """Find interesting values for categorical variables, to be used to generate "where" clauses
 
         Args:
             max_values (int) : Maximum number of values per variable to add.
             verbose (bool) : If True, print summary of interesting values found.
+            entity_id (str) : The entity for which to add interesting values. If not specified
+                interesting values will be added for all entities.
 
         Returns:
             None
 
         """
-        for entity in self.entities:
-            entity.add_interesting_values(max_values=max_values, verbose=verbose)
+        if entity_id:
+            entities = [self[entity_id]]
+        else:
+            entities = self.entities
+        for entity in entities:
+            for variable in entity.variables:
+                # some heuristics to find basic 'where'-able variables
+                if isinstance(variable, vtypes.Discrete):
+                    variable.interesting_values = pd.Series(dtype=variable.entity.df[variable.id].dtype)
+
+                    # TODO - consider removing this constraints
+                    # don't add interesting values for entities in relationships
+                    skip = False
+                    for r in self.relationships:
+                        if variable in [r.child_variable, r.parent_variable]:
+                            skip = True
+                            break
+                    if skip:
+                        continue
+
+                    counts = entity.df[variable.id].value_counts()
+
+                    # find how many of each unique value there are; sort by count,
+                    # and add interesting values to each variable
+                    total_count = np.sum(counts)
+                    counts[:] = counts.sort_values()[::-1]
+                    for i in range(min(max_values, len(counts.index))):
+                        idx = counts.index[i]
+
+                        # add the value to interesting_values if it represents more than
+                        # 25% of the values we have not seen so far
+                        if len(counts.index) < 25:
+                            if verbose:
+                                msg = "Variable {}: Marking {} as an "
+                                msg += "interesting value"
+                                logger.info(msg.format(variable.id, idx))
+                            variable.interesting_values = variable.interesting_values.append(pd.Series([idx]))
+                        else:
+                            fraction = counts[idx] / total_count
+                            if fraction > 0.05 and fraction < 0.95:
+                                if verbose:
+                                    msg = "Variable {}: Marking {} as an "
+                                    msg += "interesting value"
+                                    logger.info(msg.format(variable.id, idx))
+                                variable.interesting_values = variable.interesting_values.append(pd.Series([idx]))
+                                # total_count -= counts[idx]
+                            else:
+                                break
+
         self.reset_data_description()
 
     def plot(self, to_file=None):

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -909,25 +909,25 @@ class EntitySet(object):
     #  Other ###############################################
     ###########################################################################
 
-    def add_interesting_values(self, max_values=5, verbose=False, datatable_id=None):
+    def add_interesting_values(self, max_values=5, verbose=False, entity_id=None):
         """Find interesting values for categorical variables, to be used to generate "where" clauses
 
         Args:
             max_values (int) : Maximum number of values per variable to add.
             verbose (bool) : If True, print summary of interesting values found.
-            datatable_id (str) : The DataTable for which to add interesting values. If not specified
-                interesting values will be added for all DataTables.
+            entity_id (str) : The Entity for which to add interesting values. If not specified
+                interesting values will be added for all Entities.
 
         Returns:
             None
 
         """
-        if datatable_id:
-            tables = [self[datatable_id]]
+        if entity_id:
+            entities = [self[entity_id]]
         else:
-            tables = self.entities
-        for table in tables:
-            for variable in table.variables:
+            entities = self.entities
+        for entity in entities:
+            for variable in entity.variables:
                 # some heuristics to find basic 'where'-able variables
                 if isinstance(variable, vtypes.Discrete):
                     variable.interesting_values = pd.Series(dtype=variable.entity.df[variable.id].dtype)
@@ -942,7 +942,7 @@ class EntitySet(object):
                     if skip:
                         continue
 
-                    counts = table.df[variable.id].value_counts()
+                    counts = entity.df[variable.id].value_counts()
 
                     # find how many of each unique value there are; sort by count,
                     # and add interesting values to each variable

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -949,8 +949,6 @@ class EntitySet(object):
                     for i in range(min(max_values, len(counts.index))):
                         idx = counts.index[i]
 
-                        # add the value to interesting_values if it represents more than
-                        # 25% of the values we have not seen so far
                         if len(counts.index) < 25:
                             if verbose:
                                 msg = "Variable {}: Marking {} as an "
@@ -965,7 +963,6 @@ class EntitySet(object):
                                     msg += "interesting value"
                                     logger.info(msg.format(variable.id, idx))
                                 variable.interesting_values = variable.interesting_values.append(pd.Series([idx]))
-                                # total_count -= counts[idx]
                             else:
                                 break
 

--- a/featuretools/tests/entityset_tests/test_entity.py
+++ b/featuretools/tests/entityset_tests/test_entity.py
@@ -67,7 +67,7 @@ def test_eq(es):
     assert es['log'].__eq__(other_es['log'], deep=True)
     assert all(to_pandas(es['log'].df['latlong']).eq(to_pandas(latlong)))
 
-    other_es.add_interesting_values(datatable_id='log')
+    other_es.add_interesting_values(entity_id='log')
     assert not es['log'].__eq__(other_es['log'], deep=True)
 
     es['log'].id = 'customers'

--- a/featuretools/tests/entityset_tests/test_entity.py
+++ b/featuretools/tests/entityset_tests/test_entity.py
@@ -67,7 +67,7 @@ def test_eq(es):
     assert es['log'].__eq__(other_es['log'], deep=True)
     assert all(to_pandas(es['log'].df['latlong']).eq(to_pandas(latlong)))
 
-    other_es.add_interesting_values(entity_id='log')
+    other_es.add_interesting_values(datatable_id='log')
     assert not es['log'].__eq__(other_es['log'], deep=True)
 
     es['log'].id = 'customers'

--- a/featuretools/tests/entityset_tests/test_entity.py
+++ b/featuretools/tests/entityset_tests/test_entity.py
@@ -67,7 +67,7 @@ def test_eq(es):
     assert es['log'].__eq__(other_es['log'], deep=True)
     assert all(to_pandas(es['log'].df['latlong']).eq(to_pandas(latlong)))
 
-    other_es['log'].add_interesting_values()
+    other_es.add_interesting_values(entity_id='log')
     assert not es['log'].__eq__(other_es['log'], deep=True)
 
     es['log'].id = 'customers'

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -1521,11 +1521,10 @@ def test_add_interesting_values_verbose_output(caplog):
     es['order_products'].convert_variable_type('quantity', ft.variable_types.Discrete)
     logger = logging.getLogger('featuretools')
     logger.propagate = True
-    logger = logging.getLogger('featuretools.entityset')
-    logger.propagate = True
+    logger_es = logging.getLogger('featuretools.entityset')
+    logger_es.propagate = True
     es.add_interesting_values(verbose=True, max_values=10)
     logger.propagate = False
-    logger = logging.getLogger('featuretools')
-    logger.propagate = False
+    logger_es.propagate = False
     assert 'Variable country: Marking United Kingdom as an interesting value' in caplog.text
     assert 'Variable quantity: Marking 6 as an interesting value' in caplog.text

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -1523,7 +1523,7 @@ def test_add_interesting_values_verbose_output(caplog):
     logger.propagate = True
     logger = logging.getLogger('featuretools.entityset')
     logger.propagate = True
-    es.add_interesting_values(verbose=True)
+    es.add_interesting_values(verbose=True, max_values=10)
     logger.propagate = False
     logger = logging.getLogger('featuretools')
     logger.propagate = False

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -1516,13 +1516,16 @@ def test_entityset_init():
     assert es['transactions'].__eq__(es_copy['transactions'], deep=True)
 
 
-def test_add_interesting_values_verbose_output(caplog, pd_es):
+def test_add_interesting_values_verbose_output(caplog):
+    es = ft.demo.load_retail(nrows=200)
+    es['order_products'].convert_variable_type('quantity', ft.variable_types.Discrete)
     logger = logging.getLogger('featuretools')
     logger.propagate = True
     logger = logging.getLogger('featuretools.entityset')
     logger.propagate = True
-    pd_es.add_interesting_values(verbose=True)
+    es.add_interesting_values(verbose=True)
     logger.propagate = False
     logger = logging.getLogger('featuretools')
     logger.propagate = False
-    assert 'Variable language: Marking en as an interesting value' in caplog.text
+    assert 'Variable country: Marking United Kingdom as an interesting value' in caplog.text
+    assert 'Variable quantity: Marking 6 as an interesting value' in caplog.text

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -1514,3 +1514,15 @@ def test_entityset_init():
     es_copy.add_relationship(relationship)
     assert es['cards'].__eq__(es_copy['cards'], deep=True)
     assert es['transactions'].__eq__(es_copy['transactions'], deep=True)
+
+
+def test_add_interesting_values_verbose_output(caplog, pd_es):
+    logger = logging.getLogger('featuretools')
+    logger.propagate = True
+    logger = logging.getLogger('featuretools.entityset')
+    logger.propagate = True
+    pd_es.add_interesting_values(verbose=True)
+    logger.propagate = False
+    logger = logging.getLogger('featuretools')
+    logger.propagate = False
+    assert 'Variable language: Marking en as an interesting value' in caplog.text


### PR DESCRIPTION
### Remove add interesting values from Entity
This PR moves all functionality for adding interesting values to EntitySet. Since `add_interesting_values` was already a method on EntitySet, one change was made. An additional parameter was added to the method to specify an entity_id, if the user wants to add interesting values for a single Entity - equivalent to the previous call to `Entity.add_interesting_values`. If this parameter is not passed, `EntitySet.add_interesting_values` will add interesting values for all entities in the entityset.
