### PR TITLE
Restrict smart-open version

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -7,6 +7,7 @@ Release Notes
     * Fixes
     * Changes
         * Minor updates to work with Koalas version 1.7.0 (:pr:`1351`)
+        * Restrict smart-open version to <5.0.0 (:pr:`1372`)
     * Documentation Changes
     * Testing Changes
          * Make release notes updated check separate from unit tests (:pr:`1347`)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,7 +6,7 @@ pytest-cov==2.6.1
 fastparquet>=0.1.6
 graphviz>=0.8.4
 moto[all]>=1.3.15
-smart-open>=1.8.4
+smart-open>=1.8.4,<5.0.0
 boto3>=1.10.45
 composeml>=0.2.0
 urllib3>=1.25.10,<1.26


### PR DESCRIPTION
### Restrict smart-open version
Some serialization test fail with the new smart-open version 5.0.0. This PR restricts smart-open to `<5.0.0` while this is being investigated.