### PR TITLE
Replace Entity with Woodwork.DataTable

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -11,6 +11,7 @@ Release Notes
         * Move ``query_by_values`` method from ``Entity`` to ``EntitySet`` (:pr:`1251`)
         * Remove ``add_interesting_values`` from ``Entity`` (:pr:`1269`)
         * Move ``_handle_time`` method from ``Entity`` to ``EntitySet`` (:pr:`1276`)
+        * Move ``set_secondary_time_index`` method from ``Entity`` to ``EntitySet`` (:pr:`1280`)
     * Documentation Changes
         * Fix installation command for Add-ons (:pr:`1279`)
     * Testing Changes
@@ -27,6 +28,8 @@ Release Notes
 * ``Entity.add_interesting_values`` has been removed. To add interesting values for a single
     entity, call ``EntitySet.add_interesting_values`` and pass the id of the entity for
     which to add interesting values in the ``entity_id`` parameter. 
+* ``Entity.set_secondary_time_index`` has been removed and replaced by ``EntitySet.set_secondary_time_index``
+    with an added ``entity`` parameter to specify the entity on which to set the secondary time index.
 
 **v0.22.0 Nov 30, 2020**
     * Enhancements

--- a/featuretools/entityset/deserialize.py
+++ b/featuretools/entityset/deserialize.py
@@ -55,6 +55,7 @@ def description_to_entity(description, entityset, path=None):
         dataframe = empty_dataframe(description)
     variable_types = {variable['id']: (description_to_variable(variable), variable)
                       for variable in description['variables']}
+
     es = entityset.entity_from_dataframe(
         description['id'],
         dataframe,
@@ -62,7 +63,7 @@ def description_to_entity(description, entityset, path=None):
         time_index=description.get('time_index'),
         secondary_time_index=description['properties'].get('secondary_time_index'),
         variable_types={variable: variable_types[variable][0] for variable in variable_types})
-    for variable in es[description['id']].variables:
+    for variable in es[description['id']].metadata['variables'].values():
         interesting_values = variable_types[variable.id][1]['properties']['interesting_values']
         interesting_values = pd.read_json(interesting_values, typ="series")
         variable.interesting_values = interesting_values

--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -1,7 +1,6 @@
 import warnings
 
 import dask.dataframe as dd
-import numpy as np
 import pandas as pd
 
 from featuretools import variable_types as vtypes
@@ -76,7 +75,7 @@ class Entity(object):
         if time_index:
             self.set_time_index(time_index, already_sorted=already_sorted)
 
-        self.set_secondary_time_index(secondary_time_index)
+        entityset.set_secondary_time_index(self, secondary_time_index)
 
     def __repr__(self):
         repr_out = u"Entity: {}\n".format(self.id)
@@ -281,7 +280,7 @@ class Entity(object):
         if self.time_index is not None:
             self.set_time_index(self.time_index, already_sorted=already_sorted)
 
-        self.set_secondary_time_index(self.secondary_time_index)
+        self.entityset.set_secondary_time_index(self, self.secondary_time_index)
         if recalculate_last_time_indexes and self.last_time_index is not None:
             self.entityset.add_last_time_indexes(updated_entities=[self.id])
         self.entityset.reset_data_description()
@@ -359,25 +358,6 @@ class Entity(object):
 
         self.convert_variable_type(variable_id, vtypes.Index, convert_data=False)
         self.index = variable_id
-
-    def set_secondary_time_index(self, secondary_time_index):
-        for time_index, columns in secondary_time_index.items():
-            if is_instance(self.df, (dd, ks), 'DataFrame') or self.df.empty:
-                time_to_check = vtypes.DEFAULT_DTYPE_VALUES[self[time_index]._default_pandas_dtype]
-            else:
-                time_to_check = self.df[time_index].head(1).iloc[0]
-            time_type = _check_time_type(time_to_check)
-            if time_type is None:
-                raise TypeError("%s time index not recognized as numeric or"
-                                " datetime" % (self.id))
-            if self.entityset.time_type != time_type:
-                raise TypeError("%s time index is %s type which differs from"
-                                " other entityset time indexes" %
-                                (self.id, time_type))
-            if time_index not in columns:
-                columns.append(time_index)
-
-        self.secondary_time_index = secondary_time_index
 
 
 def _create_index(index, make_index, df):

