### PR TITLE
Remove unnecessary `pytest.skip` calls

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -11,6 +11,7 @@ Release Notes
         * Unpin python-graphviz package on Windows (:pr:`1296`)
         * Reorganize and clean up tests (:pr:`1294`, :pr:`1303`, :pr:`1306`)
         * Trigger tests on pull request events (:pr:`1304`, :pr:`1315`)
+        * Remove unnecessary test skips on Windows (:pr:`1320`)
 
     Thanks to the following people for contributing to this release:
     :user:`jeff-hernandez`, :user:`rwedge`, :user:`thehomebrewnerd`

--- a/featuretools/tests/computational_backend/test_feature_set_calculator.py
+++ b/featuretools/tests/computational_backend/test_feature_set_calculator.py
@@ -1,4 +1,3 @@
-import sys
 from datetime import datetime
 
 import numpy as np
@@ -439,8 +438,6 @@ def dd_df(pd_df):
 @pytest.fixture
 def ks_df(pd_df):
     ks = pytest.importorskip('databricks.koalas', reason="Koalas not installed, skipping")
-    if sys.platform.startswith('win'):
-        pytest.skip('skipping Koalas tests for Windows')
     return ks.from_pandas(pd_df)
 
 
@@ -749,8 +746,6 @@ def dd_parent_child(pd_parent_child):
 @pytest.fixture
 def ks_parent_child(pd_parent_child):
     ks = pytest.importorskip('databricks.koalas', reason="Koalas not installed, skipping")
-    if sys.platform.startswith('win'):
-        pytest.skip('skipping Koalas tests for Windows')
     parent_df, child_df = pd_parent_child
     parent_df = ks.from_pandas(parent_df)
     child_df = ks.from_pandas(child_df)

--- a/featuretools/tests/conftest.py
+++ b/featuretools/tests/conftest.py
@@ -1,5 +1,4 @@
 import copy
-import sys
 
 import composeml as cp
 import dask.dataframe as dd
@@ -60,8 +59,6 @@ def dask_es(make_es):
 @pytest.fixture
 def ks_es(make_es):
     ks = pytest.importorskip('databricks.koalas', reason="Koalas not installed, skipping")
-    if sys.platform.startswith('win'):
-        pytest.skip('skipping Koalas tests for Windows')
     ks_es = copy.deepcopy(make_es)
     for entity in ks_es.entities:
         cleaned_df = pd_to_ks_clean(entity.df).reset_index(drop=True)
@@ -143,8 +140,6 @@ def dask_diamond_es(pd_diamond_es):
 @pytest.fixture
 def ks_diamond_es(pd_diamond_es):
     ks = pytest.importorskip('databricks.koalas', reason="Koalas not installed, skipping")
-    if sys.platform.startswith('win'):
-        pytest.skip('skipping Koalas tests for Windows')
     entities = {}
     for entity in pd_diamond_es.entities:
         entities[entity.id] = (ks.from_pandas(pd_to_ks_clean(entity.df)), entity.index, None, entity.variable_types)
@@ -198,8 +193,6 @@ def dask_home_games_es(pd_home_games_es):
 @pytest.fixture
 def ks_home_games_es(pd_home_games_es):
     ks = pytest.importorskip('databricks.koalas', reason="Koalas not installed, skipping")
-    if sys.platform.startswith('win'):
-        pytest.skip('skipping Koalas tests for Windows')
     entities = {}
     for entity in pd_home_games_es.entities:
         entities[entity.id] = (ks.from_pandas(pd_to_ks_clean(entity.df)), entity.index, None, entity.variable_types)
@@ -235,8 +228,6 @@ def dd_mock_customer(pd_mock_customer):
 @pytest.fixture
 def ks_mock_customer(pd_mock_customer):
     ks = pytest.importorskip('databricks.koalas', reason="Koalas not installed, skipping")
-    if sys.platform.startswith('win'):
-        pytest.skip('skipping Koalas tests for Windows')
     ks_mock_customer = copy.deepcopy(pd_mock_customer)
     for entity in ks_mock_customer.entities:
         cleaned_df = pd_to_ks_clean(entity.df).reset_index(drop=True)
@@ -320,8 +311,6 @@ def dask_entities():
 @pytest.fixture
 def koalas_entities():
     ks = pytest.importorskip('databricks.koalas', reason="Koalas not installed, skipping")
