### PR TITLE
[v0.9.1] fix performance bottleneck

### DIFF
--- a/featuretools/computational_backends/calculate_feature_matrix.py
+++ b/featuretools/computational_backends/calculate_feature_matrix.py
@@ -1,6 +1,5 @@
 from __future__ import division
 
-import gc
 import logging
 import os
 import shutil
@@ -497,9 +496,7 @@ def linear_calculate_chunks(chunks, feature_set, approximate, training_window,
                                           cutoff_df_time_var,
                                           target_time, pass_columns)
         feature_matrix.append(_feature_matrix)
-        # Do a manual garbage collection in case objects from calculate_chunk
-        # weren't collected automatically
-        gc.collect()
+
     if verbose:
         chunks.close()
     return feature_matrix


### PR DESCRIPTION
### Pull Request Description

When calculating feature matrix, FeatureTools v0.9.1 would diligently run manual garbage collection, this adds significant latency as seen in the diagram below.

![image](https://user-images.githubusercontent.com/20734828/106334783-37e33c00-6240-11eb-9278-f4032d607cad.png)


Although by upgrading could we avoid this performance issue since later versions have removed manual GC, it is not always feasible, for example: 

* Project A depends on library S and Featuretools, S requires pandas to be <= 0.23.4, where Featuretools v0.9.1 can meet that criteria.
* When try to upgrade Featuretools, in order to avoid the incompatible dependency issue, only v0.10.0 and v0.11.0 can be candidates, because versions >= 0.11.0 require pandas >= 0.24.1.
* However, v0.10.0 and v0.11.0 have a bug that causes features not JSON serializable (this bug is fixed in later version), thus, no candidate version is available.

To deal with situations like this, it would be great if v0.9.1 could remove manual GC.
