### PR TITLE
Unpin graphviz on windows ci tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -244,7 +244,7 @@ jobs:
           . $env:USERPROFILE\Miniconda3\shell\condabin\conda-hook.ps1
           conda activate featuretools
           conda config --add channels conda-forge
-          conda install 'python-graphviz<0.16' -q -y
+          conda install python-graphviz -q -y
           python -m pip install --upgrade pip
           python -m pip install .
           python -m pip install -r test-requirements.txt

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -9,9 +9,10 @@ Release Notes
     * Documentation Changes
     * Testing Changes
         * Fix non-deterministic Dask test (:pr:`1294`)
+        * Unpin python-graphviz package on Windows (:pr:`1296`)
 
     Thanks to the following people for contributing to this release:
-    :user:`thehomebrewnerd`
+    :user:`rwedge`, :user:`thehomebrewnerd`
 
 **v0.23.0 Dec 31, 2020**
     * Fixes


### PR DESCRIPTION
Fixes #1289 
Unpin python-graphviz package on windows unit tests now that issue with latest release has been resolved