### PR TITLE
Fix Entityset.__eq__ bug and test coverage

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -6,7 +6,7 @@ Release Notes
     * Enhancements
     * Fixes
         * Calculate direct features uses default value if parent missing (:pr:`1312`)
-        * Fix bug in ``EntitySet.__eq__`` (:pr:`1323`)
+        * Fix bug and improve tests for ``EntitySet.__eq__`` and ``Entity.__eq__`` (:pr:`1323`)
     * Changes
     * Documentation Changes
         * Update Twitter link to documentation toolbar (:pr:`1322`)

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -5,6 +5,7 @@ Release Notes
 **Future Release**
     * Enhancements
     * Fixes
+        * Fix bug in ``EntitySet.__eq__`` (:pr:`1323`)
     * Changes
     * Documentation Changes
     * Testing Changes

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -117,7 +117,7 @@ class EntitySet(object):
                 return False
             if not e.__eq__(other[eid], deep=deep):
                 return False
-        for r in other.relationships:
+        for r in self.relationships:
             if r not in other.relationships:
                 return False
         return True

--- a/featuretools/tests/entityset_tests/test_entity.py
+++ b/featuretools/tests/entityset_tests/test_entity.py
@@ -49,13 +49,13 @@ def test_eq(es):
     assert es['log'].__eq__(es['log'], deep=True)
     assert es['log'].__eq__(other_es['log'], deep=True)
     assert all(to_pandas(es['log'].df['latlong']).eq(to_pandas(latlong)))
-    
+
     # Test different index
     other_es['log'].index = None
     assert not es['log'].__eq__(other_es['log'])
     other_es['log'].index = 'id'
     assert es['log'].__eq__(other_es['log'])
-    
+
     # Test different time index
     other_es['log'].time_index = None
     assert not es['log'].__eq__(other_es['log'])

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -1407,3 +1407,41 @@ def test_entityset_init():
     es_copy.add_relationship(relationship)
     assert es['cards'].__eq__(es_copy['cards'], deep=True)
     assert es['transactions'].__eq__(es_copy['transactions'], deep=True)
+
+
+def test_entityset_equality(es):
+    first_es = EntitySet()
+    second_es = EntitySet()
+    assert first_es == second_es
+    
+    first_es.entity_from_dataframe(entity_id='customers',
+                                   dataframe=es['customers'].df,
+                                   index='id',
+                                   time_index='signup_date',
+                                   variable_types=es['customers'].variable_types)
+    assert first_es != second_es
+
+    second_es.entity_from_dataframe(entity_id='sessions',
+                                    dataframe=es['sessions'].df,
+                                    index='id',
+                                    variable_types=es['sessions'].variable_types)
+    assert first_es != second_es
+
+    first_es.entity_from_dataframe(entity_id='sessions',
+                                   dataframe=es['sessions'].df,
+                                   index='id',
+                                   variable_types=es['sessions'].variable_types)
+    second_es.entity_from_dataframe(entity_id='customers',
+                                    dataframe=es['customers'].df,
+                                    index='id',
+                                    time_index='signup_date',
+                                    variable_types=es['customers'].variable_types)
+    assert first_es == second_es
+
+    first_es.add_relationship(ft.Relationship(es['customers']['id'], es['sessions']['customer_id']))
+    assert first_es != second_es
+
+    second_es.add_relationship(ft.Relationship(es['customers']['id'], es['sessions']['customer_id']))
+    assert first_es == second_es
+
+

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -1413,7 +1413,7 @@ def test_entityset_equality(es):
     first_es = EntitySet()
     second_es = EntitySet()
     assert first_es == second_es
-    
+
     first_es.entity_from_dataframe(entity_id='customers',
                                    dataframe=es['customers'].df,
                                    index='id',
@@ -1443,5 +1443,3 @@ def test_entityset_equality(es):
 
     second_es.add_relationship(ft.Relationship(es['customers']['id'], es['sessions']['customer_id']))
     assert first_es == second_es
-
-


### PR DESCRIPTION
### Fix `EntitySet.__eq__` bug and test coverage

Fixes #1281 

Fixes a bug in `EntitySet.__eq__` where relationships were not being compared properly between `self` and `other`. Also adds a new test to cover lines in `__eq__` and `__ne__` that were previously uncovered