### PR TITLE
Fix broken docs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ customer_id                                                                     
 
 [5 rows x 69 columns]
 ```
-We now have a feature vector for each customer that can be used for machine learning. See the [documentation on Deep Feature Synthesis](https://docs.featuretools.com/en/stable/automated_feature_engineering/afe.html) for more examples.
+We now have a feature vector for each customer that can be used for machine learning. See the [documentation on Deep Feature Synthesis](https://featuretools.alteryx.com/en/stable/getting_started/afe.html) for more examples.
 
-Featuretools contains many [different types of built-in primitives](https://primitives.featurelabs.com/) for creating features. If the primitive you need is not included, Featuretools also allows you to [define your own custom primitives](https://docs.featuretools.com/en/stable/automated_feature_engineering/primitives.html#defining-custom-primitives).
+Featuretools contains many [different types of built-in primitives](https://primitives.featurelabs.com/) for creating features. If the primitive you need is not included, Featuretools also allows you to [define your own custom primitives](https://featuretools.alteryx.com/en/stable/getting_started/primitives.html#defining-custom-primitives).
 
 ## Demos
 **Predict Next Purchase**
@@ -95,7 +95,7 @@ For more examples of how to use Featuretools, check out our [demos](https://www.
 
 ## Testing & Development
 
-The Featuretools community welcomes pull requests. Instructions for testing and development are available [here.](https://docs.featuretools.com/en/stable/getting_started/install.html#development)
+The Featuretools community welcomes pull requests. Instructions for testing and development are available [here.](https://featuretools.alteryx.com/en/stable/install.html#development)
 
 ## Support
 The Featuretools community is happy to provide support to users of Featuretools. Project support can be found in four places depending on the type of question:

--- a/contributing.md
+++ b/contributing.md
@@ -18,7 +18,7 @@ There are many ways to contribute to Featuretools, with the most common ones bei
 5. [Report issues](#Report-issues) you're facing, and give a "thumbs up" on issues that others reported and that are relevant to you. Issues should be used for bugs, and feature requests only.
 
 6. Spread the word: reference Featuretools from your blog and articles, link to it from your website, or simply star it in GitHub to say "I use it".
-    * If you would like to be featured on [ecosystem page](https://docs.featuretools.com/en/stable/ecosystem.html), you can submit a [pull request](https://github.com/alteryx/featuretools).
+    * If you would like to be featured on [ecosystem page](https://featuretools.alteryx.com/en/stable/resources/ecosystem.html), you can submit a [pull request](https://github.com/alteryx/featuretools).
 
 ## Contributing to the Codebase
 

--- a/docs/issue_template.md
+++ b/docs/issue_template.md
@@ -2,7 +2,7 @@
 (replace this text with your issue)
 
 -----
-*Issues created here on Github are for bugs or feature requests. For usage questions and questions about errors, please ask on Stack Overflow with the [featuretools](https://stackoverflow.com/questions/tagged/featuretools) tag. Check the [documentation](https://docs.featuretools.com/en/stable/help.html) for further guidance on where to ask your question.*
+*Issues created here on Github are for bugs or feature requests. For usage questions and questions about errors, please ask on Stack Overflow with the [featuretools](https://stackoverflow.com/questions/tagged/featuretools) tag. Check the [documentation](https://featuretools.alteryx.com/en/stable/resources/help.html) for further guidance on where to ask your question.*
 
 
 #### Bug/Feature Request Description

--- a/docs/source/getting_started/variables.ipynb
+++ b/docs/source/getting_started/variables.ipynb
@@ -84,7 +84,7 @@
     "\n",
     "There are also more distinctions within the Categorical variable type. These include CountryCode, Id, SubRegionCode, and ZIPCode.\n",
     "\n",
-    "It is important to make this distinction because there are certain operations that can be applied, but they don't necessary apply to all Categorical types. For example, there could be a [custom primitive](https://docs.featuretools.com/en/stable/automated_feature_engineering/primitives.html#defining-custom-primitives) that applies to the ZIPCode variable type. It could extract the first 5 digits of a ZIPCode. However, this operation is not valid for all Categorical variable types. Therefore it is approriate to use the ZIPCode variable type. "
+    "It is important to make this distinction because there are certain operations that can be applied, but they don't necessary apply to all Categorical types. For example, there could be a [custom primitive](https://featuretools.alteryx.com/en/stable/getting_started/primitives.html#defining-custom-primitives) that applies to the ZIPCode variable type. It could extract the first 5 digits of a ZIPCode. However, this operation is not valid for all Categorical variable types. Therefore it is approriate to use the ZIPCode variable type. "
    ]
   },
   {
@@ -294,7 +294,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -25,6 +25,7 @@ Release Notes
         * Remove usage of ``ravel`` to resolve unexpected warning with pandas 1.2.0 (:pr:`1286`)
     * Documentation Changes
         * Fix installation command for Add-ons (:pr:`1279`)
+        * Fix various broken links in documentation (:pr:`1313`)
     * Testing Changes
         * Use repository-scoped token for dependency check (:pr:`1245`:, :pr:`1248`)
         * Fix install error during docs CI test (:pr:`1250`)

--- a/docs/source/templates/layout.html
+++ b/docs/source/templates/layout.html
@@ -9,7 +9,7 @@
 </script>
 
 
-{% set image = 'https://docs.featuretools.com/en/stable/_static/featuretools-open-graph-min.jpg' %}
+{% set image = 'https://featurelabs-static.s3.amazonaws.com/OpenSource_OpenGraph_1200x630px-featuretools.png' %}
 {% set description = 'Automated feature engineering in Python' %}
 {% if meta is defined %}
     {% if meta.description is defined %}

--- a/featuretools/computational_backends/utils.py
+++ b/featuretools/computational_backends/utils.py
@@ -191,7 +191,7 @@ def create_client_and_cluster(n_jobs, dask_kwargs, entityset_size):
             logger.warning("Worker memory is between 1 to 2 times the memory"
                            " size of the EntitySet. If errors occur that do"
                            " not occur with n_jobs equals 1, this may be the "
-                           "cause.  See https://docs.featuretools.com/en/stable/guides/parallel.html"
+                           "cause.  See https://featuretools.alteryx.com/en/stable/guides/performance.html#parallel-feature-computation"
                            " for more information.")
             warned_of_memory = True
 

--- a/featuretools/utils/plot_utils.py
+++ b/featuretools/utils/plot_utils.py
@@ -3,7 +3,7 @@ from featuretools.utils.gen_utils import import_or_raise
 
 def check_graphviz():
     GRAPHVIZ_ERR_MSG = ('Please install graphviz to plot.' +
-                        ' (See https://docs.featuretools.com/en/stable/getting_started/install.html#installing-graphviz for' +
+                        ' (See https://featuretools.alteryx.com/en/stable/install.html#installing-graphviz for' +
                         ' details)')
     graphviz = import_or_raise("graphviz", GRAPHVIZ_ERR_MSG)
     # Try rendering a dummy graph to see if a working backend is installed
@@ -16,7 +16,7 @@ def check_graphviz():
             "  Mac OS: brew install graphviz\n" +
             "  Linux (Ubuntu): sudo apt-get install graphviz\n" +
             "  Windows: conda install python-graphviz\n" +
-            "  For more details visit: https://docs.featuretools.com/en/stable/getting_started/install.html"
+            "  For more details visit: https://featuretools.alteryx.com/en/stable/install.html#installing-graphviz"
         )
     return graphviz
 


### PR DESCRIPTION
### Fix broken docs links
Several links in the documentation and code were still linking to `docs.featuretools.com`. Updated these links to point to the corresponding file in the new documentation at `featuretools.alteryx.com`.

Closes #1299 