--- a/featuretools/entityset/relationship.py
+++ b/featuretools/entityset/relationship.py
@@ -16,15 +16,15 @@ class Relationship(object):
 
         """
 
-        self.entityset = child_variable.entityset
-        self._parent_entity_id = parent_variable.entity.id
-        self._child_entity_id = child_variable.entity.id
-        self._parent_variable_id = parent_variable.id
-        self._child_variable_id = child_variable.id
+        self.entityset = child_variable.metadata['datatable'].metadata['entityset']
+        self._parent_entity_id = parent_variable.metadata['datatable'].name
+        self._child_entity_id = child_variable.metadata['datatable'].name
+        self._parent_variable_id = parent_variable.name
+        self._child_variable_id = child_variable.name
 
-        if (parent_variable.entity.index is not None and
-                parent_variable.id != parent_variable.entity.index):
-            raise AttributeError("Parent variable '%s' is not the index of entity %s" % (parent_variable, parent_variable.entity))
+        if (parent_variable.metadata['datatable'].index is not None and
+                parent_variable.name != parent_variable.metadata['datatable'].index):
+            raise AttributeError("Parent variable '%s' is not the index of entity %s" % (parent_variable, parent_variable.metadata['datatable'].name))
 
     @classmethod
     def from_dictionary(cls, arguments, es):

--- a/featuretools/entityset/relationship.py
+++ b/featuretools/entityset/relationship.py
@@ -24,7 +24,7 @@ class Relationship(object):
 
         if (parent_variable.metadata['datatable'].index is not None and
                 parent_variable.name != parent_variable.metadata['datatable'].index):
-            raise AttributeError("Parent variable '%s' is not the index of entity %s" % (parent_variable, parent_variable.metadata['datatable'].name))
+            raise AttributeError("Parent variable '%s' is not the index of entity %s" % (parent_variable.name, parent_variable.metadata['datatable'].name))
 
     @classmethod
     def from_dictionary(cls, arguments, es):

--- a/featuretools/entityset/relationship.py
+++ b/featuretools/entityset/relationship.py
@@ -102,7 +102,7 @@ class Relationship(object):
 
     def _is_unique(self):
         """Is there any other relationship with same parent and child entities?"""
-        es = self.child_entity.entityset
+        es = self.child_entity.metadata['entityset']
         relationships = es.get_forward_relationships(self._child_entity_id)
         n = len([r for r in relationships
                  if r._parent_entity_id == self._parent_entity_id])
@@ -128,16 +128,16 @@ class RelationshipPath(object):
             # Yield first entity.
             is_forward, relationship = self[0]
             if is_forward:
-                yield relationship.child_entity.id
+                yield relationship.child_entity.name
             else:
-                yield relationship.parent_entity.id
+                yield relationship.parent_entity.name
 
         # Yield the entity pointed to by each relationship.
         for is_forward, relationship in self:
             if is_forward:
-                yield relationship.parent_entity.id
+                yield relationship.parent_entity.name
             else:
-                yield relationship.child_entity.id
+                yield relationship.child_entity.name
 
     def __add__(self, other):
         return RelationshipPath(self._relationships_with_direction +

--- a/featuretools/tests/conftest.py
+++ b/featuretools/tests/conftest.py
@@ -52,7 +52,7 @@ def int_es(make_int_es):
 def dask_es(make_es):
     dask_es = copy.deepcopy(make_es)
     for entity in dask_es.entities:
-        entity.df = dd.from_pandas(entity.df.reset_index(drop=True), npartitions=2)
+        entity.update_dataframe(dd.from_pandas(entity.to_dataframe().reset_index(drop=True), npartitions=2))
     return dask_es
 
 
@@ -63,8 +63,11 @@ def ks_es(make_es):
         pytest.skip('skipping Koalas tests for Windows')
     ks_es = copy.deepcopy(make_es)
     for entity in ks_es.entities:
-        cleaned_df = pd_to_ks_clean(entity.df).reset_index(drop=True)
-        entity.df = ks.from_pandas(cleaned_df)
+        cleaned_df = pd_to_ks_clean(entity.to_dataframe()).reset_index(drop=True)
+        # Set everything to object to prevent error on unsupported dtypes like Int64
+        for column in cleaned_df.columns:
+            cleaned_df[column] = cleaned_df.astype('object')
+        entity.update_dataframe(ks.from_pandas(cleaned_df))
     return ks_es
 
 

--- a/featuretools/tests/conftest.py
+++ b/featuretools/tests/conftest.py
@@ -66,7 +66,7 @@ def ks_es(make_es):
         cleaned_df = pd_to_ks_clean(entity.df).reset_index(drop=True)
         # Set everything to object to prevent error on unsupported dtypes like Int64
         for column in cleaned_df.columns:
-            cleaned_df[column] = cleaned_df.astype('object')
+            cleaned_df[column] = cleaned_df[column].astype('object')
         entity.update_dataframe(ks.from_pandas(cleaned_df))
     return ks_es
 
@@ -132,11 +132,11 @@ def pd_diamond_es():
 def dask_diamond_es(pd_diamond_es):
     entities = {}
     for entity in pd_diamond_es.entities:
-        entities[entity.id] = (dd.from_pandas(entity.df, npartitions=2), entity.index, None, entity.variable_types)
+        entities[entity.name] = (dd.from_pandas(entity.df, npartitions=2), entity.index, None, entity.metadata['variable_types'])
 
-    relationships = [(rel.parent_entity.id,
+    relationships = [(rel.parent_entity.name,
                       rel.parent_variable.name,
-                      rel.child_entity.id,
+                      rel.child_entity.name,
                       rel.child_variable.name) for rel in pd_diamond_es.relationships]
 
     return ft.EntitySet(id=pd_diamond_es.id, entities=entities, relationships=relationships)
@@ -149,11 +149,11 @@ def ks_diamond_es(pd_diamond_es):
         pytest.skip('skipping Koalas tests for Windows')
     entities = {}
     for entity in pd_diamond_es.entities:
-        entities[entity.id] = (ks.from_pandas(pd_to_ks_clean(entity.df)), entity.index, None, entity.variable_types)
+        entities[entity.name] = (ks.from_pandas(pd_to_ks_clean(entity.df)), entity.index, None, entity.metadata['variable_types'])
 
-    relationships = [(rel.parent_entity.id,
+    relationships = [(rel.parent_entity.name,
                       rel.parent_variable.name,
-                      rel.child_entity.id,
+                      rel.child_entity.name,
                       rel.child_variable.name) for rel in pd_diamond_es.relationships]
 
     return ft.EntitySet(id=pd_diamond_es.id, entities=entities, relationships=relationships)
@@ -187,11 +187,11 @@ def pd_home_games_es():
 def dask_home_games_es(pd_home_games_es):
     entities = {}
     for entity in pd_home_games_es.entities:
-        entities[entity.id] = (dd.from_pandas(entity.df, npartitions=2), entity.index, None, entity.variable_types)
+        entities[entity.name] = (dd.from_pandas(entity.df, npartitions=2), entity.index, None, entity.metadata['variable_types'])
 
-    relationships = [(rel.parent_entity.id,
+    relationships = [(rel.parent_entity.name,
                       rel.parent_variable.name,
-                      rel.child_entity.id,
+                      rel.child_entity.name,
                       rel.child_variable.name) for rel in pd_home_games_es.relationships]
 
     return ft.EntitySet(id=pd_home_games_es.id, entities=entities, relationships=relationships)
@@ -204,11 +204,11 @@ def ks_home_games_es(pd_home_games_es):
         pytest.skip('skipping Koalas tests for Windows')
     entities = {}
     for entity in pd_home_games_es.entities:
-        entities[entity.id] = (ks.from_pandas(pd_to_ks_clean(entity.df)), entity.index, None, entity.variable_types)
+        entities[entity.name] = (ks.from_pandas(pd_to_ks_clean(entity.df)), entity.index, None, entity.metadata['variable_types'])
 
-    relationships = [(rel.parent_entity.id,
+    relationships = [(rel.parent_entity.name,
                       rel.parent_variable.name,
-                      rel.child_entity.id,
+                      rel.child_entity.name,
                       rel.child_variable.name) for rel in pd_home_games_es.relationships]
 
     return ft.EntitySet(id=pd_home_games_es.id, entities=entities, relationships=relationships)

--- a/featuretools/tests/conftest.py
+++ b/featuretools/tests/conftest.py
@@ -52,7 +52,7 @@ def int_es(make_int_es):
 def dask_es(make_es):
     dask_es = copy.deepcopy(make_es)
     for entity in dask_es.entities:
-        entity.update_dataframe(dd.from_pandas(entity.to_dataframe().reset_index(drop=True), npartitions=2))
+        entity.update_dataframe(dd.from_pandas(entity.df.reset_index(drop=True), npartitions=2))
     return dask_es
 
 
@@ -63,7 +63,7 @@ def ks_es(make_es):
         pytest.skip('skipping Koalas tests for Windows')
     ks_es = copy.deepcopy(make_es)
     for entity in ks_es.entities:
-        cleaned_df = pd_to_ks_clean(entity.to_dataframe()).reset_index(drop=True)
+        cleaned_df = pd_to_ks_clean(entity.df).reset_index(drop=True)
         # Set everything to object to prevent error on unsupported dtypes like Int64
         for column in cleaned_df.columns:
             cleaned_df[column] = cleaned_df.astype('object')

--- a/featuretools/tests/entityset_tests/test_dask_es.py
+++ b/featuretools/tests/entityset_tests/test_dask_es.py
@@ -14,7 +14,7 @@ def test_create_entity_from_dask_df(pd_es):
         dataframe=log_dask,
         index="id",
         time_index="datetime",
-        variable_types=pd_es["log"].variable_types
+        variable_types=pd_es["log"].metadata['variable_types']
     )
     pd.testing.assert_frame_equal(pd_es["log"].df, dask_es["log_dask"].df.compute(), check_like=True)
 
@@ -84,7 +84,7 @@ def test_add_last_time_indexes():
     sessions_vtypes = {
         "id": ft.variable_types.Id,
         "user": ft.variable_types.Id,
-        "time": ft.variable_types.DatetimeTimeIndex,
+        "time": ft.variable_types.Datetime,
         "strings": ft.variable_types.NaturalLanguage
     }
 
@@ -102,7 +102,7 @@ def test_add_last_time_indexes():
         "id": ft.variable_types.Id,
         "session_id": ft.variable_types.Id,
         "amount": ft.variable_types.Numeric,
-        "time": ft.variable_types.DatetimeTimeIndex,
+        "time": ft.variable_types.Datetime,
     }
 
     pd_es.entity_from_dataframe(entity_id="sessions", dataframe=sessions, index="id", time_index="time")
@@ -119,13 +119,14 @@ def test_add_last_time_indexes():
     pd_es = pd_es.add_relationship(new_rel)
     dask_es = dask_es.add_relationship(dask_rel)
 
-    assert pd_es['sessions'].last_time_index is None
-    assert dask_es['sessions'].last_time_index is None
+    assert pd_es['sessions'].metadata.get('last_time_index') is None
+    assert dask_es['sessions'].metadata.get('last_time_index') is None
 
     pd_es.add_last_time_indexes()
     dask_es.add_last_time_indexes()
 
-    pd.testing.assert_series_equal(pd_es['sessions'].last_time_index.sort_index(), dask_es['sessions'].last_time_index.compute(), check_names=False)
+    pd.testing.assert_series_equal(pd_es['sessions'].metadata.get('last_time_index').sort_index(),
+                                   dask_es['sessions'].metadata.get('last_time_index').compute(), check_names=False)
 
 
 def test_create_entity_with_make_index():
@@ -136,369 +137,8 @@ def test_create_entity_with_make_index():
     vtypes = {"values": ft.variable_types.Numeric}
     dask_es.entity_from_dataframe(entity_id="new_entity", dataframe=dask_df, make_index=True, index="new_index", variable_types=vtypes)
 
+    # TODO: WOODWORK: Remove column reordering after Woodwork is updated to insert index as first column
     expected_df = pd.DataFrame({"new_index": range(len(values)), "values": values})
-    pd.testing.assert_frame_equal(expected_df, dask_es['new_entity'].df.compute())
-
-
-def test_single_table_dask_entityset():
-    primitives_list = ['absolute', 'is_weekend', 'year', 'day', 'num_characters', 'num_words']
-
-    dask_es = EntitySet(id="dask_es")
-    df = pd.DataFrame({"id": [0, 1, 2, 3],
-                       "values": [1, 12, -34, 27],
-                       "dates": [pd.to_datetime('2019-01-10'),
-                                 pd.to_datetime('2019-02-03'),
-                                 pd.to_datetime('2019-01-01'),
-                                 pd.to_datetime('2017-08-25')],
-                       "strings": ["I am a string",
-                                   "23",
-                                   "abcdef ghijk",
-                                   ""]})
-    values_dd = dd.from_pandas(df, npartitions=2)
-    vtypes = {
-        "id": ft.variable_types.Id,
-        "values": ft.variable_types.Numeric,
-        "dates": ft.variable_types.Datetime,
-        "strings": ft.variable_types.NaturalLanguage
-    }
-    dask_es.entity_from_dataframe(entity_id="data",
-                                  dataframe=values_dd,
-                                  index="id",
-                                  variable_types=vtypes)
-
-    dask_fm, _ = ft.dfs(entityset=dask_es,
-                        target_entity="data",
-                        trans_primitives=primitives_list)
-
-    pd_es = ft.EntitySet(id="pd_es")
-    pd_es.entity_from_dataframe(entity_id="data",
-                                dataframe=df,
-                                index="id",
-                                variable_types={"strings": ft.variable_types.NaturalLanguage})
-
-    fm, _ = ft.dfs(entityset=pd_es,
-                   target_entity="data",
-                   trans_primitives=primitives_list)
-
-    # Use the same columns and make sure both indexes are sorted the same
-    dask_computed_fm = dask_fm.compute().set_index('id').loc[fm.index][fm.columns]
-    pd.testing.assert_frame_equal(fm, dask_computed_fm)
-
-
-def test_single_table_dask_entityset_ids_not_sorted():
-    primitives_list = ['absolute', 'is_weekend', 'year', 'day', 'num_characters', 'num_words']
-
-    dask_es = EntitySet(id="dask_es")
-    df = pd.DataFrame({"id": [2, 0, 1, 3],
-                       "values": [1, 12, -34, 27],
-                       "dates": [pd.to_datetime('2019-01-10'),
-                                 pd.to_datetime('2019-02-03'),
-                                 pd.to_datetime('2019-01-01'),
-                                 pd.to_datetime('2017-08-25')],
-                       "strings": ["I am a string",
-                                   "23",
-                                   "abcdef ghijk",
-                                   ""]})
-    values_dd = dd.from_pandas(df, npartitions=2)
-    vtypes = {
-        "id": ft.variable_types.Id,
-        "values": ft.variable_types.Numeric,
-        "dates": ft.variable_types.Datetime,
-        "strings": ft.variable_types.NaturalLanguage
-    }
-    dask_es.entity_from_dataframe(entity_id="data",
-                                  dataframe=values_dd,
-                                  index="id",
-                                  variable_types=vtypes)
-
-    dask_fm, _ = ft.dfs(entityset=dask_es,
-                        target_entity="data",
-                        trans_primitives=primitives_list)
-
-    pd_es = ft.EntitySet(id="pd_es")
-    pd_es.entity_from_dataframe(entity_id="data",
-                                dataframe=df,
-                                index="id",
-                                variable_types={"strings": ft.variable_types.NaturalLanguage})
-
-    fm, _ = ft.dfs(entityset=pd_es,
-                   target_entity="data",
-                   trans_primitives=primitives_list)
-
-    # Make sure both indexes are sorted the same
-    pd.testing.assert_frame_equal(fm, dask_fm.compute().set_index('id').loc[fm.index])
-
-
-def test_single_table_dask_entityset_with_instance_ids():
-    primitives_list = ['absolute', 'is_weekend', 'year', 'day', 'num_characters', 'num_words']
-    instance_ids = [0, 1, 3]
-
-    dask_es = EntitySet(id="dask_es")
-    df = pd.DataFrame({"id": [0, 1, 2, 3],
-                       "values": [1, 12, -34, 27],
-                       "dates": [pd.to_datetime('2019-01-10'),
-                                 pd.to_datetime('2019-02-03'),
-                                 pd.to_datetime('2019-01-01'),
-                                 pd.to_datetime('2017-08-25')],
-                       "strings": ["I am a string",
-                                   "23",
-                                   "abcdef ghijk",
-                                   ""]})
-
-    values_dd = dd.from_pandas(df, npartitions=2)
-    vtypes = {
-        "id": ft.variable_types.Id,
-        "values": ft.variable_types.Numeric,
-        "dates": ft.variable_types.Datetime,
-        "strings": ft.variable_types.NaturalLanguage
-    }
-    dask_es.entity_from_dataframe(entity_id="data",
-                                  dataframe=values_dd,
-                                  index="id",
-                                  variable_types=vtypes)
-
-    dask_fm, _ = ft.dfs(entityset=dask_es,
-                        target_entity="data",
-                        trans_primitives=primitives_list,
-                        instance_ids=instance_ids)
-
-    pd_es = ft.EntitySet(id="pd_es")
-    pd_es.entity_from_dataframe(entity_id="data",
-                                dataframe=df,
-                                index="id",
-                                variable_types={"strings": ft.variable_types.NaturalLanguage})
-
-    fm, _ = ft.dfs(entityset=pd_es,
-                   target_entity="data",
-                   trans_primitives=primitives_list,
-                   instance_ids=instance_ids)
-
-    # Make sure both indexes are sorted the same
-    pd.testing.assert_frame_equal(fm, dask_fm.compute().set_index('id').loc[fm.index])
-
-
-def test_single_table_dask_entityset_single_cutoff_time():
-    primitives_list = ['absolute', 'is_weekend', 'year', 'day', 'num_characters', 'num_words']
-
-    dask_es = EntitySet(id="dask_es")
-    df = pd.DataFrame({"id": [0, 1, 2, 3],
-                       "values": [1, 12, -34, 27],
-                       "dates": [pd.to_datetime('2019-01-10'),
-                                 pd.to_datetime('2019-02-03'),
-                                 pd.to_datetime('2019-01-01'),
-                                 pd.to_datetime('2017-08-25')],
-                       "strings": ["I am a string",
-                                   "23",
-                                   "abcdef ghijk",
-                                   ""]})
-    values_dd = dd.from_pandas(df, npartitions=2)
-    vtypes = {
-        "id": ft.variable_types.Id,
-        "values": ft.variable_types.Numeric,
-        "dates": ft.variable_types.Datetime,
-        "strings": ft.variable_types.NaturalLanguage
-    }
-    dask_es.entity_from_dataframe(entity_id="data",
-                                  dataframe=values_dd,
-                                  index="id",
-                                  variable_types=vtypes)
-
-    dask_fm, _ = ft.dfs(entityset=dask_es,
-                        target_entity="data",
-                        trans_primitives=primitives_list,
-                        cutoff_time=pd.Timestamp("2019-01-05 04:00"))
-
-    pd_es = ft.EntitySet(id="pd_es")
-    pd_es.entity_from_dataframe(entity_id="data",
-                                dataframe=df,
-                                index="id",
-                                variable_types={"strings": ft.variable_types.NaturalLanguage})
-
-    fm, _ = ft.dfs(entityset=pd_es,
-                   target_entity="data",
-                   trans_primitives=primitives_list,
-                   cutoff_time=pd.Timestamp("2019-01-05 04:00"))
-
-    # Make sure both indexes are sorted the same
-    pd.testing.assert_frame_equal(fm, dask_fm.compute().set_index('id').loc[fm.index])
-
-
-def test_single_table_dask_entityset_cutoff_time_df():
-    primitives_list = ['absolute', 'is_weekend', 'year', 'day', 'num_characters', 'num_words']
-
-    dask_es = EntitySet(id="dask_es")
-    df = pd.DataFrame({"id": [0, 1, 2],
-                       "values": [1, 12, -34],
-                       "dates": [pd.to_datetime('2019-01-10'),
-                                 pd.to_datetime('2019-02-03'),
-                                 pd.to_datetime('2019-01-01')],
-                       "strings": ["I am a string",
-                                   "23",
-                                   "abcdef ghijk"]})
-    values_dd = dd.from_pandas(df, npartitions=2)
-    vtypes = {
-        "id": ft.variable_types.Id,
-        "values": ft.variable_types.Numeric,
-        "dates": ft.variable_types.DatetimeTimeIndex,
-        "strings": ft.variable_types.NaturalLanguage
-    }
-    dask_es.entity_from_dataframe(entity_id="data",
-                                  dataframe=values_dd,
-                                  index="id",
-                                  time_index="dates",
-                                  variable_types=vtypes)
-    ids = [0, 1, 2, 0]
-    times = [pd.Timestamp("2019-01-05 04:00"),
-             pd.Timestamp("2019-01-05 04:00"),
-             pd.Timestamp("2019-01-05 04:00"),
-             pd.Timestamp("2019-01-15 04:00")]
-    labels = [True, False, True, False]
-    cutoff_times = pd.DataFrame({"id": ids, "time": times, "labels": labels}, columns=["id", "time", "labels"])
-
-    dask_fm, _ = ft.dfs(entityset=dask_es,
-                        target_entity="data",
-                        trans_primitives=primitives_list,
-                        cutoff_time=cutoff_times)
-
-    pd_es = ft.EntitySet(id="pd_es")
-    pd_es.entity_from_dataframe(entity_id="data",
-                                dataframe=df,
-                                index="id",
-                                time_index="dates",
-                                variable_types={"strings": ft.variable_types.NaturalLanguage})
-
-    fm, _ = ft.dfs(entityset=pd_es,
-                   target_entity="data",
-                   trans_primitives=primitives_list,
-                   cutoff_time=cutoff_times)
-    # Because row ordering with Dask is not guaranteed, we need to sort on two columns to make sure that values
-    # for instance id 0 are compared correctly. Also, make sure the boolean column has the same dtype.
-    fm = fm.sort_values(['id', 'labels'])
-    dask_fm = dask_fm.compute().set_index('id').sort_values(['id', 'labels'])
-    dask_fm['IS_WEEKEND(dates)'] = dask_fm['IS_WEEKEND(dates)'].astype(fm['IS_WEEKEND(dates)'].dtype)
-    pd.testing.assert_frame_equal(fm, dask_fm)
-
-
-def test_single_table_dask_entityset_dates_not_sorted():
-    dask_es = EntitySet(id="dask_es")
-    df = pd.DataFrame({"id": [0, 1, 2, 3],
-                       "values": [1, 12, -34, 27],
-                       "dates": [pd.to_datetime('2019-01-10'),
-                                 pd.to_datetime('2019-02-03'),
-                                 pd.to_datetime('2019-01-01'),
-                                 pd.to_datetime('2017-08-25')]})
-
-    primitives_list = ['absolute', 'is_weekend', 'year', 'day']
-    values_dd = dd.from_pandas(df, npartitions=1)
-    vtypes = {
-        "id": ft.variable_types.Id,
-        "values": ft.variable_types.Numeric,
-        "dates": ft.variable_types.Datetime,
-    }
-    dask_es.entity_from_dataframe(entity_id="data",
-                                  dataframe=values_dd,
-                                  index="id",
-                                  time_index="dates",
-                                  variable_types=vtypes)
-
-    dask_fm, _ = ft.dfs(entityset=dask_es,
-                        target_entity="data",
-                        trans_primitives=primitives_list,
-                        max_depth=1)
-
-    pd_es = ft.EntitySet(id="pd_es")
-    pd_es.entity_from_dataframe(entity_id="data",
-                                dataframe=df,
-                                index="id",
-                                time_index="dates")
-
-    fm, _ = ft.dfs(entityset=pd_es,
-                   target_entity="data",
-                   trans_primitives=primitives_list,
-                   max_depth=1)
-
-    pd.testing.assert_frame_equal(fm, dask_fm.compute().set_index('id').loc[fm.index])
-
-
-def test_secondary_time_index():
-    log_df = pd.DataFrame()
-    log_df['id'] = [0, 1, 2, 3]
-    log_df['scheduled_time'] = pd.to_datetime([
-        "2019-01-01",
-        "2019-01-01",
-        "2019-01-01",
-        "2019-01-01"
-    ])
-    log_df['departure_time'] = pd.to_datetime([
-        "2019-02-01 09:00",
-        "2019-02-06 10:00",
-        "2019-02-12 10:00",
-        "2019-03-01 11:30"])
-    log_df['arrival_time'] = pd.to_datetime([
-        "2019-02-01 11:23",
-        "2019-02-06 12:45",
-        "2019-02-12 13:53",
-        "2019-03-01 14:07"
-    ])
-    log_df['delay'] = [-2, 10, 60, 0]
-    log_df['flight_id'] = [0, 1, 0, 1]
-    log_dask = dd.from_pandas(log_df, npartitions=2)
-
-    flights_df = pd.DataFrame()
-    flights_df['id'] = [0, 1, 2, 3]
-    flights_df['origin'] = ["BOS", "LAX", "BOS", "LAX"]
-    flights_dask = dd.from_pandas(flights_df, npartitions=2)
-
-    pd_es = ft.EntitySet("flights")
-    dask_es = ft.EntitySet("flights_dask")
-
-    pd_es.entity_from_dataframe(entity_id='logs',
-                                dataframe=log_df,
-                                index="id",
-                                time_index="scheduled_time",
-                                secondary_time_index={
-                                    'arrival_time': ['departure_time', 'delay']})
-
-    log_vtypes = {
-        "id": ft.variable_types.Id,
-        "scheduled_time": ft.variable_types.DatetimeTimeIndex,
-        "departure_time": ft.variable_types.DatetimeTimeIndex,
-        "arrival_time": ft.variable_types.DatetimeTimeIndex,
-        "delay": ft.variable_types.Numeric,
-        "flight_id": ft.variable_types.Id
-    }
-    dask_es.entity_from_dataframe(entity_id='logs',
-                                  dataframe=log_dask,
-                                  index="id",
-                                  variable_types=log_vtypes,
-                                  time_index="scheduled_time",
-                                  secondary_time_index={
-                                      'arrival_time': ['departure_time', 'delay']})
-
-    pd_es.entity_from_dataframe('flights', flights_df, index="id")
-    flights_vtypes = pd_es['flights'].variable_types
-    dask_es.entity_from_dataframe('flights', flights_dask, index="id", variable_types=flights_vtypes)
-
-    new_rel = ft.Relationship(pd_es['flights']['id'], pd_es['logs']['flight_id'])
-    dask_rel = ft.Relationship(dask_es['flights']['id'], dask_es['logs']['flight_id'])
-    pd_es.add_relationship(new_rel)
-    dask_es.add_relationship(dask_rel)
-
-    cutoff_df = pd.DataFrame()
-    cutoff_df['id'] = [0, 1, 1]
-    cutoff_df['time'] = pd.to_datetime(['2019-02-02', '2019-02-02', '2019-02-20'])
-
-    fm, _ = ft.dfs(entityset=pd_es,
-                   target_entity="logs",
-                   cutoff_time=cutoff_df,
-                   agg_primitives=["max"],
-                   trans_primitives=["month"])
-
-    dask_fm, _ = ft.dfs(entityset=dask_es,
-                        target_entity="logs",
-                        cutoff_time=cutoff_df,
-                        agg_primitives=["max"],
-                        trans_primitives=["month"])
-
-    # Make sure both matrixes are sorted the same
-    pd.testing.assert_frame_equal(fm.sort_values('delay'), dask_fm.compute().set_index('id').sort_values('delay'))
+    expected_df["new_index"] = expected_df["new_index"].astype("Int64")
+    expected_df["values"] = expected_df["values"].astype("Int64")
+    pd.testing.assert_frame_equal(expected_df[["values", "new_index"]], dask_es["new_entity"].df.compute())

--- a/featuretools/tests/entityset_tests/test_entity.py
+++ b/featuretools/tests/entityset_tests/test_entity.py
@@ -246,7 +246,7 @@ def test_replace_latlong_nan_during_entity_creation(pd_es):
     df['latlong'][0] = np.nan
 
     with pytest.warns(UserWarning, match="LatLong columns should contain only tuples. All single 'NaN' values in column 'latlong' have been replaced with '\\(NaN, NaN\\)'."):
-        entity = ft.Entity(id="nan_latlong_entity", df=df, entityset=nan_es, variable_types=pd_es['log'].variable_types)
+        entity = ft.Entity(id="nan_latlong_entity", df=df, entityset=nan_es, variable_types=pd_es['log'])
     assert entity.df['latlong'][0] == (np.nan, np.nan)
 
 

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -27,7 +27,7 @@ ks = import_or_none('databricks.koalas')
 def test_normalize_time_index_as_additional_variable(es):
     error_text = "Not moving signup_date as it is the base time index variable."
     with pytest.raises(ValueError, match=error_text):
-        assert "signup_date" in es["customers"].df.columns
+        assert "signup_date" in es["customers"].to_dataframe().columns
         es.normalize_entity(base_entity_id='customers',
                             new_entity_id='cancellations',
                             index='cancel_reason',
@@ -42,21 +42,21 @@ def test_operations_invalidate_metadata(es):
     assert new_es._data_description is None
     assert new_es.metadata is not None  # generated after access
     assert new_es._data_description is not None
-    if not isinstance(es['customers'].df, pd.DataFrame):
+    if not isinstance(es['customers'].to_dataframe(), pd.DataFrame):
         customers_vtypes = es["customers"].variable_types
         customers_vtypes['signup_date'] = variable_types.Datetime
     else:
         customers_vtypes = None
     new_es.entity_from_dataframe("customers",
-                                 es["customers"].df,
+                                 es["customers"].to_dataframe(),
                                  index=es["customers"].index,
                                  variable_types=customers_vtypes)
-    if not isinstance(es['sessions'].df, pd.DataFrame):
+    if not isinstance(es['sessions'].to_dataframe(), pd.DataFrame):
         sessions_vtypes = es["sessions"].variable_types
     else:
         sessions_vtypes = None
     new_es.entity_from_dataframe("sessions",
-                                 es["sessions"].df,
+                                 es["sessions"].to_dataframe(),
                                  index=es["sessions"].index,
                                  variable_types=sessions_vtypes)
     assert new_es._data_description is None
@@ -81,7 +81,7 @@ def test_operations_invalidate_metadata(es):
     assert new_es._data_description is not None
 
     # automatically adding interesting values not supported in Dask or Koalas
-    if any(isinstance(entity.df, pd.DataFrame) for entity in new_es.entities):
+    if any(isinstance(entity.to_dataframe, pd.DataFrame) for entity in new_es.entities):
         new_es.add_interesting_values()
         assert new_es._data_description is None
         assert new_es.metadata is not None
@@ -149,7 +149,7 @@ def test_add_relationship_errors_on_dtype_mismatch(es):
 
 
 def test_add_relationship_errors_child_v_index(es):
-    log_df = es['log'].df.copy()
+    log_df = es['log'].to_dataframe().copy()
     log_vtypes = es['log'].variable_types
     es.entity_from_dataframe(entity_id='log2',
                              dataframe=log_df,

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -27,7 +27,7 @@ ks = import_or_none('databricks.koalas')
 def test_normalize_time_index_as_additional_variable(es):
     error_text = "Not moving signup_date as it is the base time index variable."
     with pytest.raises(ValueError, match=error_text):
-        assert "signup_date" in es["customers"].to_dataframe().columns
+        assert "signup_date" in es["customers"].df.columns
         es.normalize_entity(base_entity_id='customers',
                             new_entity_id='cancellations',
                             index='cancel_reason',
@@ -42,21 +42,21 @@ def test_operations_invalidate_metadata(es):
     assert new_es._data_description is None
     assert new_es.metadata is not None  # generated after access
     assert new_es._data_description is not None
-    if not isinstance(es['customers'].to_dataframe(), pd.DataFrame):
+    if not isinstance(es['customers'].df, pd.DataFrame):
         customers_vtypes = es["customers"].variable_types
         customers_vtypes['signup_date'] = variable_types.Datetime
     else:
         customers_vtypes = None
     new_es.entity_from_dataframe("customers",
-                                 es["customers"].to_dataframe(),
+                                 es["customers"].df,
                                  index=es["customers"].index,
                                  variable_types=customers_vtypes)
-    if not isinstance(es['sessions'].to_dataframe(), pd.DataFrame):
+    if not isinstance(es['sessions'].df, pd.DataFrame):
         sessions_vtypes = es["sessions"].variable_types
     else:
         sessions_vtypes = None
     new_es.entity_from_dataframe("sessions",
-                                 es["sessions"].to_dataframe(),
+                                 es["sessions"].df,
                                  index=es["sessions"].index,
                                  variable_types=sessions_vtypes)
     assert new_es._data_description is None
@@ -149,7 +149,7 @@ def test_add_relationship_errors_on_dtype_mismatch(es):
 
 
 def test_add_relationship_errors_child_v_index(es):
-    log_df = es['log'].to_dataframe().copy()
+    log_df = es['log'].df.copy()
     log_vtypes = es['log'].variable_types
     es.entity_from_dataframe(entity_id='log2',
                              dataframe=log_df,

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -971,27 +971,27 @@ def test_checks_time_type_setting_secondary_time_index(es):
     # add secondary index that is timestamp type
     new_2nd_ti = {'upgrade_date': ['upgrade_date', 'favorite_quote'],
                   'cancel_date': ['cancel_date', 'cancel_reason']}
-    es["customers"].set_secondary_time_index(new_2nd_ti)
+    es.set_secondary_time_index(es["customers"], new_2nd_ti)
     assert es.time_type == variable_types.DatetimeTimeIndex
     # add secondary index that is numeric type
     new_2nd_ti = {'age': ['age', 'loves_ice_cream']}
 
     error_text = "customers time index is <class 'featuretools.variable_types.variable.NumericTimeIndex'> type which differs from other entityset time indexes"
     with pytest.raises(TypeError, match=error_text):
-        es["customers"].set_secondary_time_index(new_2nd_ti)
+        es.set_secondary_time_index(es["customers"], new_2nd_ti)
     # add secondary index that is non-time type
     new_2nd_ti = {'favorite_quote': ['favorite_quote', 'loves_ice_cream']}
 
     error_text = r"data type (\"|')(All members of the working classes must seize the means of production.|test)(\"|') not understood"
     with pytest.raises(TypeError, match=error_text):
-        es["customers"].set_secondary_time_index(new_2nd_ti)
+        es.set_secondary_time_index(es["customers"], new_2nd_ti)
     # add mismatched pair of secondary time indexes
     new_2nd_ti = {'upgrade_date': ['upgrade_date', 'favorite_quote'],
                   'age': ['age', 'loves_ice_cream']}
 
     error_text = "customers time index is <class 'featuretools.variable_types.variable.NumericTimeIndex'> type which differs from other entityset time indexes"
     with pytest.raises(TypeError, match=error_text):
-        es["customers"].set_secondary_time_index(new_2nd_ti)
+        es.set_secondary_time_index(es["customers"], new_2nd_ti)
 
     # create entityset with numeric time type
     cards_df = pd.DataFrame({"id": [1, 2, 3, 4, 5]})
@@ -1013,30 +1013,30 @@ def test_checks_time_type_setting_secondary_time_index(es):
     assert card_es.time_type == variable_types.NumericTimeIndex
     # add secondary index that is numeric time type
     new_2nd_ti = {'fraud_decision_time': ['fraud_decision_time', 'fraud']}
-    card_es['transactions'].set_secondary_time_index(new_2nd_ti)
+    card_es.set_secondary_time_index(card_es['transactions'], new_2nd_ti)
     assert card_es.time_type == variable_types.NumericTimeIndex
     # add secondary index that is timestamp type
     new_2nd_ti = {'transaction_date': ['transaction_date', 'fraud']}
 
     error_text = "transactions time index is <class 'featuretools.variable_types.variable.DatetimeTimeIndex'> type which differs from other entityset time indexes"
     with pytest.raises(TypeError, match=error_text):
-        card_es['transactions'].set_secondary_time_index(new_2nd_ti)
+        card_es.set_secondary_time_index(card_es['transactions'], new_2nd_ti)
     # add secondary index that is non-time type
     new_2nd_ti = {'transaction_city': ['transaction_city', 'fraud']}
 
     error_text = r"data type ('|\")City A('|\") not understood"
     with pytest.raises(TypeError, match=error_text):
-        card_es['transactions'].set_secondary_time_index(new_2nd_ti)
+        card_es.set_secondary_time_index(card_es['transactions'], new_2nd_ti)
     # add mixed secondary time indexes
     new_2nd_ti = {'transaction_city': ['transaction_city', 'fraud'],
                   'fraud_decision_time': ['fraud_decision_time', 'fraud']}
     with pytest.raises(TypeError, match=error_text):
-        card_es['transactions'].set_secondary_time_index(new_2nd_ti)
+        card_es.set_secondary_time_index(card_es['transactions'], new_2nd_ti)
 
     # add bool secondary time index
     error_text = 'transactions time index not recognized as numeric or datetime'
     with pytest.raises(TypeError, match=error_text):
-        card_es['transactions'].set_secondary_time_index({'fraud': ['fraud']})
+        card_es.set_secondary_time_index(card_es['transactions'], {'fraud': ['fraud']})
 
 
 def test_normalize_entity(es):

--- a/featuretools/tests/entityset_tests/test_es_metadata.py
+++ b/featuretools/tests/entityset_tests/test_es_metadata.py
@@ -18,8 +18,8 @@ def test_cannot_re_add_relationships_that_already_exists(es):
 
 def test_add_relationships_convert_type(es):
     for r in es.relationships:
-        assert type(r.parent_variable) == variable_types.Index
-        assert type(r.child_variable) == variable_types.Id
+        assert type(r.parent_variable.metadata['variable']) == variable_types.Index
+        assert type(r.child_variable.metadata['variable']) == variable_types.Id
 
 
 def test_get_forward_entities(es):
@@ -61,27 +61,27 @@ def test_get_backward_entities_deep(es):
 def test_get_forward_relationships(es):
     relationships = es.get_forward_relationships('log')
     assert len(relationships) == 2
-    assert relationships[0].parent_entity.id == 'sessions'
-    assert relationships[0].child_entity.id == 'log'
-    assert relationships[1].parent_entity.id == 'products'
-    assert relationships[1].child_entity.id == 'log'
+    assert relationships[0].parent_entity.name == 'sessions'
+    assert relationships[0].child_entity.name == 'log'
+    assert relationships[1].parent_entity.name == 'products'
+    assert relationships[1].child_entity.name == 'log'
 
     relationships = es.get_forward_relationships('sessions')
     assert len(relationships) == 1
-    assert relationships[0].parent_entity.id == 'customers'
-    assert relationships[0].child_entity.id == 'sessions'
+    assert relationships[0].parent_entity.name == 'customers'
+    assert relationships[0].child_entity.name == 'sessions'
 
 
 def test_get_backward_relationships(es):
     relationships = es.get_backward_relationships('sessions')
     assert len(relationships) == 1
-    assert relationships[0].parent_entity.id == 'sessions'
-    assert relationships[0].child_entity.id == 'log'
+    assert relationships[0].parent_entity.name == 'sessions'
+    assert relationships[0].child_entity.name == 'log'
 
     relationships = es.get_backward_relationships('customers')
     assert len(relationships) == 1
-    assert relationships[0].parent_entity.id == 'customers'
-    assert relationships[0].child_entity.id == 'sessions'
+    assert relationships[0].parent_entity.name == 'customers'
+    assert relationships[0].child_entity.name == 'sessions'
 
 
 def test_find_forward_paths(es):
@@ -91,10 +91,10 @@ def test_find_forward_paths(es):
     path = paths[0]
 
     assert len(path) == 2
-    assert path[0].child_entity.id == 'log'
-    assert path[0].parent_entity.id == 'sessions'
-    assert path[1].child_entity.id == 'sessions'
-    assert path[1].parent_entity.id == 'customers'
+    assert path[0].child_entity.name == 'log'
+    assert path[0].parent_entity.name == 'sessions'
+    assert path[1].child_entity.name == 'sessions'
+    assert path[1].parent_entity.name == 'customers'
 
 
 def test_find_forward_paths_multiple_paths(diamond_es):
@@ -104,16 +104,16 @@ def test_find_forward_paths_multiple_paths(diamond_es):
     path1, path2 = paths
 
     r1, r2 = path1
-    assert r1.child_entity.id == 'transactions'
-    assert r1.parent_entity.id == 'stores'
-    assert r2.child_entity.id == 'stores'
-    assert r2.parent_entity.id == 'regions'
+    assert r1.child_entity.name == 'transactions'
+    assert r1.parent_entity.name == 'stores'
+    assert r2.child_entity.name == 'stores'
+    assert r2.parent_entity.name == 'regions'
 
     r1, r2 = path2
-    assert r1.child_entity.id == 'transactions'
-    assert r1.parent_entity.id == 'customers'
-    assert r2.child_entity.id == 'customers'
-    assert r2.parent_entity.id == 'regions'
+    assert r1.child_entity.name == 'transactions'
+    assert r1.parent_entity.name == 'customers'
+    assert r2.child_entity.name == 'customers'
+    assert r2.parent_entity.name == 'regions'
 
 
 def test_find_forward_paths_multiple_relationships(games_es):
@@ -126,15 +126,15 @@ def test_find_forward_paths_multiple_relationships(games_es):
     r1 = path1[0]
     r2 = path2[0]
 
-    assert r1.child_entity.id == 'games'
-    assert r2.child_entity.id == 'games'
-    assert r1.parent_entity.id == 'teams'
-    assert r2.parent_entity.id == 'teams'
+    assert r1.child_entity.name == 'games'
+    assert r2.child_entity.name == 'games'
+    assert r1.parent_entity.name == 'teams'
+    assert r2.parent_entity.name == 'teams'
 
-    assert r1.child_variable.id == 'home_team_id'
-    assert r2.child_variable.id == 'away_team_id'
-    assert r1.parent_variable.id == 'id'
-    assert r2.parent_variable.id == 'id'
+    assert r1.child_variable.name == 'home_team_id'
+    assert r2.child_variable.name == 'away_team_id'
+    assert r1.parent_variable.name == 'id'
+    assert r2.parent_variable.name == 'id'
 
 
 @pytest.fixture
@@ -178,10 +178,10 @@ def test_find_backward_paths(es):
     path = paths[0]
 
     assert len(path) == 2
-    assert path[0].child_entity.id == 'sessions'
-    assert path[0].parent_entity.id == 'customers'
-    assert path[1].child_entity.id == 'log'
-    assert path[1].parent_entity.id == 'sessions'
+    assert path[0].child_entity.name == 'sessions'
+    assert path[0].parent_entity.name == 'customers'
+    assert path[1].child_entity.name == 'log'
+    assert path[1].parent_entity.name == 'sessions'
 
 
 def test_find_backward_paths_multiple_paths(diamond_es):
@@ -191,16 +191,16 @@ def test_find_backward_paths_multiple_paths(diamond_es):
     path1, path2 = paths
 
     r1, r2 = path1
-    assert r1.child_entity.id == 'stores'
-    assert r1.parent_entity.id == 'regions'
-    assert r2.child_entity.id == 'transactions'
-    assert r2.parent_entity.id == 'stores'
+    assert r1.child_entity.name == 'stores'
+    assert r1.parent_entity.name == 'regions'
+    assert r2.child_entity.name == 'transactions'
+    assert r2.parent_entity.name == 'stores'
 
     r1, r2 = path2
-    assert r1.child_entity.id == 'customers'
-    assert r1.parent_entity.id == 'regions'
-    assert r2.child_entity.id == 'transactions'
-    assert r2.parent_entity.id == 'customers'
+    assert r1.child_entity.name == 'customers'
+    assert r1.parent_entity.name == 'regions'
+    assert r2.child_entity.name == 'transactions'
+    assert r2.parent_entity.name == 'customers'
 
 
 def test_find_backward_paths_multiple_relationships(games_es):
@@ -213,15 +213,15 @@ def test_find_backward_paths_multiple_relationships(games_es):
     r1 = path1[0]
     r2 = path2[0]
 
-    assert r1.child_entity.id == 'games'
-    assert r2.child_entity.id == 'games'
-    assert r1.parent_entity.id == 'teams'
-    assert r2.parent_entity.id == 'teams'
+    assert r1.child_entity.name == 'games'
+    assert r2.child_entity.name == 'games'
+    assert r1.parent_entity.name == 'teams'
+    assert r2.parent_entity.name == 'teams'
 
-    assert r1.child_variable.id == 'home_team_id'
-    assert r2.child_variable.id == 'away_team_id'
-    assert r1.parent_variable.id == 'id'
-    assert r2.parent_variable.id == 'id'
+    assert r1.child_variable.name == 'home_team_id'
+    assert r2.child_variable.name == 'away_team_id'
+    assert r1.parent_variable.name == 'id'
+    assert r2.parent_variable.name == 'id'
 
 
 def test_has_unique_path(diamond_es):
@@ -241,7 +241,7 @@ def test_raise_key_error_missing_entity(es):
 
 
 def test_add_parent_not_index_variable(es):
-    error_text = "Parent variable.*is not the index of entity Entity.*"
+    error_text = "Parent variable 'language' is not the index of entity régions"
     with pytest.raises(AttributeError, match=error_text):
         es.add_relationship(Relationship(es[u'régions']['language'],
                                          es['customers'][u'région_id']))

--- a/featuretools/tests/entityset_tests/test_koalas_es.py
+++ b/featuretools/tests/entityset_tests/test_koalas_es.py
@@ -20,8 +20,11 @@ def test_create_entity_from_ks_df(pd_es):
         dataframe=log_ks,
         index="id",
         time_index="datetime",
-        variable_types=pd_es["log"].variable_types
+        variable_types=pd_es["log"].metadata['variable_types']
     )
+    # Woodwork converts latlong values to a list instead of tuple which breaks assert_frame_equal comparison
+    cleaned_df["latlong"] = cleaned_df['latlong'].apply(lambda x: "[{}, {}]".format(x[0], x[1]))
+    cleaned_df["latlong2"] = cleaned_df['latlong2'].apply(lambda x: "[{}, {}]".format(x[0], x[1]))
     pd.testing.assert_frame_equal(cleaned_df, ks_es["log_ks"].df.to_pandas(), check_like=True)
 
 
@@ -92,7 +95,7 @@ def test_add_last_time_indexes():
     sessions_vtypes = {
         "id": ft.variable_types.Id,
         "user": ft.variable_types.Id,
-        "time": ft.variable_types.DatetimeTimeIndex,
+        "time": ft.variable_types.Datetime,
         "strings": ft.variable_types.NaturalLanguage
     }
 
@@ -110,7 +113,7 @@ def test_add_last_time_indexes():
         "id": ft.variable_types.Id,
         "session_id": ft.variable_types.Id,
         "amount": ft.variable_types.Numeric,
-        "time": ft.variable_types.DatetimeTimeIndex,
+        "time": ft.variable_types.Datetime,
     }
 
     pd_es.entity_from_dataframe(entity_id="sessions", dataframe=sessions, index="id", time_index="time")
@@ -125,13 +128,14 @@ def test_add_last_time_indexes():
     pd_es = pd_es.add_relationship(new_rel)
     ks_es = ks_es.add_relationship(ks_rel)
 
-    assert pd_es['sessions'].last_time_index is None
-    assert ks_es['sessions'].last_time_index is None
+    assert pd_es['sessions'].metadata.get('last_time_index') is None
+    assert ks_es['sessions'].metadata.get('last_time_index') is None
 
     pd_es.add_last_time_indexes()
     ks_es.add_last_time_indexes()
 
-    pd.testing.assert_series_equal(pd_es['sessions'].last_time_index.sort_index(), ks_es['sessions'].last_time_index.to_pandas().sort_index(), check_names=False)
+    pd.testing.assert_series_equal(pd_es['sessions'].get('last_time_index').sort_index(),
+                                   ks_es['sessions'].get('last_time_index').to_pandas().sort_index(), check_names=False)
 
 
 @pytest.mark.skipif('not ks')
@@ -144,375 +148,4 @@ def test_create_entity_with_make_index():
     ks_es.entity_from_dataframe(entity_id="new_entity", dataframe=ks_df, make_index=True, index="new_index", variable_types=vtypes)
 
     expected_df = pd.DataFrame({"new_index": range(len(values)), "values": values})
-    pd.testing.assert_frame_equal(expected_df, ks_es['new_entity'].df.to_pandas().sort_index())
-
-
-@pytest.mark.skipif('not ks')
-def test_single_table_ks_entityset():
-    primitives_list = ['absolute', 'is_weekend', 'year', 'day', 'num_characters', 'num_words']
-
-    ks_es = EntitySet(id="ks_es")
-    df = pd.DataFrame({"id": [0, 1, 2, 3],
-                       "values": [1, 12, -34, 27],
-                       "dates": [pd.to_datetime('2019-01-10'),
-                                 pd.to_datetime('2019-02-03'),
-                                 pd.to_datetime('2019-01-01'),
-                                 pd.to_datetime('2017-08-25')],
-                       "strings": ["I am a string",
-                                   "23",
-                                   "abcdef ghijk",
-                                   ""]})
-    values_dd = ks.from_pandas(df)
-    vtypes = {
-        "id": ft.variable_types.Id,
-        "values": ft.variable_types.Numeric,
-        "dates": ft.variable_types.Datetime,
-        "strings": ft.variable_types.NaturalLanguage
-    }
-    ks_es.entity_from_dataframe(entity_id="data",
-                                dataframe=values_dd,
-                                index="id",
-                                variable_types=vtypes)
-
-    ks_fm, _ = ft.dfs(entityset=ks_es,
-                      target_entity="data",
-                      trans_primitives=primitives_list)
-
-    pd_es = ft.EntitySet(id="pd_es")
-    pd_es.entity_from_dataframe(entity_id="data",
-                                dataframe=df,
-                                index="id",
-                                variable_types={"strings": ft.variable_types.NaturalLanguage})
-
-    fm, _ = ft.dfs(entityset=pd_es,
-                   target_entity="data",
-                   trans_primitives=primitives_list)
-
-    ks_computed_fm = ks_fm.to_pandas().set_index('id').loc[fm.index][fm.columns]
-    # NUM_WORDS(strings) is int32 in koalas for some reason
-    pd.testing.assert_frame_equal(fm, ks_computed_fm, check_dtype=False)
-
-
-@pytest.mark.skipif('not ks')
-def test_single_table_ks_entityset_ids_not_sorted():
-    primitives_list = ['absolute', 'is_weekend', 'year', 'day', 'num_characters', 'num_words']
-
-    ks_es = EntitySet(id="ks_es")
-    df = pd.DataFrame({"id": [2, 0, 1, 3],
-                       "values": [1, 12, -34, 27],
-                       "dates": [pd.to_datetime('2019-01-10'),
-                                 pd.to_datetime('2019-02-03'),
-                                 pd.to_datetime('2019-01-01'),
-                                 pd.to_datetime('2017-08-25')],
-                       "strings": ["I am a string",
-                                   "23",
-                                   "abcdef ghijk",
-                                   ""]})
-    values_dd = ks.from_pandas(df)
-    vtypes = {
-        "id": ft.variable_types.Id,
-        "values": ft.variable_types.Numeric,
-        "dates": ft.variable_types.Datetime,
-        "strings": ft.variable_types.NaturalLanguage
-    }
-    ks_es.entity_from_dataframe(entity_id="data",
-                                dataframe=values_dd,
-                                index="id",
-                                variable_types=vtypes)
-
-    ks_fm, _ = ft.dfs(entityset=ks_es,
-                      target_entity="data",
-                      trans_primitives=primitives_list)
-
-    pd_es = ft.EntitySet(id="pd_es")
-    pd_es.entity_from_dataframe(entity_id="data",
-                                dataframe=df,
-                                index="id",
-                                variable_types={"strings": ft.variable_types.NaturalLanguage})
-
-    fm, _ = ft.dfs(entityset=pd_es,
-                   target_entity="data",
-                   trans_primitives=primitives_list)
-
-    # Make sure both indexes are sorted the same
-    pd.testing.assert_frame_equal(fm, ks_fm.to_pandas().set_index('id').loc[fm.index], check_dtype=False)
-
-
-@pytest.mark.skipif('not ks')
-def test_single_table_ks_entityset_with_instance_ids():
-    primitives_list = ['absolute', 'is_weekend', 'year', 'day', 'num_characters', 'num_words']
-    instance_ids = [0, 1, 3]
-
-    ks_es = EntitySet(id="ks_es")
-    df = pd.DataFrame({"id": [0, 1, 2, 3],
-                       "values": [1, 12, -34, 27],
-                       "dates": [pd.to_datetime('2019-01-10'),
-                                 pd.to_datetime('2019-02-03'),
-                                 pd.to_datetime('2019-01-01'),
-                                 pd.to_datetime('2017-08-25')],
-                       "strings": ["I am a string",
-                                   "23",
-                                   "abcdef ghijk",
-                                   ""]})
-
-    values_dd = ks.from_pandas(df)
-    vtypes = {
-        "id": ft.variable_types.Id,
-        "values": ft.variable_types.Numeric,
-        "dates": ft.variable_types.Datetime,
-        "strings": ft.variable_types.NaturalLanguage
-    }
-    ks_es.entity_from_dataframe(entity_id="data",
-                                dataframe=values_dd,
-                                index="id",
-                                variable_types=vtypes)
-
-    ks_fm, _ = ft.dfs(entityset=ks_es,
-                      target_entity="data",
-                      trans_primitives=primitives_list,
-                      instance_ids=instance_ids)
-
-    pd_es = ft.EntitySet(id="pd_es")
-    pd_es.entity_from_dataframe(entity_id="data",
-                                dataframe=df,
-                                index="id",
-                                variable_types={"strings": ft.variable_types.NaturalLanguage})
-
-    fm, _ = ft.dfs(entityset=pd_es,
-                   target_entity="data",
-                   trans_primitives=primitives_list,
-                   instance_ids=instance_ids)
-
-    # Make sure both indexes are sorted the same
-    pd.testing.assert_frame_equal(fm, ks_fm.to_pandas().set_index('id').loc[fm.index], check_dtype=False)
-
-
-@pytest.mark.skipif('not ks')
-def test_single_table_ks_entityset_single_cutoff_time():
-    primitives_list = ['absolute', 'is_weekend', 'year', 'day', 'num_characters', 'num_words']
-
-    ks_es = EntitySet(id="ks_es")
-    df = pd.DataFrame({"id": [0, 1, 2, 3],
-                       "values": [1, 12, -34, 27],
-                       "dates": [pd.to_datetime('2019-01-10'),
-                                 pd.to_datetime('2019-02-03'),
-                                 pd.to_datetime('2019-01-01'),
-                                 pd.to_datetime('2017-08-25')],
-                       "strings": ["I am a string",
-                                   "23",
-                                   "abcdef ghijk",
-                                   ""]})
-    values_dd = ks.from_pandas(df)
-    vtypes = {
-        "id": ft.variable_types.Id,
-        "values": ft.variable_types.Numeric,
-        "dates": ft.variable_types.Datetime,
-        "strings": ft.variable_types.NaturalLanguage
-    }
-    ks_es.entity_from_dataframe(entity_id="data",
-                                dataframe=values_dd,
-                                index="id",
-                                variable_types=vtypes)
-
-    ks_fm, _ = ft.dfs(entityset=ks_es,
-                      target_entity="data",
-                      trans_primitives=primitives_list,
-                      cutoff_time=pd.Timestamp("2019-01-05 04:00"))
-
-    pd_es = ft.EntitySet(id="pd_es")
-    pd_es.entity_from_dataframe(entity_id="data",
-                                dataframe=df,
-                                index="id",
-                                variable_types={"strings": ft.variable_types.NaturalLanguage})
-
-    fm, _ = ft.dfs(entityset=pd_es,
-                   target_entity="data",
-                   trans_primitives=primitives_list,
-                   cutoff_time=pd.Timestamp("2019-01-05 04:00"))
-
-    # Make sure both indexes are sorted the same
-    pd.testing.assert_frame_equal(fm, ks_fm.to_pandas().set_index('id').loc[fm.index], check_dtype=False)
-
-
-@pytest.mark.skipif('not ks')
-def test_single_table_ks_entityset_cutoff_time_df():
-    primitives_list = ['absolute', 'is_weekend', 'year', 'day', 'num_characters', 'num_words']
-
-    ks_es = EntitySet(id="ks_es")
-    df = pd.DataFrame({"id": [0, 1, 2],
-                       "values": [1, 12, -34],
-                       "dates": [pd.to_datetime('2019-01-10'),
-                                 pd.to_datetime('2019-02-03'),
-                                 pd.to_datetime('2019-01-01')],
-                       "strings": ["I am a string",
-                                   "23",
-                                   "abcdef ghijk"]})
-    values_dd = ks.from_pandas(df)
-    vtypes = {
-        "id": ft.variable_types.Id,
-        "values": ft.variable_types.Numeric,
-        "dates": ft.variable_types.Datetime,
-        "strings": ft.variable_types.NaturalLanguage
-    }
-    ks_es.entity_from_dataframe(entity_id="data",
-                                dataframe=values_dd,
-                                index="id",
-                                time_index="dates",
-                                variable_types=vtypes)
-    ids = [0, 1, 2, 0]
-    times = [pd.Timestamp("2019-01-05 04:00"),
-             pd.Timestamp("2019-01-05 04:00"),
-             pd.Timestamp("2019-01-05 04:00"),
-             pd.Timestamp("2019-01-15 04:00")]
-    labels = [True, False, True, False]
-    cutoff_times = pd.DataFrame({"id": ids, "time": times, "labels": labels}, columns=["id", "time", "labels"])
-
-    ks_fm, _ = ft.dfs(entityset=ks_es,
-                      target_entity="data",
-                      trans_primitives=primitives_list,
-                      cutoff_time=cutoff_times)
-
-    pd_es = ft.EntitySet(id="pd_es")
-    pd_es.entity_from_dataframe(entity_id="data",
-                                dataframe=df,
-                                index="id",
-                                time_index="dates",
-                                variable_types={"strings": ft.variable_types.NaturalLanguage})
-
-    fm, _ = ft.dfs(entityset=pd_es,
-                   target_entity="data",
-                   trans_primitives=primitives_list,
-                   cutoff_time=cutoff_times)
-    # Because row ordering with koalas is not guaranteed, `we need to sort on two columns to make sure that values
-    # for instance id 0 are compared correctly. Also, make sure the boolean column has the same dtype.
-    fm = fm.sort_values(['id', 'labels'])
-    ks_fm = ks_fm.to_pandas().set_index('id').sort_values(['id', 'labels'])
-    ks_fm['IS_WEEKEND(dates)'] = ks_fm['IS_WEEKEND(dates)'].astype(fm['IS_WEEKEND(dates)'].dtype)
-    pd.testing.assert_frame_equal(fm, ks_fm)
-
-
-@pytest.mark.skipif('not ks')
-def test_single_table_ks_entityset_dates_not_sorted():
-    ks_es = EntitySet(id="ks_es")
-    df = pd.DataFrame({"id": [0, 1, 2, 3],
-                       "values": [1, 12, -34, 27],
-                       "dates": [pd.to_datetime('2019-01-10'),
-                                 pd.to_datetime('2019-02-03'),
-                                 pd.to_datetime('2019-01-01'),
-                                 pd.to_datetime('2017-08-25')]})
-
-    primitives_list = ['absolute', 'is_weekend', 'year', 'day']
-    values_dd = ks.from_pandas(df)
-    vtypes = {
-        "id": ft.variable_types.Id,
-        "values": ft.variable_types.Numeric,
-        "dates": ft.variable_types.Datetime,
-    }
-    ks_es.entity_from_dataframe(entity_id="data",
-                                dataframe=values_dd,
-                                index="id",
-                                time_index="dates",
-                                variable_types=vtypes)
-
-    ks_fm, _ = ft.dfs(entityset=ks_es,
-                      target_entity="data",
-                      trans_primitives=primitives_list,
-                      max_depth=1)
-
-    pd_es = ft.EntitySet(id="pd_es")
-    pd_es.entity_from_dataframe(entity_id="data",
-                                dataframe=df,
-                                index="id",
-                                time_index="dates")
-
-    fm, _ = ft.dfs(entityset=pd_es,
-                   target_entity="data",
-                   trans_primitives=primitives_list,
-                   max_depth=1)
-
-    pd.testing.assert_frame_equal(fm, ks_fm.to_pandas().set_index('id').loc[fm.index])
-
-
-@pytest.mark.skipif('not ks')
-def test_secondary_time_index():
-    log_df = pd.DataFrame()
-    log_df['id'] = [0, 1, 2, 3]
-    log_df['scheduled_time'] = pd.to_datetime([
-        "2019-01-01",
-        "2019-01-01",
-        "2019-01-01",
-        "2019-01-01"
-    ])
-    log_df['departure_time'] = pd.to_datetime([
-        "2019-02-01 09:00",
-        "2019-02-06 10:00",
-        "2019-02-12 10:00",
-        "2019-03-01 11:30"])
-    log_df['arrival_time'] = pd.to_datetime([
-        "2019-02-01 11:23",
-        "2019-02-06 12:45",
-        "2019-02-12 13:53",
-        "2019-03-01 14:07"
-    ])
-    log_df['delay'] = [-2, 10, 60, 0]
-    log_df['flight_id'] = [0, 1, 0, 1]
-    log_ks = ks.from_pandas(log_df)
-
-    flights_df = pd.DataFrame()
-    flights_df['id'] = [0, 1, 2, 3]
-    flights_df['origin'] = ["BOS", "LAX", "BOS", "LAX"]
-    flights_ks = ks.from_pandas(flights_df)
-
-    pd_es = ft.EntitySet("flights")
-    ks_es = ft.EntitySet("flights_ks")
-
-    pd_es.entity_from_dataframe(entity_id='logs',
-                                dataframe=log_df,
-                                index="id",
-                                time_index="scheduled_time",
-                                secondary_time_index={
-                                    'arrival_time': ['departure_time', 'delay']})
-
-    log_vtypes = {
-        "id": ft.variable_types.Id,
-        "scheduled_time": ft.variable_types.DatetimeTimeIndex,
-        "departure_time": ft.variable_types.DatetimeTimeIndex,
-        "arrival_time": ft.variable_types.DatetimeTimeIndex,
-        "delay": ft.variable_types.Numeric,
-        "flight_id": ft.variable_types.Id
-    }
-    ks_es.entity_from_dataframe(entity_id='logs',
-                                dataframe=log_ks,
-                                index="id",
-                                variable_types=log_vtypes,
-                                time_index="scheduled_time",
-                                secondary_time_index={
-                                      'arrival_time': ['departure_time', 'delay']})
-
-    pd_es.entity_from_dataframe('flights', flights_df, index="id")
-    flights_vtypes = pd_es['flights'].variable_types
-    ks_es.entity_from_dataframe('flights', flights_ks, index="id", variable_types=flights_vtypes)
-
-    new_rel = ft.Relationship(pd_es['flights']['id'], pd_es['logs']['flight_id'])
-    ks_rel = ft.Relationship(ks_es['flights']['id'], ks_es['logs']['flight_id'])
-    pd_es.add_relationship(new_rel)
-    ks_es.add_relationship(ks_rel)
-
-    cutoff_df = pd.DataFrame()
-    cutoff_df['id'] = [0, 1, 1]
-    cutoff_df['time'] = pd.to_datetime(['2019-02-02', '2019-02-02', '2019-02-20'])
-
-    fm, _ = ft.dfs(entityset=pd_es,
-                   target_entity="logs",
-                   cutoff_time=cutoff_df,
-                   agg_primitives=["max"],
-                   trans_primitives=["month"])
-
-    ks_fm, _ = ft.dfs(entityset=ks_es,
-                      target_entity="logs",
-                      cutoff_time=cutoff_df,
-                      agg_primitives=["max"],
-                      trans_primitives=["month"])
-
-    # Make sure both matrixes are sorted the same
-    pd.testing.assert_frame_equal(fm.sort_values('delay'), ks_fm.to_pandas().set_index('id').sort_values('delay'), check_dtype=False)
+    pd.testing.assert_frame_equal(expected_df[['values', 'new_index']], ks_es['new_entity'].df.to_pandas().sort_index())

--- a/featuretools/tests/entityset_tests/test_last_time_index.py
+++ b/featuretools/tests/entityset_tests/test_last_time_index.py
@@ -84,9 +84,9 @@ class TestLastTimeIndex(object):
     def test_leaf(self, es):
         es.add_last_time_indexes()
         log = es['log']
-        assert len(log.last_time_index) == 17
+        assert len(log.metadata['last_time_index']) == 17
         log_df = to_pandas(log.df)
-        log_lti = to_pandas(log.last_time_index)
+        log_lti = to_pandas(log.metadata['last_time_index'])
         for v1, v2 in zip(log_lti, log_df['datetime']):
             assert (pd.isnull(v1) and pd.isnull(v2)) or v1 == v2
 
@@ -94,8 +94,8 @@ class TestLastTimeIndex(object):
         es.add_last_time_indexes()
         stores = es['stores']
         true_lti = pd.Series([None for x in range(6)], dtype='datetime64[ns]')
-        assert len(true_lti) == len(stores.last_time_index)
-        stores_lti = to_pandas(stores.last_time_index)
+        assert len(true_lti) == len(stores.metadata['last_time_index'])
+        stores_lti = to_pandas(stores.metadata['last_time_index'])
         for v1, v2 in zip(stores_lti, true_lti):
             assert (pd.isnull(v1) and pd.isnull(v2)) or v1 == v2
 
@@ -106,8 +106,8 @@ class TestLastTimeIndex(object):
             pytest.xfail('possible issue with either normalize_entity or add_last_time_indexes')
         values_es.add_last_time_indexes()
         values = values_es['values']
-        assert len(values.last_time_index) == 11
-        sorted_lti = to_pandas(values.last_time_index).sort_index()
+        assert len(values.metadata['last_time_index']) == 11
+        sorted_lti = to_pandas(values.metadata['last_time_index']).sort_index()
         for v1, v2 in zip(sorted_lti, true_values_lti):
             assert (pd.isnull(v1) and pd.isnull(v2)) or v1 == v2
 
@@ -127,14 +127,14 @@ class TestLastTimeIndex(object):
         df = values.df.append(row, sort=True)
         df = df[['value', 'value_time']].sort_values(by='value')
         df.index.name = 'values_id'
-        values.update_data(df)
+        values.update_dataframe(df)
         values_es.add_last_time_indexes()
         # lti value should default to instance's time index
         true_values_lti[10] = pd.Timestamp("2011-04-10 11:10:02")
         true_values_lti[11] = pd.Timestamp("2011-04-10 11:10:03")
 
-        assert len(values.last_time_index) == 12
-        sorted_lti = values.last_time_index.sort_index()
+        assert len(values.metadata['last_time_index']) == 12
+        sorted_lti = values.metadata['last_time_index'].sort_index()
         for v1, v2 in zip(sorted_lti, true_values_lti):
             assert (pd.isnull(v1) and pd.isnull(v2)) or v1 == v2
 
@@ -142,8 +142,8 @@ class TestLastTimeIndex(object):
         # test entity without time index and all instances have children
         es.add_last_time_indexes()
         sessions = es['sessions']
-        assert len(sessions.last_time_index) == 6
-        sorted_lti = to_pandas(sessions.last_time_index).sort_index()
+        assert len(sessions.metadata['last_time_index']) == 6
+        sorted_lti = to_pandas(sessions.metadata['last_time_index']).sort_index()
         for v1, v2 in zip(sorted_lti, true_sessions_lti):
             assert (pd.isnull(v1) and pd.isnull(v2)) or v1 == v2
 
@@ -153,13 +153,13 @@ class TestLastTimeIndex(object):
         sessions = es['sessions']
 
         # add session instance with no associated log instances
-        sessions.update_data(extra_session_df)
+        sessions.update_dataframe(extra_session_df)
         es.add_last_time_indexes()
         # since sessions has no time index, default value is NaT
         true_sessions_lti[6] = pd.NaT
 
-        assert len(sessions.last_time_index) == 7
-        sorted_lti = to_pandas(sessions.last_time_index).sort_index()
+        assert len(sessions.metadata['last_time_index']) == 7
+        sorted_lti = to_pandas(sessions.metadata['last_time_index']).sort_index()
         for v1, v2 in zip(sorted_lti, true_sessions_lti):
             assert (pd.isnull(v1) and pd.isnull(v2)) or v1 == v2
 
@@ -189,8 +189,8 @@ class TestLastTimeIndex(object):
         true_sessions_lti[1] = pd.Timestamp("2011-4-9 10:31:30")
         true_sessions_lti[3] = pd.Timestamp("2011-4-10 10:41:00")
 
-        assert len(sessions.last_time_index) == 6
-        sorted_lti = to_pandas(sessions.last_time_index).sort_index()
+        assert len(sessions.metadata['last_time_index']) == 6
+        sorted_lti = to_pandas(sessions.metadata['last_time_index']).sort_index()
         for v1, v2 in zip(sorted_lti, true_sessions_lti):
             assert (pd.isnull(v1) and pd.isnull(v2)) or v1 == v2
 
@@ -223,8 +223,8 @@ class TestLastTimeIndex(object):
         # now only session id 1 has newer event in wishlist_log
         true_sessions_lti[1] = pd.Timestamp("2011-4-9 10:31:30")
 
-        assert len(sessions.last_time_index) == 6
-        sorted_lti = to_pandas(sessions.last_time_index).sort_index()
+        assert len(sessions.metadata['last_time_index']) == 6
+        sorted_lti = to_pandas(sessions.metadata['last_time_index']).sort_index()
         for v1, v2 in zip(sorted_lti, true_sessions_lti):
             assert (pd.isnull(v1) and pd.isnull(v2)) or v1 == v2
 
@@ -234,7 +234,7 @@ class TestLastTimeIndex(object):
         sessions = es['sessions']
 
         # add row to sessions so not all session instances are in log
-        sessions.update_data(extra_session_df)
+        sessions.update_dataframe(extra_session_df)
 
         # add row to wishlist df so new session instance in in wishlist_log
         row_values = {'session_id': 6,
@@ -266,8 +266,8 @@ class TestLastTimeIndex(object):
         true_sessions_lti[3] = pd.Timestamp("2011-4-10 10:41:00")
         true_sessions_lti[6] = pd.Timestamp("2011-04-11 11:11:11")
 
-        assert len(sessions.last_time_index) == 7
-        sorted_lti = to_pandas(sessions.last_time_index).sort_index()
+        assert len(sessions.metadata['last_time_index']) == 7
+        sorted_lti = to_pandas(sessions.metadata['last_time_index']).sort_index()
         for v1, v2 in zip(sorted_lti, true_sessions_lti):
             assert (pd.isnull(v1) and pd.isnull(v2)) or v1 == v2
 
@@ -277,7 +277,7 @@ class TestLastTimeIndex(object):
         sessions = es['sessions']
 
         # add row to sessions so not all session instances are in log
-        sessions.update_data(extra_session_df)
+        sessions.update_dataframe(extra_session_df)
 
         # add row to wishlist_log so extra session has child instance
         row_values = {'session_id': 6,
@@ -311,8 +311,8 @@ class TestLastTimeIndex(object):
         true_sessions_lti[1] = pd.Timestamp("2011-4-9 10:31:30")
         true_sessions_lti[6] = pd.Timestamp("2011-04-11 11:11:11")
 
-        assert len(sessions.last_time_index) == 7
-        sorted_lti = to_pandas(sessions.last_time_index).sort_index()
+        assert len(sessions.metadata['last_time_index']) == 7
+        sorted_lti = to_pandas(sessions.metadata['last_time_index']).sort_index()
         for v1, v2 in zip(sorted_lti, true_sessions_lti):
             assert (pd.isnull(v1) and pd.isnull(v2)) or v1 == v2
 
@@ -331,7 +331,7 @@ class TestLastTimeIndex(object):
                           'datetime': ft.variable_types.variable.DatetimeTimeIndex,
                           'product_id': ft.variable_types.variable.Categorical}
         # add row to sessions to create session with no events
-        sessions.update_data(extra_session_df)
+        sessions.update_dataframe(extra_session_df)
 
         es.entity_from_dataframe(entity_id="wishlist_log",
                                  dataframe=wishlist_df,
@@ -350,8 +350,8 @@ class TestLastTimeIndex(object):
         true_sessions_lti[3] = pd.Timestamp("2011-4-10 10:41:00")
         true_sessions_lti[6] = pd.NaT
 
-        assert len(sessions.last_time_index) == 7
-        sorted_lti = to_pandas(sessions.last_time_index).sort_index()
+        assert len(sessions.metadata['last_time_index']) == 7
+        sorted_lti = to_pandas(sessions.metadata['last_time_index']).sort_index()
         for v1, v2 in zip(sorted_lti, true_sessions_lti):
             assert (pd.isnull(v1) and pd.isnull(v2)) or v1 == v2
 
@@ -372,14 +372,14 @@ class TestLastTimeIndex(object):
             df = dd.from_pandas(df, npartitions=2)
         if ks and isinstance(log.df, ks.DataFrame):
             df = ks.from_pandas(df)
-        log.update_data(df)
+        log.update_dataframe(df)
         es.add_last_time_indexes()
 
         true_customers_lti = pd.Series([datetime(2011, 4, 9, 10, 40, 1),
                                         datetime(2011, 4, 10, 10, 41, 6),
                                         datetime(2011, 4, 10, 11, 10, 3)])
 
-        assert len(customers.last_time_index) == 3
-        sorted_lti = to_pandas(customers.last_time_index).sort_index()
+        assert len(customers.metadata['last_time_index']) == 3
+        sorted_lti = to_pandas(customers.metadata['last_time_index']).sort_index()
         for v1, v2 in zip(sorted_lti, true_customers_lti):
             assert (pd.isnull(v1) and pd.isnull(v2)) or v1 == v2

--- a/featuretools/tests/entityset_tests/test_last_time_index.py
+++ b/featuretools/tests/entityset_tests/test_last_time_index.py
@@ -8,6 +8,7 @@ import featuretools as ft
 from featuretools import Relationship
 from featuretools.tests.testing_utils import to_pandas
 from featuretools.utils.gen_utils import import_or_none
+from featuretools.utils.koalas_utils import pd_to_ks_clean
 
 ks = import_or_none('databricks.koalas')
 
@@ -76,6 +77,7 @@ def extra_session_df(es):
     if isinstance(es['sessions'].df, dd.DataFrame):
         df = dd.from_pandas(df, npartitions=3)
     if ks and isinstance(es['sessions'].df, ks.DataFrame):
+        df['customer_id'] = df['customer_id'].astype('int')
         df = ks.from_pandas(df)
     return df
 

--- a/featuretools/tests/entityset_tests/test_serialization.py
+++ b/featuretools/tests/entityset_tests/test_serialization.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import tempfile
 from urllib.request import urlretrieve
@@ -7,7 +8,10 @@ import boto3
 import pandas as pd
 import pytest
 
+import featuretools as ft
+from featuretools import variable_types
 from featuretools.entityset import EntitySet, deserialize, serialize
+from featuretools.entityset.serialize import SCHEMA_VERSION
 from featuretools.tests.testing_utils import to_pandas
 from featuretools.utils.gen_utils import import_or_none
 from featuretools.variable_types import (
@@ -27,6 +31,65 @@ TEST_FILE = "test_serialization_data_entityset_schema_5.1.0.tar"
 S3_URL = "s3://featuretools-static/" + TEST_FILE
 URL = "https://featuretools-static.s3.amazonaws.com/" + TEST_FILE
 TEST_KEY = "test_access_key_es"
+
+
+def test_operations_invalidate_metadata(es):
+    new_es = ft.EntitySet(id="test")
+    # test metadata gets created on access
+    assert new_es._data_description is None
+    assert new_es.metadata is not None  # generated after access
+    assert new_es._data_description is not None
+    if not isinstance(es['customers'].df, pd.DataFrame):
+        customers_vtypes = es["customers"].variable_types
+        customers_vtypes['signup_date'] = variable_types.Datetime
+    else:
+        customers_vtypes = None
+    new_es.entity_from_dataframe("customers",
+                                 es["customers"].df,
+                                 index=es["customers"].index,
+                                 variable_types=customers_vtypes)
+    if not isinstance(es['sessions'].df, pd.DataFrame):
+        sessions_vtypes = es["sessions"].variable_types
+    else:
+        sessions_vtypes = None
+    new_es.entity_from_dataframe("sessions",
+                                 es["sessions"].df,
+                                 index=es["sessions"].index,
+                                 variable_types=sessions_vtypes)
+    assert new_es._data_description is None
+    assert new_es.metadata is not None
+    assert new_es._data_description is not None
+
+    r = ft.Relationship(new_es["customers"]["id"],
+                        new_es["sessions"]["customer_id"])
+    new_es = new_es.add_relationship(r)
+    assert new_es._data_description is None
+    assert new_es.metadata is not None
+    assert new_es._data_description is not None
+
+    new_es = new_es.normalize_entity("customers", "cohort", "cohort")
+    assert new_es._data_description is None
+    assert new_es.metadata is not None
+    assert new_es._data_description is not None
+
+    new_es.add_last_time_indexes()
+    assert new_es._data_description is None
+    assert new_es.metadata is not None
+    assert new_es._data_description is not None
+
+    # automatically adding interesting values not supported in Dask or Koalas
+    if any(isinstance(entity.to_dataframe, pd.DataFrame) for entity in new_es.entities):
+        new_es.add_interesting_values()
+        assert new_es._data_description is None
+        assert new_es.metadata is not None
+        assert new_es._data_description is not None
+
+
+def test_reset_metadata(es):
+    assert es.metadata is not None
+    assert es._data_description is not None
+    es.reset_data_description()
+    assert es._data_description is None
 
 
 def test_all_variable_descriptions():
@@ -395,3 +458,68 @@ def test_default_s3_csv(es):
 def test_anon_s3_csv(es):
     new_es = deserialize.read_entityset(S3_URL, profile_name=False)
     assert es.__eq__(new_es, deep=True)
+
+
+def test_later_schema_version(es, caplog):
+    def test_version(major, minor, patch, raises=True):
+        version = '.'.join([str(v) for v in [major, minor, patch]])
+        if raises:
+            warning_text = ('The schema version of the saved entityset'
+                            '(%s) is greater than the latest supported (%s). '
+                            'You may need to upgrade featuretools. Attempting to load entityset ...'
+                            % (version, SCHEMA_VERSION))
+        else:
+            warning_text = None
+
+        _check_schema_version(version, es, warning_text, caplog, 'warn')
+
+    major, minor, patch = [int(s) for s in SCHEMA_VERSION.split('.')]
+
+    test_version(major + 1, minor, patch)
+    test_version(major, minor + 1, patch)
+    test_version(major, minor, patch + 1)
+    test_version(major, minor - 1, patch + 1, raises=False)
+
+
+def test_earlier_schema_version(es, caplog):
+    def test_version(major, minor, patch, raises=True):
+        version = '.'.join([str(v) for v in [major, minor, patch]])
+        if raises:
+            warning_text = ('The schema version of the saved entityset'
+                            '(%s) is no longer supported by this version '
+                            'of featuretools. Attempting to load entityset ...'
+                            % (version))
+        else:
+            warning_text = None
+
+        _check_schema_version(version, es, warning_text, caplog, 'log')
+
+    major, minor, patch = [int(s) for s in SCHEMA_VERSION.split('.')]
+
+    test_version(major - 1, minor, patch)
+    test_version(major, minor - 1, patch, raises=False)
+    test_version(major, minor, patch - 1, raises=False)
+
+
+def _check_schema_version(version, es, warning_text, caplog, warning_type=None):
+    entities = {entity.name: serialize.entity_to_description(entity) for entity in es.entities}
+    relationships = [relationship.to_dictionary() for relationship in es.relationships]
+    dictionary = {
+        'schema_version': version,
+        'id': es.id,
+        'entities': entities,
+        'relationships': relationships,
+    }
+
+    if warning_type == 'log' and warning_text:
+        logger = logging.getLogger('featuretools')
+        logger.propagate = True
+        deserialize.description_to_entityset(dictionary)
+        assert warning_text in caplog.text
+        logger.propagate = False
+    elif warning_type == 'warn' and warning_text:
+        with pytest.warns(UserWarning) as record:
+            deserialize.description_to_entityset(dictionary)
+        assert record[0].message.args[0] == warning_text
+    else:
+        deserialize.description_to_entityset(dictionary)

--- a/featuretools/tests/primitive_tests/test_dask_primitives.py
+++ b/featuretools/tests/primitive_tests/test_dask_primitives.py
@@ -23,14 +23,14 @@ def test_transform(pd_es, dask_es):
     # Run DFS using each entity as a target and confirm results match
     for entity in pd_es.entities:
         features = ft.dfs(entityset=pd_es,
-                          target_entity=entity.id,
+                          target_entity=entity.name,
                           trans_primitives=trans_primitives,
                           agg_primitives=agg_primitives,
                           max_depth=2,
                           features_only=True)
 
         dask_features = ft.dfs(entityset=dask_es,
-                               target_entity=entity.id,
+                               target_entity=entity.name,
                                trans_primitives=trans_primitives,
                                agg_primitives=agg_primitives,
                                max_depth=2,
@@ -58,14 +58,14 @@ def test_aggregation(pd_es, dask_es):
     # Run DFS using each entity as a target and confirm results match
     for entity in pd_es.entities:
         fm, _ = ft.dfs(entityset=pd_es,
-                       target_entity=entity.id,
+                       target_entity=entity.name,
                        trans_primitives=trans_primitives,
                        agg_primitives=agg_primitives,
                        cutoff_time=pd.Timestamp("2019-01-05 04:00"),
                        max_depth=2)
 
         dask_fm, _ = ft.dfs(entityset=dask_es,
-                            target_entity=entity.id,
+                            target_entity=entity.name,
                             trans_primitives=trans_primitives,
                             agg_primitives=agg_primitives,
                             cutoff_time=pd.Timestamp("2019-01-05 04:00"),

--- a/featuretools/tests/primitive_tests/test_transform_features.py
+++ b/featuretools/tests/primitive_tests/test_transform_features.py
@@ -474,7 +474,7 @@ def pd_boolean_mult_es():
 def dask_boolean_mult_es(pd_boolean_mult_es):
     entities = {}
     for entity in pd_boolean_mult_es.entities:
-        entities[entity.id] = (dd.from_pandas(entity.df, npartitions=2), entity.index, None, entity.variable_types)
+        entities[entity.name] = (dd.from_pandas(entity.df, npartitions=2), entity.index, None, entity.metadata['variable_types'])
 
     return ft.EntitySet(id=pd_boolean_mult_es.id, entities=entities)
 

--- a/featuretools/tests/synthesis/test_dask_dfs.py
+++ b/featuretools/tests/synthesis/test_dask_dfs.py
@@ -1,0 +1,369 @@
+import dask.dataframe as dd
+import pandas as pd
+
+import featuretools as ft
+from featuretools.entityset import EntitySet
+
+
+def test_single_table_dask_entityset():
+    primitives_list = ['absolute', 'is_weekend', 'year', 'day', 'num_characters', 'num_words']
+
+    dask_es = EntitySet(id="dask_es")
+    df = pd.DataFrame({"id": [0, 1, 2, 3],
+                       "values": [1, 12, -34, 27],
+                       "dates": [pd.to_datetime('2019-01-10'),
+                                 pd.to_datetime('2019-02-03'),
+                                 pd.to_datetime('2019-01-01'),
+                                 pd.to_datetime('2017-08-25')],
+                       "strings": ["I am a string",
+                                   "23",
+                                   "abcdef ghijk",
+                                   ""]})
+    values_dd = dd.from_pandas(df, npartitions=2)
+    vtypes = {
+        "id": ft.variable_types.Id,
+        "values": ft.variable_types.Numeric,
+        "dates": ft.variable_types.Datetime,
+        "strings": ft.variable_types.NaturalLanguage
+    }
+    dask_es.entity_from_dataframe(entity_id="data",
+                                  dataframe=values_dd,
+                                  index="id",
+                                  variable_types=vtypes)
+
+    dask_fm, _ = ft.dfs(entityset=dask_es,
+                        target_entity="data",
+                        trans_primitives=primitives_list)
+
+    pd_es = ft.EntitySet(id="pd_es")
+    pd_es.entity_from_dataframe(entity_id="data",
+                                dataframe=df,
+                                index="id",
+                                variable_types={"strings": ft.variable_types.NaturalLanguage})
+
+    fm, _ = ft.dfs(entityset=pd_es,
+                   target_entity="data",
+                   trans_primitives=primitives_list)
+
+    # Use the same columns and make sure both indexes are sorted the same
+    dask_computed_fm = dask_fm.compute().set_index('id').loc[fm.index][fm.columns]
+    pd.testing.assert_frame_equal(fm, dask_computed_fm)
+
+
+def test_single_table_dask_entityset_ids_not_sorted():
+    primitives_list = ['absolute', 'is_weekend', 'year', 'day', 'num_characters', 'num_words']
+
+    dask_es = EntitySet(id="dask_es")
+    df = pd.DataFrame({"id": [2, 0, 1, 3],
+                       "values": [1, 12, -34, 27],
+                       "dates": [pd.to_datetime('2019-01-10'),
+                                 pd.to_datetime('2019-02-03'),
+                                 pd.to_datetime('2019-01-01'),
+                                 pd.to_datetime('2017-08-25')],
+                       "strings": ["I am a string",
+                                   "23",
+                                   "abcdef ghijk",
+                                   ""]})
+    values_dd = dd.from_pandas(df, npartitions=2)
+    vtypes = {
+        "id": ft.variable_types.Id,
+        "values": ft.variable_types.Numeric,
+        "dates": ft.variable_types.Datetime,
+        "strings": ft.variable_types.NaturalLanguage
+    }
+    dask_es.entity_from_dataframe(entity_id="data",
+                                  dataframe=values_dd,
+                                  index="id",
+                                  variable_types=vtypes)
+
+    dask_fm, _ = ft.dfs(entityset=dask_es,
+                        target_entity="data",
+                        trans_primitives=primitives_list)
+
+    pd_es = ft.EntitySet(id="pd_es")
+    pd_es.entity_from_dataframe(entity_id="data",
+                                dataframe=df,
+                                index="id",
+                                variable_types={"strings": ft.variable_types.NaturalLanguage})
+
+    fm, _ = ft.dfs(entityset=pd_es,
+                   target_entity="data",
+                   trans_primitives=primitives_list)
+
+    # Make sure both indexes are sorted the same
+    pd.testing.assert_frame_equal(fm, dask_fm.compute().set_index('id').loc[fm.index])
+
+
+def test_single_table_dask_entityset_with_instance_ids():
+    primitives_list = ['absolute', 'is_weekend', 'year', 'day', 'num_characters', 'num_words']
+    instance_ids = [0, 1, 3]
+
+    dask_es = EntitySet(id="dask_es")
+    df = pd.DataFrame({"id": [0, 1, 2, 3],
+                       "values": [1, 12, -34, 27],
+                       "dates": [pd.to_datetime('2019-01-10'),
+                                 pd.to_datetime('2019-02-03'),
+                                 pd.to_datetime('2019-01-01'),
+                                 pd.to_datetime('2017-08-25')],
+                       "strings": ["I am a string",
+                                   "23",
+                                   "abcdef ghijk",
+                                   ""]})
+
+    values_dd = dd.from_pandas(df, npartitions=2)
+    vtypes = {
+        "id": ft.variable_types.Id,
+        "values": ft.variable_types.Numeric,
+        "dates": ft.variable_types.Datetime,
+        "strings": ft.variable_types.NaturalLanguage
+    }
+    dask_es.entity_from_dataframe(entity_id="data",
+                                  dataframe=values_dd,
+                                  index="id",
+                                  variable_types=vtypes)
+
+    dask_fm, _ = ft.dfs(entityset=dask_es,
+                        target_entity="data",
+                        trans_primitives=primitives_list,
+                        instance_ids=instance_ids)
+
+    pd_es = ft.EntitySet(id="pd_es")
+    pd_es.entity_from_dataframe(entity_id="data",
+                                dataframe=df,
+                                index="id",
+                                variable_types={"strings": ft.variable_types.NaturalLanguage})
+
+    fm, _ = ft.dfs(entityset=pd_es,
+                   target_entity="data",
+                   trans_primitives=primitives_list,
+                   instance_ids=instance_ids)
+
+    # Make sure both indexes are sorted the same
+    pd.testing.assert_frame_equal(fm, dask_fm.compute().set_index('id').loc[fm.index])
+
+
+def test_single_table_dask_entityset_single_cutoff_time():
+    primitives_list = ['absolute', 'is_weekend', 'year', 'day', 'num_characters', 'num_words']
+
+    dask_es = EntitySet(id="dask_es")
+    df = pd.DataFrame({"id": [0, 1, 2, 3],
+                       "values": [1, 12, -34, 27],
+                       "dates": [pd.to_datetime('2019-01-10'),
+                                 pd.to_datetime('2019-02-03'),
+                                 pd.to_datetime('2019-01-01'),
+                                 pd.to_datetime('2017-08-25')],
+                       "strings": ["I am a string",
+                                   "23",
+                                   "abcdef ghijk",
+                                   ""]})
+    values_dd = dd.from_pandas(df, npartitions=2)
+    vtypes = {
+        "id": ft.variable_types.Id,
+        "values": ft.variable_types.Numeric,
+        "dates": ft.variable_types.Datetime,
+        "strings": ft.variable_types.NaturalLanguage
+    }
+    dask_es.entity_from_dataframe(entity_id="data",
+                                  dataframe=values_dd,
+                                  index="id",
+                                  variable_types=vtypes)
+
+    dask_fm, _ = ft.dfs(entityset=dask_es,
+                        target_entity="data",
+                        trans_primitives=primitives_list,
+                        cutoff_time=pd.Timestamp("2019-01-05 04:00"))
+
+    pd_es = ft.EntitySet(id="pd_es")
+    pd_es.entity_from_dataframe(entity_id="data",
+                                dataframe=df,
+                                index="id",
+                                variable_types={"strings": ft.variable_types.NaturalLanguage})
+
+    fm, _ = ft.dfs(entityset=pd_es,
+                   target_entity="data",
+                   trans_primitives=primitives_list,
+                   cutoff_time=pd.Timestamp("2019-01-05 04:00"))
+
+    # Make sure both indexes are sorted the same
+    pd.testing.assert_frame_equal(fm, dask_fm.compute().set_index('id').loc[fm.index])
+
+
+def test_single_table_dask_entityset_cutoff_time_df():
+    primitives_list = ['absolute', 'is_weekend', 'year', 'day', 'num_characters', 'num_words']
+
+    dask_es = EntitySet(id="dask_es")
+    df = pd.DataFrame({"id": [0, 1, 2],
+                       "values": [1, 12, -34],
+                       "dates": [pd.to_datetime('2019-01-10'),
+                                 pd.to_datetime('2019-02-03'),
+                                 pd.to_datetime('2019-01-01')],
+                       "strings": ["I am a string",
+                                   "23",
+                                   "abcdef ghijk"]})
+    values_dd = dd.from_pandas(df, npartitions=2)
+    vtypes = {
+        "id": ft.variable_types.Id,
+        "values": ft.variable_types.Numeric,
+        "dates": ft.variable_types.DatetimeTimeIndex,
+        "strings": ft.variable_types.NaturalLanguage
+    }
+    dask_es.entity_from_dataframe(entity_id="data",
+                                  dataframe=values_dd,
+                                  index="id",
+                                  time_index="dates",
+                                  variable_types=vtypes)
+    ids = [0, 1, 2, 0]
+    times = [pd.Timestamp("2019-01-05 04:00"),
+             pd.Timestamp("2019-01-05 04:00"),
+             pd.Timestamp("2019-01-05 04:00"),
+             pd.Timestamp("2019-01-15 04:00")]
+    labels = [True, False, True, False]
+    cutoff_times = pd.DataFrame({"id": ids, "time": times, "labels": labels}, columns=["id", "time", "labels"])
+
+    dask_fm, _ = ft.dfs(entityset=dask_es,
+                        target_entity="data",
+                        trans_primitives=primitives_list,
+                        cutoff_time=cutoff_times)
+
+    pd_es = ft.EntitySet(id="pd_es")
+    pd_es.entity_from_dataframe(entity_id="data",
+                                dataframe=df,
+                                index="id",
+                                time_index="dates",
+                                variable_types={"strings": ft.variable_types.NaturalLanguage})
+
+    fm, _ = ft.dfs(entityset=pd_es,
+                   target_entity="data",
+                   trans_primitives=primitives_list,
+                   cutoff_time=cutoff_times)
+    # Because row ordering with Dask is not guaranteed, we need to sort on two columns to make sure that values
+    # for instance id 0 are compared correctly. Also, make sure the boolean column has the same dtype.
+    fm = fm.sort_values(['id', 'labels'])
+    dask_fm = dask_fm.compute().set_index('id').sort_values(['id', 'labels'])
+    dask_fm['IS_WEEKEND(dates)'] = dask_fm['IS_WEEKEND(dates)'].astype(fm['IS_WEEKEND(dates)'].dtype)
+    pd.testing.assert_frame_equal(fm, dask_fm)
+
+
+def test_single_table_dask_entityset_dates_not_sorted():
+    dask_es = EntitySet(id="dask_es")
+    df = pd.DataFrame({"id": [0, 1, 2, 3],
+                       "values": [1, 12, -34, 27],
+                       "dates": [pd.to_datetime('2019-01-10'),
+                                 pd.to_datetime('2019-02-03'),
+                                 pd.to_datetime('2019-01-01'),
+                                 pd.to_datetime('2017-08-25')]})
+
+    primitives_list = ['absolute', 'is_weekend', 'year', 'day']
+    values_dd = dd.from_pandas(df, npartitions=1)
+    vtypes = {
+        "id": ft.variable_types.Id,
+        "values": ft.variable_types.Numeric,
+        "dates": ft.variable_types.Datetime,
+    }
+    dask_es.entity_from_dataframe(entity_id="data",
+                                  dataframe=values_dd,
+                                  index="id",
+                                  time_index="dates",
+                                  variable_types=vtypes)
+
+    dask_fm, _ = ft.dfs(entityset=dask_es,
+                        target_entity="data",
+                        trans_primitives=primitives_list,
+                        max_depth=1)
+
+    pd_es = ft.EntitySet(id="pd_es")
+    pd_es.entity_from_dataframe(entity_id="data",
+                                dataframe=df,
+                                index="id",
+                                time_index="dates")
+
+    fm, _ = ft.dfs(entityset=pd_es,
+                   target_entity="data",
+                   trans_primitives=primitives_list,
+                   max_depth=1)
+
+    pd.testing.assert_frame_equal(fm, dask_fm.compute().set_index('id').loc[fm.index])
+
+
+def test_secondary_time_index():
+    log_df = pd.DataFrame()
+    log_df['id'] = [0, 1, 2, 3]
+    log_df['scheduled_time'] = pd.to_datetime([
+        "2019-01-01",
+        "2019-01-01",
+        "2019-01-01",
+        "2019-01-01"
+    ])
+    log_df['departure_time'] = pd.to_datetime([
+        "2019-02-01 09:00",
+        "2019-02-06 10:00",
+        "2019-02-12 10:00",
+        "2019-03-01 11:30"])
+    log_df['arrival_time'] = pd.to_datetime([
+        "2019-02-01 11:23",
+        "2019-02-06 12:45",
+        "2019-02-12 13:53",
+        "2019-03-01 14:07"
+    ])
+    log_df['delay'] = [-2, 10, 60, 0]
+    log_df['flight_id'] = [0, 1, 0, 1]
+    log_dask = dd.from_pandas(log_df, npartitions=2)
+
+    flights_df = pd.DataFrame()
+    flights_df['id'] = [0, 1, 2, 3]
+    flights_df['origin'] = ["BOS", "LAX", "BOS", "LAX"]
+    flights_dask = dd.from_pandas(flights_df, npartitions=2)
+
+    pd_es = ft.EntitySet("flights")
+    dask_es = ft.EntitySet("flights_dask")
+
+    pd_es.entity_from_dataframe(entity_id='logs',
+                                dataframe=log_df,
+                                index="id",
+                                time_index="scheduled_time",
+                                secondary_time_index={
+                                    'arrival_time': ['departure_time', 'delay']})
+
+    log_vtypes = {
+        "id": ft.variable_types.Id,
+        "scheduled_time": ft.variable_types.DatetimeTimeIndex,
+        "departure_time": ft.variable_types.DatetimeTimeIndex,
+        "arrival_time": ft.variable_types.DatetimeTimeIndex,
+        "delay": ft.variable_types.Numeric,
+        "flight_id": ft.variable_types.Id
+    }
+    dask_es.entity_from_dataframe(entity_id='logs',
+                                  dataframe=log_dask,
+                                  index="id",
+                                  variable_types=log_vtypes,
+                                  time_index="scheduled_time",
+                                  secondary_time_index={
+                                      'arrival_time': ['departure_time', 'delay']})
+
+    pd_es.entity_from_dataframe('flights', flights_df, index="id")
+    flights_vtypes = pd_es['flights'].variable_types
+    dask_es.entity_from_dataframe('flights', flights_dask, index="id", variable_types=flights_vtypes)
+
+    new_rel = ft.Relationship(pd_es['flights']['id'], pd_es['logs']['flight_id'])
+    dask_rel = ft.Relationship(dask_es['flights']['id'], dask_es['logs']['flight_id'])
+    pd_es.add_relationship(new_rel)
+    dask_es.add_relationship(dask_rel)
+
+    cutoff_df = pd.DataFrame()
+    cutoff_df['id'] = [0, 1, 1]
+    cutoff_df['time'] = pd.to_datetime(['2019-02-02', '2019-02-02', '2019-02-20'])
+
+    fm, _ = ft.dfs(entityset=pd_es,
+                   target_entity="logs",
+                   cutoff_time=cutoff_df,
+                   agg_primitives=["max"],
+                   trans_primitives=["month"])
+
+    dask_fm, _ = ft.dfs(entityset=dask_es,
+                        target_entity="logs",
+                        cutoff_time=cutoff_df,
+                        agg_primitives=["max"],
+                        trans_primitives=["month"])
+
+    # Make sure both matrixes are sorted the same
+    pd.testing.assert_frame_equal(fm.sort_values('delay'), dask_fm.compute().set_index('id').sort_values('delay'))

--- a/featuretools/tests/synthesis/test_koalas_dfs.py
+++ b/featuretools/tests/synthesis/test_koalas_dfs.py
@@ -1,0 +1,379 @@
+import pandas as pd
+import pytest
+
+import featuretools as ft
+from featuretools.entityset import EntitySet
+from featuretools.utils.gen_utils import import_or_none
+
+ks = import_or_none('databricks.koalas')
+
+
+@pytest.mark.skipif('not ks')
+def test_single_table_ks_entityset():
+    primitives_list = ['absolute', 'is_weekend', 'year', 'day', 'num_characters', 'num_words']
+
+    ks_es = EntitySet(id="ks_es")
+    df = pd.DataFrame({"id": [0, 1, 2, 3],
+                       "values": [1, 12, -34, 27],
+                       "dates": [pd.to_datetime('2019-01-10'),
+                                 pd.to_datetime('2019-02-03'),
+                                 pd.to_datetime('2019-01-01'),
+                                 pd.to_datetime('2017-08-25')],
+                       "strings": ["I am a string",
+                                   "23",
+                                   "abcdef ghijk",
+                                   ""]})
+    values_dd = ks.from_pandas(df)
+    vtypes = {
+        "id": ft.variable_types.Id,
+        "values": ft.variable_types.Numeric,
+        "dates": ft.variable_types.Datetime,
+        "strings": ft.variable_types.NaturalLanguage
+    }
+    ks_es.entity_from_dataframe(entity_id="data",
+                                dataframe=values_dd,
+                                index="id",
+                                variable_types=vtypes)
+
+    ks_fm, _ = ft.dfs(entityset=ks_es,
+                      target_entity="data",
+                      trans_primitives=primitives_list)
+
+    pd_es = ft.EntitySet(id="pd_es")
+    pd_es.entity_from_dataframe(entity_id="data",
+                                dataframe=df,
+                                index="id",
+                                variable_types={"strings": ft.variable_types.NaturalLanguage})
+
+    fm, _ = ft.dfs(entityset=pd_es,
+                   target_entity="data",
+                   trans_primitives=primitives_list)
+
+    ks_computed_fm = ks_fm.to_pandas().set_index('id').loc[fm.index][fm.columns]
+    # NUM_WORDS(strings) is int32 in koalas for some reason
+    pd.testing.assert_frame_equal(fm, ks_computed_fm, check_dtype=False)
+
+
+@pytest.mark.skipif('not ks')
+def test_single_table_ks_entityset_ids_not_sorted():
+    primitives_list = ['absolute', 'is_weekend', 'year', 'day', 'num_characters', 'num_words']
+
+    ks_es = EntitySet(id="ks_es")
+    df = pd.DataFrame({"id": [2, 0, 1, 3],
+                       "values": [1, 12, -34, 27],
+                       "dates": [pd.to_datetime('2019-01-10'),
+                                 pd.to_datetime('2019-02-03'),
+                                 pd.to_datetime('2019-01-01'),
+                                 pd.to_datetime('2017-08-25')],
+                       "strings": ["I am a string",
+                                   "23",
+                                   "abcdef ghijk",
+                                   ""]})
+    values_dd = ks.from_pandas(df)
+    vtypes = {
+        "id": ft.variable_types.Id,
+        "values": ft.variable_types.Numeric,
+        "dates": ft.variable_types.Datetime,
+        "strings": ft.variable_types.NaturalLanguage
+    }
+    ks_es.entity_from_dataframe(entity_id="data",
+                                dataframe=values_dd,
+                                index="id",
+                                variable_types=vtypes)
+
+    ks_fm, _ = ft.dfs(entityset=ks_es,
+                      target_entity="data",
+                      trans_primitives=primitives_list)
+
+    pd_es = ft.EntitySet(id="pd_es")
+    pd_es.entity_from_dataframe(entity_id="data",
+                                dataframe=df,
+                                index="id",
+                                variable_types={"strings": ft.variable_types.NaturalLanguage})
+
+    fm, _ = ft.dfs(entityset=pd_es,
+                   target_entity="data",
+                   trans_primitives=primitives_list)
+
+    # Make sure both indexes are sorted the same
+    pd.testing.assert_frame_equal(fm, ks_fm.to_pandas().set_index('id').loc[fm.index], check_dtype=False)
+
+
+@pytest.mark.skipif('not ks')
+def test_single_table_ks_entityset_with_instance_ids():
+    primitives_list = ['absolute', 'is_weekend', 'year', 'day', 'num_characters', 'num_words']
+    instance_ids = [0, 1, 3]
+
+    ks_es = EntitySet(id="ks_es")
+    df = pd.DataFrame({"id": [0, 1, 2, 3],
+                       "values": [1, 12, -34, 27],
+                       "dates": [pd.to_datetime('2019-01-10'),
+                                 pd.to_datetime('2019-02-03'),
+                                 pd.to_datetime('2019-01-01'),
+                                 pd.to_datetime('2017-08-25')],
+                       "strings": ["I am a string",
+                                   "23",
+                                   "abcdef ghijk",
+                                   ""]})
+
+    values_dd = ks.from_pandas(df)
+    vtypes = {
+        "id": ft.variable_types.Id,
+        "values": ft.variable_types.Numeric,
+        "dates": ft.variable_types.Datetime,
+        "strings": ft.variable_types.NaturalLanguage
+    }
+    ks_es.entity_from_dataframe(entity_id="data",
+                                dataframe=values_dd,
+                                index="id",
+                                variable_types=vtypes)
+
+    ks_fm, _ = ft.dfs(entityset=ks_es,
+                      target_entity="data",
+                      trans_primitives=primitives_list,
+                      instance_ids=instance_ids)
+
+    pd_es = ft.EntitySet(id="pd_es")
+    pd_es.entity_from_dataframe(entity_id="data",
+                                dataframe=df,
+                                index="id",
+                                variable_types={"strings": ft.variable_types.NaturalLanguage})
+
+    fm, _ = ft.dfs(entityset=pd_es,
+                   target_entity="data",
+                   trans_primitives=primitives_list,
+                   instance_ids=instance_ids)
+
+    # Make sure both indexes are sorted the same
+    pd.testing.assert_frame_equal(fm, ks_fm.to_pandas().set_index('id').loc[fm.index], check_dtype=False)
+
+
+@pytest.mark.skipif('not ks')
+def test_single_table_ks_entityset_single_cutoff_time():
+    primitives_list = ['absolute', 'is_weekend', 'year', 'day', 'num_characters', 'num_words']
+
+    ks_es = EntitySet(id="ks_es")
+    df = pd.DataFrame({"id": [0, 1, 2, 3],
+                       "values": [1, 12, -34, 27],
+                       "dates": [pd.to_datetime('2019-01-10'),
+                                 pd.to_datetime('2019-02-03'),
+                                 pd.to_datetime('2019-01-01'),
+                                 pd.to_datetime('2017-08-25')],
+                       "strings": ["I am a string",
+                                   "23",
+                                   "abcdef ghijk",
+                                   ""]})
+    values_dd = ks.from_pandas(df)
+    vtypes = {
+        "id": ft.variable_types.Id,
+        "values": ft.variable_types.Numeric,
+        "dates": ft.variable_types.Datetime,
+        "strings": ft.variable_types.NaturalLanguage
+    }
+    ks_es.entity_from_dataframe(entity_id="data",
+                                dataframe=values_dd,
+                                index="id",
+                                variable_types=vtypes)
+
+    ks_fm, _ = ft.dfs(entityset=ks_es,
+                      target_entity="data",
+                      trans_primitives=primitives_list,
+                      cutoff_time=pd.Timestamp("2019-01-05 04:00"))
+
+    pd_es = ft.EntitySet(id="pd_es")
+    pd_es.entity_from_dataframe(entity_id="data",
+                                dataframe=df,
+                                index="id",
+                                variable_types={"strings": ft.variable_types.NaturalLanguage})
+
+    fm, _ = ft.dfs(entityset=pd_es,
+                   target_entity="data",
+                   trans_primitives=primitives_list,
+                   cutoff_time=pd.Timestamp("2019-01-05 04:00"))
+
+    # Make sure both indexes are sorted the same
+    pd.testing.assert_frame_equal(fm, ks_fm.to_pandas().set_index('id').loc[fm.index], check_dtype=False)
+
+
+@pytest.mark.skipif('not ks')
+def test_single_table_ks_entityset_cutoff_time_df():
+    primitives_list = ['absolute', 'is_weekend', 'year', 'day', 'num_characters', 'num_words']
+
+    ks_es = EntitySet(id="ks_es")
+    df = pd.DataFrame({"id": [0, 1, 2],
+                       "values": [1, 12, -34],
+                       "dates": [pd.to_datetime('2019-01-10'),
+                                 pd.to_datetime('2019-02-03'),
+                                 pd.to_datetime('2019-01-01')],
+                       "strings": ["I am a string",
+                                   "23",
+                                   "abcdef ghijk"]})
+    values_dd = ks.from_pandas(df)
+    vtypes = {
+        "id": ft.variable_types.Id,
+        "values": ft.variable_types.Numeric,
+        "dates": ft.variable_types.Datetime,
+        "strings": ft.variable_types.NaturalLanguage
+    }
+    ks_es.entity_from_dataframe(entity_id="data",
+                                dataframe=values_dd,
+                                index="id",
+                                time_index="dates",
+                                variable_types=vtypes)
+    ids = [0, 1, 2, 0]
+    times = [pd.Timestamp("2019-01-05 04:00"),
+             pd.Timestamp("2019-01-05 04:00"),
+             pd.Timestamp("2019-01-05 04:00"),
+             pd.Timestamp("2019-01-15 04:00")]
+    labels = [True, False, True, False]
+    cutoff_times = pd.DataFrame({"id": ids, "time": times, "labels": labels}, columns=["id", "time", "labels"])
+
+    ks_fm, _ = ft.dfs(entityset=ks_es,
+                      target_entity="data",
+                      trans_primitives=primitives_list,
+                      cutoff_time=cutoff_times)
+
+    pd_es = ft.EntitySet(id="pd_es")
+    pd_es.entity_from_dataframe(entity_id="data",
+                                dataframe=df,
+                                index="id",
+                                time_index="dates",
+                                variable_types={"strings": ft.variable_types.NaturalLanguage})
+
+    fm, _ = ft.dfs(entityset=pd_es,
+                   target_entity="data",
+                   trans_primitives=primitives_list,
+                   cutoff_time=cutoff_times)
+    # Because row ordering with koalas is not guaranteed, `we need to sort on two columns to make sure that values
+    # for instance id 0 are compared correctly. Also, make sure the boolean column has the same dtype.
+    fm = fm.sort_values(['id', 'labels'])
+    ks_fm = ks_fm.to_pandas().set_index('id').sort_values(['id', 'labels'])
+    ks_fm['IS_WEEKEND(dates)'] = ks_fm['IS_WEEKEND(dates)'].astype(fm['IS_WEEKEND(dates)'].dtype)
+    pd.testing.assert_frame_equal(fm, ks_fm)
+
+
+@pytest.mark.skipif('not ks')
+def test_single_table_ks_entityset_dates_not_sorted():
+    ks_es = EntitySet(id="ks_es")
+    df = pd.DataFrame({"id": [0, 1, 2, 3],
+                       "values": [1, 12, -34, 27],
+                       "dates": [pd.to_datetime('2019-01-10'),
+                                 pd.to_datetime('2019-02-03'),
+                                 pd.to_datetime('2019-01-01'),
+                                 pd.to_datetime('2017-08-25')]})
+
+    primitives_list = ['absolute', 'is_weekend', 'year', 'day']
+    values_dd = ks.from_pandas(df)
+    vtypes = {
+        "id": ft.variable_types.Id,
+        "values": ft.variable_types.Numeric,
+        "dates": ft.variable_types.Datetime,
+    }
+    ks_es.entity_from_dataframe(entity_id="data",
+                                dataframe=values_dd,
+                                index="id",
+                                time_index="dates",
+                                variable_types=vtypes)
+
+    ks_fm, _ = ft.dfs(entityset=ks_es,
+                      target_entity="data",
+                      trans_primitives=primitives_list,
+                      max_depth=1)
+
+    pd_es = ft.EntitySet(id="pd_es")
+    pd_es.entity_from_dataframe(entity_id="data",
+                                dataframe=df,
+                                index="id",
+                                time_index="dates")
+
+    fm, _ = ft.dfs(entityset=pd_es,
+                   target_entity="data",
+                   trans_primitives=primitives_list,
+                   max_depth=1)
+
+    pd.testing.assert_frame_equal(fm, ks_fm.to_pandas().set_index('id').loc[fm.index])
+
+
+@pytest.mark.skipif('not ks')
+def test_secondary_time_index():
+    log_df = pd.DataFrame()
+    log_df['id'] = [0, 1, 2, 3]
+    log_df['scheduled_time'] = pd.to_datetime([
+        "2019-01-01",
+        "2019-01-01",
+        "2019-01-01",
+        "2019-01-01"
+    ])
+    log_df['departure_time'] = pd.to_datetime([
+        "2019-02-01 09:00",
+        "2019-02-06 10:00",
+        "2019-02-12 10:00",
+        "2019-03-01 11:30"])
+    log_df['arrival_time'] = pd.to_datetime([
+        "2019-02-01 11:23",
+        "2019-02-06 12:45",
+        "2019-02-12 13:53",
+        "2019-03-01 14:07"
+    ])
+    log_df['delay'] = [-2, 10, 60, 0]
+    log_df['flight_id'] = [0, 1, 0, 1]
+    log_ks = ks.from_pandas(log_df)
+
+    flights_df = pd.DataFrame()
+    flights_df['id'] = [0, 1, 2, 3]
+    flights_df['origin'] = ["BOS", "LAX", "BOS", "LAX"]
+    flights_ks = ks.from_pandas(flights_df)
+
+    pd_es = ft.EntitySet("flights")
+    ks_es = ft.EntitySet("flights_ks")
+
+    pd_es.entity_from_dataframe(entity_id='logs',
+                                dataframe=log_df,
+                                index="id",
+                                time_index="scheduled_time",
+                                secondary_time_index={
+                                    'arrival_time': ['departure_time', 'delay']})
+
+    log_vtypes = {
+        "id": ft.variable_types.Id,
+        "scheduled_time": ft.variable_types.DatetimeTimeIndex,
+        "departure_time": ft.variable_types.DatetimeTimeIndex,
+        "arrival_time": ft.variable_types.DatetimeTimeIndex,
+        "delay": ft.variable_types.Numeric,
+        "flight_id": ft.variable_types.Id
+    }
+    ks_es.entity_from_dataframe(entity_id='logs',
+                                dataframe=log_ks,
+                                index="id",
+                                variable_types=log_vtypes,
+                                time_index="scheduled_time",
+                                secondary_time_index={
+                                      'arrival_time': ['departure_time', 'delay']})
+
+    pd_es.entity_from_dataframe('flights', flights_df, index="id")
+    flights_vtypes = pd_es['flights'].variable_types
+    ks_es.entity_from_dataframe('flights', flights_ks, index="id", variable_types=flights_vtypes)
+
+    new_rel = ft.Relationship(pd_es['flights']['id'], pd_es['logs']['flight_id'])
+    ks_rel = ft.Relationship(ks_es['flights']['id'], ks_es['logs']['flight_id'])
+    pd_es.add_relationship(new_rel)
+    ks_es.add_relationship(ks_rel)
+
+    cutoff_df = pd.DataFrame()
+    cutoff_df['id'] = [0, 1, 1]
+    cutoff_df['time'] = pd.to_datetime(['2019-02-02', '2019-02-02', '2019-02-20'])
+
+    fm, _ = ft.dfs(entityset=pd_es,
+                   target_entity="logs",
+                   cutoff_time=cutoff_df,
+                   agg_primitives=["max"],
+                   trans_primitives=["month"])
+
+    ks_fm, _ = ft.dfs(entityset=ks_es,
+                      target_entity="logs",
+                      cutoff_time=cutoff_df,
+                      agg_primitives=["max"],
+                      trans_primitives=["month"])
+
+    # Make sure both matrixes are sorted the same
+    pd.testing.assert_frame_equal(fm.sort_values('delay'), ks_fm.to_pandas().set_index('id').sort_values('delay'), check_dtype=False)

--- a/featuretools/tests/testing_utils/features.py
+++ b/featuretools/tests/testing_utils/features.py
@@ -16,7 +16,7 @@ def backward_path(es, entity_ids):
     """
     def _get_relationship(child, parent):
         return next(r for r in es.get_forward_relationships(child)
-                    if r.parent_entity.id == parent)
+                    if r.parent_entity.name == parent)
 
     relationships = [_get_relationship(child, parent)
                      for parent, child in zip(entity_ids[:-1], entity_ids[1:])]
