### PR TITLE
Add warning about dropping python 3.6 in the future

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,10 +3,14 @@
 Release Notes
 -------------
 **Future Release**
+    .. warning::
+        The next non-bugfix release of Featuretools will not support Python 3.6
+
     * Enhancements
     * Fixes
         * Restrict numpy version when installing koalas (:pr:`1329`)
     * Changes
+        * Warn python 3.6 users suppport will be dropped in future release (:pr:`1344`)
     * Documentation Changes
         * Update docs for defining custom primitives (:pr:`1332`)
     * Testing Changes

--- a/featuretools/__init__.py
+++ b/featuretools/__init__.py
@@ -31,6 +31,7 @@ import logging
 import pkg_resources
 import sys
 import traceback
+import warnings
 
 logger = logging.getLogger('featuretools')
 
@@ -52,3 +53,9 @@ for entry_point in pkg_resources.iter_entry_points('featuretools_plugin'):
         message += "For a full stack trace, set logging to debug."
         logger.warning(message.format(entry_point.name, entry_point.module_name))
         logger.debug(traceback.format_exc())
+
+if sys.version_info.major == 3 and sys.version_info.minor == 6:
+    warnings.warn(
+        "The next non-bugfix release of Featuretools will not support Python 3.6",
+        FutureWarning
+    )


### PR DESCRIPTION
When featuretools is imported, checks to see if the environment is python 3.6.  If so, warns that Featuretools will be dropping python 3.6 support in an upcoming release.