-    if sys.platform.startswith('win'):
-        pytest.skip('skipping Koalas tests for Windows')
     cards_df = ks.DataFrame({"id": [1, 2, 3, 4, 5]})
     transactions_df = ks.DataFrame({"id": [1, 2, 3, 4, 5, 6],
                                     "card_id": [1, 2, 1, 3, 4, 5],

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -516,7 +516,6 @@ def dd_datetime2(pd_datetime2):
 @pytest.fixture
 def ks_datetime2(pd_datetime2):
     ks = pytest.importorskip('databricks.koalas', reason="Koalas not installed, skipping")
-
     return ks.from_pandas(pd_datetime2)
 
 

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -1,5 +1,4 @@
 import copy
-import sys
 from datetime import datetime
 
 import dask.dataframe as dd
@@ -219,8 +218,6 @@ def dd_df(pd_df):
 @pytest.fixture
 def ks_df(pd_df):
     ks = pytest.importorskip('databricks.koalas', reason="Koalas not installed, skipping")
-    if sys.platform.startswith('win'):
-        pytest.skip('skipping Koalas tests for Windows')
     return ks.from_pandas(pd_df)
 
 
@@ -286,8 +283,6 @@ def dd_df2(pd_df2):
 @pytest.fixture
 def ks_df2(pd_df2):
     ks = pytest.importorskip('databricks.koalas', reason="Koalas not installed, skipping")
-    if sys.platform.startswith('win'):
-        pytest.skip('skipping Koalas tests for Windows')
     return ks.from_pandas(pd_df2)
 
 
@@ -322,8 +317,6 @@ def dd_df3(pd_df3):
 @pytest.fixture
 def ks_df3(pd_df3):
     ks = pytest.importorskip('databricks.koalas', reason="Koalas not installed, skipping")
-    if sys.platform.startswith('win'):
-        pytest.skip('skipping Koalas tests for Windows')
     return ks.from_pandas(pd_df3)
 
 
@@ -384,8 +377,6 @@ def dd_df4(pd_df4):
 @pytest.fixture
 def ks_df4(pd_df4):
     ks = pytest.importorskip('databricks.koalas', reason="Koalas not installed, skipping")
-    if sys.platform.startswith('win'):
-        pytest.skip('skipping Koalas tests for Windows')
     return ks.from_pandas(pd_to_ks_clean(pd_df4))
 
 
@@ -481,8 +472,6 @@ def dd_datetime1(pd_datetime1):
 @pytest.fixture
 def ks_datetime1(pd_datetime1):
     ks = pytest.importorskip('databricks.koalas', reason="Koalas not installed, skipping")
-    if sys.platform.startswith('win'):
-        pytest.skip('skipping Koalas tests for Windows')
     return ks.from_pandas(pd_datetime1)
 
 
@@ -527,8 +516,7 @@ def dd_datetime2(pd_datetime2):
 @pytest.fixture
 def ks_datetime2(pd_datetime2):
     ks = pytest.importorskip('databricks.koalas', reason="Koalas not installed, skipping")
-    if sys.platform.startswith('win'):
-        pytest.skip('skipping Koalas tests for Windows')
+
     return ks.from_pandas(pd_datetime2)
 
 
@@ -787,8 +775,6 @@ def dd_transactions_df(pd_transactions_df):
 @pytest.fixture
 def ks_transactions_df(pd_transactions_df):
     ks = pytest.importorskip('databricks.koalas', reason="Koalas not installed, skipping")
-    if sys.platform.startswith('win'):
-        pytest.skip('skipping Koalas tests for Windows')
     return ks.from_pandas(pd_transactions_df)
 
 
@@ -1227,8 +1213,6 @@ def dd_datetime3(pd_datetime3):
 @pytest.fixture
 def ks_datetime3(pd_datetime3):
     ks = pytest.importorskip('databricks.koalas', reason="Koalas not installed, skipping")
-    if sys.platform.startswith('win'):
-        pytest.skip('skipping Koalas tests for Windows')
     return ks.from_pandas(pd_datetime3)
 
 
@@ -1277,8 +1261,6 @@ def dd_index_df(pd_index_df):
 @pytest.fixture
 def ks_index_df(pd_index_df):
     ks = pytest.importorskip('databricks.koalas', reason="Koalas not installed, skipping")
-    if sys.platform.startswith('win'):
-        pytest.skip('skipping Koalas tests for Windows')
     return ks.from_pandas(pd_index_df)
 
 

--- a/featuretools/tests/entityset_tests/test_es_metadata.py
+++ b/featuretools/tests/entityset_tests/test_es_metadata.py
@@ -1,5 +1,3 @@
-import sys
-
 import pandas as pd
 import pytest
 from dask import dataframe as dd
@@ -150,8 +148,6 @@ def dd_employee_df(pd_employee_df):
 @pytest.fixture
 def ks_employee_df(pd_employee_df):
     ks = pytest.importorskip('databricks.koalas', reason="Koalas not installed, skipping")
-    if sys.platform.startswith('win'):
-        pytest.skip('skipping Koalas tests for Windows')
     return ks.from_pandas(pd_employee_df)
 
 

--- a/featuretools/tests/entityset_tests/test_plotting.py
+++ b/featuretools/tests/entityset_tests/test_plotting.py
@@ -1,6 +1,5 @@
 import os
 import re
-import sys
 
 import graphviz
 import pandas as pd
@@ -30,8 +29,6 @@ def dd_simple():
 @pytest.fixture
 def ks_simple():
     ks = pytest.importorskip('databricks.koalas', reason="Koalas not installed, skipping")
-    if sys.platform.startswith('win'):
-        pytest.skip('skipping Koalas tests for Windows')
     es = ft.EntitySet("test")
     df = ks.DataFrame({'foo': [1]})
     es.entity_from_dataframe('test', df)

--- a/featuretools/tests/synthesis/test_deep_feature_synthesis.py
+++ b/featuretools/tests/synthesis/test_deep_feature_synthesis.py
@@ -1,5 +1,4 @@
 import copy
-import sys
 
 import dask.dataframe as dd
 import pandas as pd
@@ -85,8 +84,6 @@ def dask_transform_es(pd_transform_es):
 @pytest.fixture
 def koalas_transform_es(pd_transform_es):
     ks = pytest.importorskip('databricks.koalas', reason="Koalas not installed, skipping")
-    if sys.platform.startswith('win'):
-        pytest.skip('skipping Koalas tests for Windows')
     es = ft.EntitySet(id=pd_transform_es.id)
     for entity in pd_transform_es.entities:
         es.entity_from_dataframe(entity_id=entity.id,


### PR DESCRIPTION
### Remove unnecessary `pytest.skip` calls

Removes multiple unnecessary calls to pytest.skip which was being used to skip Koalas tests on Windows. However, the current test environment is not installing Windows, so the tests were being skipped anyway due to a `pytest.importorskip` call that is in place.