@@ -31,7 +31,7 @@ def forward_path(es, entity_ids):
     """
     def _get_relationship(child, parent):
         return next(r for r in es.get_forward_relationships(child)
-                    if r.parent_entity.id == parent)
+                    if r.parent_entity.name == parent)
 
     relationships = [_get_relationship(child, parent)
                      for child, parent in zip(entity_ids[:-1], entity_ids[1:])]

--- a/featuretools/utils/entity_utils.py
+++ b/featuretools/utils/entity_utils.py
@@ -190,12 +190,12 @@ def convert_variable_data(df, column_id, new_type, **kwargs):
 def get_linked_vars(entity):
     """Return a list with the entity linked variables.
     """
-    link_relationships = [r for r in entity.entityset.relationships
-                          if r.parent_entity.id == entity.id or
-                          r.child_entity.id == entity.id]
+    link_relationships = [r for r in entity.metadata['entityset'].relationships
+                          if r.parent_entity.name == entity.name or
+                          r.child_entity.name == entity.name]
     link_vars = [v.id for rel in link_relationships
                  for v in [rel.parent_variable, rel.child_variable]
-                 if v.entity.id == entity.id]
+                 if v.entity.name == entity.name]
     return link_vars
 
 

--- a/featuretools/utils/gen_utils.py
+++ b/featuretools/utils/gen_utils.py
@@ -26,7 +26,7 @@ def get_relationship_variable_id(path):
     child_link_name = r.child_variable.id
     for _, r in path[1:]:
         parent_link_name = child_link_name
-        child_link_name = '%s.%s' % (r.parent_entity.id,
+        child_link_name = '%s.%s' % (r.parent_entity.name,
                                      parent_link_name)
     return child_link_name
 

--- a/featuretools/utils/koalas_utils.py
+++ b/featuretools/utils/koalas_utils.py
@@ -33,8 +33,43 @@ def replace_categorical_columns(pdf):
     return new_df
 
 
+def replace_int_columns(pdf):
+    new_df = pd.DataFrame()
+    for c in pdf.columns:
+        col = pdf[c]
+        if col.dtype.name == 'Int64':
+            new_df[c] = col.astype('int64')
+        else:
+            new_df[c] = pdf[c]
+    return new_df
+
+
+def replace_bool_columns(pdf):
+    new_df = pd.DataFrame()
+    for c in pdf.columns:
+        col = pdf[c]
+        if col.dtype.name == 'boolean':
+            new_df[c] = col.astype('bool')
+        else:
+            new_df[c] = pdf[c]
+    return new_df
+
+
+def replace_string_columns(pdf):
+    new_df = pd.DataFrame()
+    for c in pdf.columns:
+        col = pdf[c]
+        if col.dtype.name == 'string':
+            new_df[c] = col.astype('str')
+        else:
+            new_df[c] = pdf[c]
+    return new_df
+
+
 def pd_to_ks_clean(pdf):
-    steps = [replace_tuple_columns, replace_nan_with_flag, replace_categorical_columns]
+    steps = [replace_tuple_columns, replace_nan_with_flag,
+             replace_categorical_columns, replace_int_columns,
+             replace_bool_columns, replace_string_columns]
     intermediate_df = pdf
     for f in steps:
         intermediate_df = f(intermediate_df)

--- a/featuretools/utils/wrangle.py
+++ b/featuretools/utils/wrangle.py
@@ -106,9 +106,9 @@ def _check_time_type(time):
     '''
     time_type = None
     if isinstance(time, (datetime, np.datetime64)):
-        time_type = variable_types.DatetimeTimeIndex
+        time_type = variable_types.Datetime
     elif isinstance(time, (int, float)) or np.issubdtype(time, np.integer) or np.issubdtype(time, np.floating):
-        time_type = variable_types.NumericTimeIndex
+        time_type = variable_types.Numeric
     return time_type
 
 

--- a/featuretools/variable_types/variable.py
+++ b/featuretools/variable_types/variable.py
@@ -37,9 +37,9 @@ class Variable(object):
         assert isinstance(id, str), "Variable id must be a string"
         self.id = id
         self._name = name
-        self.entity_id = entity.id
+        self.entity_id = entity.name
         self._description = description
-        assert entity.entityset is not None, "Entity must contain reference to EntitySet"
+        assert entity.metadata['entityset'] is not None, "Entity must contain reference to EntitySet"
         self.entity = entity
         if self.id not in self.entity.df:
             default_dtype = self._default_pandas_dtype
@@ -53,7 +53,7 @@ class Variable(object):
 
     @property
     def entityset(self):
-        return self.entity.entityset
+        return self.entity.metadata['entityset']
 
     def __eq__(self, other, deep=False):
         shallow_eq = isinstance(other, self.__class__) and \
@@ -129,7 +129,7 @@ class Variable(object):
             'properties': {
                 'name': self.name,
                 'description': self.description,
-                'entity': self.entity.id,
+                'entity': self.entity.name,
                 'interesting_values': self._interesting_values.to_json()
             },
         }

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ distributed>=2.12.0
 dask[dataframe]>=2.12.0
 psutil>=5.4.8
 click>=7.0.0
-woodwork>=0.0.7
+git+https://github.com/alteryx/woodwork.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ distributed>=2.12.0
 dask[dataframe]>=2.12.0
 psutil>=5.4.8
 click>=7.0.0
+woodwork>=0.0.7


### PR DESCRIPTION
### Replace Entity with Woodwork.DataTable

Updates only performed in an attempt to get tests in the `entity_tests` directory to pass. Updates have not been performed for other aspects of Featuretools.

Also, some tests were relocated to better align with the contents - some tests were moved to serialization tests and others to DFS tests.
