### PR TITLE
disable fail-fast behavior on CI tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,7 @@ jobs:
     name: ${{ matrix.python_version }} build docs
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python_version: ["3.6", "3.7", "3.8"]
     steps:
@@ -43,6 +44,7 @@ jobs:
     name: ${{ matrix.python_version }} install featuretools complete
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python_version: ["3.6", "3.7", "3.8"]        
     steps:
@@ -74,6 +76,7 @@ jobs:
     name: ${{ matrix.python_version }} lint test
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python_version: ["3.6", "3.7", "3.8"]        
     steps:
@@ -102,7 +105,7 @@ jobs:
     name: ${{ matrix.python_version }} unit tests ${{ matrix.optional_libraries }}
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         python_version: ["3.6", "3.7", "3.8"]
         optional_libraries: ["minimal", "optional"]
@@ -158,7 +161,7 @@ jobs:
     name: ${{ matrix.python_version }} windows unit tests
     runs-on: windows-latest
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         python_version: ["3.6", "3.7", "3.8"]
     steps:

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -9,9 +9,10 @@ Release Notes
         * Add auto assign bot on GitHub (:pr:`1380`)
     * Documentation Changes
     * Testing Changes
+        * Don't cancel other CI jobs if one fails (:pr:`1386`)
 
     Thanks to the following people for contributing to this release:
-    :user:`gsheni`
+    :user:`gsheni`, :user:`rwedge`
 
 **v0.23.3 Mar 31, 2021**
     .. warning::


### PR DESCRIPTION
Disable the fail-fast strategy on our unit tests, which is cancelling jobs if a job in the same test matrix has failed (currently if the py38 optional unit tests fail, the py37 and py36 optionals will be cancelled).  I'd prefer to have the tests continue to so we'll know if there are issues with the other environments we're testing on.