### PR TITLE
Move handle_time to entityset

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -6,13 +6,14 @@ Release Notes
     * Enhancements
     * Fixes
     * Changes
+        * Move ``_handle_time`` method from ``Entity`` to ``EntitySet`` (:pr:`1276`)
     * Documentation Changes
     * Testing Changes
         * Use repository-scoped token for dependency check (:pr:`1245`:, :pr:`1248`)
         * Fix install error during docs CI test (:pr:`1250`)
 
     Thanks to the following people for contributing to this release:
-    :user:`jeff-hernandez`, :user:`rwedge`
+    :user:`jeff-hernandez`, :user:`rwedge`, :user:`thehomebrewnerd`
 
 **v0.22.0 Nov 30, 2020**
     * Enhancements

--- a/featuretools/computational_backends/calculate_feature_matrix.py
+++ b/featuretools/computational_backends/calculate_feature_matrix.py
@@ -177,10 +177,11 @@ def calculate_feature_matrix(features, entityset=None, cutoff_time=None, instanc
 
         if instance_ids is None:
             index_var = target_entity.index
-            df = target_entity._handle_time(target_entity.df,
-                                            time_last=cutoff_time,
-                                            training_window=training_window,
-                                            include_cutoff_time=include_cutoff_time)
+            df = entityset._handle_time(datatable_id=target_entity.id,
+                                        df=target_entity.df,
+                                        time_last=cutoff_time,
+                                        training_window=training_window,
+                                        include_cutoff_time=include_cutoff_time)
             instance_ids = df[index_var]
 
         if isinstance(instance_ids, dd.Series):

--- a/featuretools/computational_backends/calculate_feature_matrix.py
+++ b/featuretools/computational_backends/calculate_feature_matrix.py
@@ -177,7 +177,7 @@ def calculate_feature_matrix(features, entityset=None, cutoff_time=None, instanc
 
         if instance_ids is None:
             index_var = target_entity.index
-            df = entityset._handle_time(datatable_id=target_entity.id,
+            df = entityset._handle_time(entity_id=target_entity.id,
                                         df=target_entity.df,
                                         time_last=cutoff_time,
                                         training_window=training_window,

--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -269,7 +269,7 @@ class Entity(object):
                 categories = pd.api.types.CategoricalDtype(categories=self.df[variable_id].cat.categories)
                 df[variable_id] = df[variable_id].astype(categories)
 
-        df = self.entityset._handle_time(datatable_id=self.id,
+        df = self.entityset._handle_time(entity_id=self.id,
                                          df=df,
                                          time_last=time_last,
                                          training_window=training_window,

--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -269,10 +269,11 @@ class Entity(object):
                 categories = pd.api.types.CategoricalDtype(categories=self.df[variable_id].cat.categories)
                 df[variable_id] = df[variable_id].astype(categories)
 
-        df = self._handle_time(df=df,
-                               time_last=time_last,
-                               training_window=training_window,
-                               include_cutoff_time=include_cutoff_time)
+        df = self.entityset._handle_time(datatable_id=self.id,
+                                         df=df,
+                                         time_last=time_last,
+                                         training_window=training_window,
+                                         include_cutoff_time=include_cutoff_time)
 
         if columns is not None:
             df = df[columns]
@@ -536,57 +537,6 @@ class Entity(object):
         out_vals.index.name = None
 
         return out_vals
-
-    def _handle_time(self, df, time_last=None, training_window=None, include_cutoff_time=True):
-        """
-        Filter a dataframe for all instances before time_last.
-        If this entity does not have a time index, return the original
-        dataframe.
-        """
-        if is_instance(df, ks, 'DataFrame') and isinstance(time_last, np.datetime64):
-            time_last = pd.to_datetime(time_last)
-        if self.time_index:
-            df_empty = df.empty if isinstance(df, pd.DataFrame) else False
-            if time_last is not None and not df_empty:
-                if include_cutoff_time:
-                    df = df[df[self.time_index] <= time_last]
-                else:
-                    df = df[df[self.time_index] < time_last]
-                if training_window is not None:
-                    training_window = _check_timedelta(training_window)
-                    if include_cutoff_time:
-                        mask = df[self.time_index] > time_last - training_window
-                    else:
-                        mask = df[self.time_index] >= time_last - training_window
-                    if self.last_time_index is not None:
-                        lti_slice = self.last_time_index.reindex(df.index)
-                        if include_cutoff_time:
-                            lti_mask = lti_slice > time_last - training_window
-                        else:
-                            lti_mask = lti_slice >= time_last - training_window
-                        mask = mask | lti_mask
-                    else:
-                        warnings.warn(
-                            "Using training_window but last_time_index is "
-                            "not set on entity %s" % (self.id)
-                        )
-
-                    df = df[mask]
-
-        for secondary_time_index, columns in self.secondary_time_index.items():
-            # should we use ignore time last here?
-            df_empty = df.empty if isinstance(df, pd.DataFrame) else False
-            if time_last is not None and not df_empty:
-                mask = df[secondary_time_index] >= time_last
-                if isinstance(df, dd.DataFrame):
-                    for col in columns:
-                        df[col] = df[col].mask(mask, np.nan)
-                elif is_instance(df, ks, 'DataFrame'):
-                    df.loc[mask, columns] = None
-                else:
-                    df.loc[mask, columns] = np.nan
-
-        return df
 
 
 def _create_index(index, make_index, df):

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -970,13 +970,13 @@ class EntitySet(object):
             save_graph(graph, to_file, format_)
         return graph
 
-    def _handle_time(self, datatable_id, df, time_last=None, training_window=None, include_cutoff_time=True):
+    def _handle_time(self, entity_id, df, time_last=None, training_window=None, include_cutoff_time=True):
         """
         Filter a dataframe for all instances before time_last.
         If the DataTable does not have a time index, return the original
         dataframe.
         """
-        dt = self[datatable_id]
+        dt = self[entity_id]
         if is_instance(df, ks, 'DataFrame') and isinstance(time_last, np.datetime64):
             time_last = pd.to_datetime(time_last)
         if dt.time_index:

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -18,6 +18,7 @@ from featuretools.utils.plot_utils import (
     get_graphviz_format,
     save_graph
 )
+from featuretools.utils.wrangle import _check_timedelta
 
 ks = import_or_none('databricks.koalas')
 
@@ -968,3 +969,55 @@ class EntitySet(object):
         if to_file:
             save_graph(graph, to_file, format_)
         return graph
+
+    def _handle_time(self, datatable_id, df, time_last=None, training_window=None, include_cutoff_time=True):
+        """
+        Filter a dataframe for all instances before time_last.
+        If the DataTable does not have a time index, return the original
+        dataframe.
+        """
+        dt = self[datatable_id]
+        if is_instance(df, ks, 'DataFrame') and isinstance(time_last, np.datetime64):
+            time_last = pd.to_datetime(time_last)
+        if dt.time_index:
+            df_empty = df.empty if isinstance(df, pd.DataFrame) else False
+            if time_last is not None and not df_empty:
+                if include_cutoff_time:
+                    df = df[df[dt.time_index] <= time_last]
+                else:
+                    df = df[df[dt.time_index] < time_last]
+                if training_window is not None:
+                    training_window = _check_timedelta(training_window)
+                    if include_cutoff_time:
+                        mask = df[dt.time_index] > time_last - training_window
+                    else:
+                        mask = df[dt.time_index] >= time_last - training_window
+                    if dt.last_time_index is not None:
+                        lti_slice = dt.last_time_index.reindex(df.index)
+                        if include_cutoff_time:
+                            lti_mask = lti_slice > time_last - training_window
+                        else:
+                            lti_mask = lti_slice >= time_last - training_window
+                        mask = mask | lti_mask
+                    else:
+                        warnings.warn(
+                            "Using training_window but last_time_index is "
+                            "not set on entity %s" % (dt.id)
+                        )
+
+                    df = df[mask]
+
+        for secondary_time_index, columns in dt.secondary_time_index.items():
+            # should we use ignore time last here?
+            df_empty = df.empty if isinstance(df, pd.DataFrame) else False
+            if time_last is not None and not df_empty:
+                mask = df[secondary_time_index] >= time_last
+                if isinstance(df, dd.DataFrame):
+                    for col in columns:
+                        df[col] = df[col].mask(mask, np.nan)
+                elif is_instance(df, ks, 'DataFrame'):
+                    df.loc[mask, columns] = None
+                else:
+                    df.loc[mask, columns] = np.nan
+
+        return df


### PR DESCRIPTION
### Move `_handle_time` from Entity to EntitySet
Closes #1275 

Moves the `_handle_time` method from Entity to EntitySet in preparation for Woodwork integration.