### PR TITLE
Allow passing entities without relationships to CFM

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -6,6 +6,7 @@ Release Notes
     * Enhancements
     * Fixes
         * Fix logic for inferring variable type from unusual dtype (:pr:`1273`)
+        * Allow passing entities without relationships to `calculate_feature_matrix` (:pr:`1290`)
     * Changes
         * Move ``query_by_values`` method from ``Entity`` to ``EntitySet`` (:pr:`1251`)
         * Move ``_handle_time`` method from ``Entity`` to ``EntitySet`` (:pr:`1276`)

--- a/featuretools/computational_backends/calculate_feature_matrix.py
+++ b/featuretools/computational_backends/calculate_feature_matrix.py
@@ -142,8 +142,7 @@ def calculate_feature_matrix(features, entityset=None, cutoff_time=None, instanc
     # handle loading entityset
     from featuretools.entityset.entityset import EntitySet
     if not isinstance(entityset, EntitySet):
-        if entities is not None and relationships is not None:
-            entityset = EntitySet("entityset", entities, relationships)
+        entityset = EntitySet("entityset", entities, relationships)
 
     if any(isinstance(es.df, dd.DataFrame) for es in entityset.entities):
         if approximate:

--- a/featuretools/computational_backends/calculate_feature_matrix.py
+++ b/featuretools/computational_backends/calculate_feature_matrix.py
@@ -142,7 +142,10 @@ def calculate_feature_matrix(features, entityset=None, cutoff_time=None, instanc
     # handle loading entityset
     from featuretools.entityset.entityset import EntitySet
     if not isinstance(entityset, EntitySet):
-        entityset = EntitySet("entityset", entities, relationships)
+        if entities is not None:
+            entityset = EntitySet("entityset", entities, relationships)
+        else:
+            raise TypeError("No entities or valid EntitySet provided")
 
     if any(isinstance(es.df, dd.DataFrame) for es in entityset.entities):
         if approximate:

--- a/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
+++ b/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
@@ -1828,3 +1828,44 @@ def test_calc_feature_matrix_with_cutoff_df_and_instance_ids(es):
 
     feature_matrix = to_pandas(feature_matrix)
     assert (feature_matrix[property_feature.get_name()] == labels).values.all()
+
+
+def test_entities_relationships(entities, relationships):
+    fm_1, features = ft.dfs(entities=entities,
+                            relationships=relationships,
+                            target_entity="transactions")
+
+    fm_2 = calculate_feature_matrix(features=features,
+                                    entities=entities,
+                                    relationships=relationships)
+
+    fm_1 = to_pandas(fm_1, index='id')
+    fm_2 = to_pandas(fm_2, index='id')
+    assert fm_1.equals(fm_2)
+
+
+def test_no_entities(entities, relationships):
+    features = ft.dfs(entities=entities,
+                      relationships=relationships,
+                      target_entity="transactions",
+                      features_only=True)
+
+    msg = "Entity transactions does not exist in entityset"
+    with pytest.raises(KeyError, match=msg):
+        calculate_feature_matrix(features=features,
+                                 entities=None,
+                                 relationships=None)
+
+
+def test_single_entity(entities):
+    fm_1, features = ft.dfs(entities={'transactions': entities['transactions']},
+                            relationships=None,
+                            target_entity="transactions")
+
+    fm_2 = calculate_feature_matrix(features=features,
+                                    entities={'transactions': entities['transactions']},
+                                    relationships=None)
+
+    fm_1 = to_pandas(fm_1, index='id')
+    fm_2 = to_pandas(fm_2, index='id')
+    assert fm_1.equals(fm_2)

--- a/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
+++ b/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
@@ -1850,8 +1850,8 @@ def test_no_entities(entities, relationships):
                       target_entity="transactions",
                       features_only=True)
 
-    msg = "Entity transactions does not exist in entityset"
-    with pytest.raises(KeyError, match=msg):
+    msg = "No entities or valid EntitySet provided"
+    with pytest.raises(TypeError, match=msg):
         calculate_feature_matrix(features=features,
                                  entities=None,
                                  relationships=None)

--- a/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
+++ b/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
@@ -1857,13 +1857,13 @@ def test_no_entities(entities, relationships):
                                  relationships=None)
 
 
-def test_single_entity(entities):
-    fm_1, features = ft.dfs(entities={'transactions': entities['transactions']},
+def test_no_relationships(entities):
+    fm_1, features = ft.dfs(entities=entities,
                             relationships=None,
                             target_entity="transactions")
 
     fm_2 = calculate_feature_matrix(features=features,
-                                    entities={'transactions': entities['transactions']},
+                                    entities=entities,
                                     relationships=None)
 
     fm_1 = to_pandas(fm_1, index='id')

--- a/featuretools/tests/conftest.py
+++ b/featuretools/tests/conftest.py
@@ -7,6 +7,7 @@ import pandas as pd
 import pytest
 
 import featuretools as ft
+from featuretools import variable_types as vtypes
 from featuretools.tests.testing_utils import (
     make_ecommerce_entityset,
     to_pandas
@@ -268,3 +269,81 @@ def lt(es):
     )
     labels = labels.rename(columns={'cutoff_time': 'time'})
     return labels
+
+
+@pytest.fixture(params=['pd_entities', 'dask_entities', 'koalas_entities'])
+def entities(request):
+    return request.getfixturevalue(request.param)
+
+
+@pytest.fixture
+def pd_entities():
+    cards_df = pd.DataFrame({"id": [1, 2, 3, 4, 5]})
+    transactions_df = pd.DataFrame({"id": [1, 2, 3, 4, 5, 6],
+                                    "card_id": [1, 2, 1, 3, 4, 5],
+                                    "transaction_time": [10, 12, 13, 20, 21, 20],
+                                    "fraud": [True, False, False, False, True, True]})
+    entities = {
+        "cards": (cards_df, "id"),
+        "transactions": (transactions_df, "id", "transaction_time")
+    }
+    return entities
+
+
+@pytest.fixture
+def dask_entities():
+    cards_df = pd.DataFrame({"id": [1, 2, 3, 4, 5]})
+    transactions_df = pd.DataFrame({"id": [1, 2, 3, 4, 5, 6],
+                                    "card_id": [1, 2, 1, 3, 4, 5],
+                                    "transaction_time": [10, 12, 13, 20, 21, 20],
+                                    "fraud": [True, False, False, False, True, True]})
+    cards_df = dd.from_pandas(cards_df, npartitions=2)
+    transactions_df = dd.from_pandas(transactions_df, npartitions=2)
+
+    cards_vtypes = {
+        'id': vtypes.Index
+    }
+    transactions_vtypes = {
+        'id': vtypes.Index,
+        'card_id': vtypes.Id,
+        'transaction_time': vtypes.NumericTimeIndex,
+        'fraud': vtypes.Boolean
+    }
+
+    entities = {
+        "cards": (cards_df, "id", None, cards_vtypes),
+        "transactions": (transactions_df, "id", "transaction_time", transactions_vtypes)
+    }
+    return entities
+
+
+@pytest.fixture
+def koalas_entities():
+    ks = pytest.importorskip('databricks.koalas', reason="Koalas not installed, skipping")
+    if sys.platform.startswith('win'):
+        pytest.skip('skipping Koalas tests for Windows')
+    cards_df = ks.DataFrame({"id": [1, 2, 3, 4, 5]})
+    transactions_df = ks.DataFrame({"id": [1, 2, 3, 4, 5, 6],
+                                    "card_id": [1, 2, 1, 3, 4, 5],
+                                    "transaction_time": [10, 12, 13, 20, 21, 20],
+                                    "fraud": [True, False, False, False, True, True]})
+    cards_vtypes = {
+        'id': vtypes.Index
+    }
+    transactions_vtypes = {
+        'id': vtypes.Index,
+        'card_id': vtypes.Id,
+        'transaction_time': vtypes.NumericTimeIndex,
+        'fraud': vtypes.Boolean
+    }
+
+    entities = {
+        "cards": (cards_df, "id", None, cards_vtypes),
+        "transactions": (transactions_df, "id", "transaction_time", transactions_vtypes)
+    }
+    return entities
+
+
+@pytest.fixture
+def relationships():
+    return [("cards", "id", "transactions", "card_id")]

--- a/featuretools/tests/synthesis/test_dfs_method.py
+++ b/featuretools/tests/synthesis/test_dfs_method.py
@@ -1,5 +1,3 @@
-import sys
-
 import composeml as cp
 import numpy as np
 import pandas as pd
@@ -7,7 +5,6 @@ import pytest
 from dask import dataframe as dd
 from distributed.utils_test import cluster
 
-from featuretools import variable_types as vtypes
 from featuretools.computational_backends.calculate_feature_matrix import (
     FEATURE_CALCULATION_PERCENTAGE
 )
@@ -28,84 +25,6 @@ from featuretools.utils.gen_utils import import_or_none
 from featuretools.variable_types import Numeric
 
 ks = import_or_none('databricks.koalas')
-
-
-@pytest.fixture(params=['pd_entities', 'dask_entities', 'koalas_entities'])
-def entities(request):
-    return request.getfixturevalue(request.param)
-
-
-@pytest.fixture
-def pd_entities():
-    cards_df = pd.DataFrame({"id": [1, 2, 3, 4, 5]})
-    transactions_df = pd.DataFrame({"id": [1, 2, 3, 4, 5, 6],
-                                    "card_id": [1, 2, 1, 3, 4, 5],
-                                    "transaction_time": [10, 12, 13, 20, 21, 20],
-                                    "fraud": [True, False, False, False, True, True]})
-    entities = {
-        "cards": (cards_df, "id"),
-        "transactions": (transactions_df, "id", "transaction_time")
-    }
-    return entities
-
-
-@pytest.fixture
-def dask_entities():
-    cards_df = pd.DataFrame({"id": [1, 2, 3, 4, 5]})
-    transactions_df = pd.DataFrame({"id": [1, 2, 3, 4, 5, 6],
-                                    "card_id": [1, 2, 1, 3, 4, 5],
-                                    "transaction_time": [10, 12, 13, 20, 21, 20],
-                                    "fraud": [True, False, False, False, True, True]})
-    cards_df = dd.from_pandas(cards_df, npartitions=2)
-    transactions_df = dd.from_pandas(transactions_df, npartitions=2)
-
-    cards_vtypes = {
-        'id': vtypes.Index
-    }
-    transactions_vtypes = {
-        'id': vtypes.Index,
-        'card_id': vtypes.Id,
-        'transaction_time': vtypes.NumericTimeIndex,
-        'fraud': vtypes.Boolean
-    }
-
-    entities = {
-        "cards": (cards_df, "id", None, cards_vtypes),
-        "transactions": (transactions_df, "id", "transaction_time", transactions_vtypes)
-    }
-    return entities
-
-
-@pytest.fixture
-def koalas_entities():
-    ks = pytest.importorskip('databricks.koalas', reason="Koalas not installed, skipping")
-    if sys.platform.startswith('win'):
-        pytest.skip('skipping Koalas tests for Windows')
-    cards_df = ks.DataFrame({"id": [1, 2, 3, 4, 5]})
-    transactions_df = ks.DataFrame({"id": [1, 2, 3, 4, 5, 6],
-                                    "card_id": [1, 2, 1, 3, 4, 5],
-                                    "transaction_time": [10, 12, 13, 20, 21, 20],
-                                    "fraud": [True, False, False, False, True, True]})
-    cards_vtypes = {
-        'id': vtypes.Index
-    }
-    transactions_vtypes = {
-        'id': vtypes.Index,
-        'card_id': vtypes.Id,
-        'transaction_time': vtypes.NumericTimeIndex,
-        'fraud': vtypes.Boolean
-    }
-
-    entities = {
-        "cards": (cards_df, "id", None, cards_vtypes),
-        "transactions": (transactions_df, "id", "transaction_time", transactions_vtypes)
-    }
-    return entities
-
-
-@pytest.fixture
-def relationships():
-    return [("cards", "id", "transactions", "card_id")]
 
 
 @pytest.fixture


### PR DESCRIPTION
Fixes #1287

Before, `calculate_feature_matrix` would  check that both`entities` and `relationships` were not `None` before creating an entityset with them, which required passing an empty iterable of relationships in order to work with a single entity.  This PR changes that by removing that check and relying on the `EntitySet` init method to handle valdiating the `entities` and `relationships`