### PR TITLE
Don't pass EntitySet to Relationship on init

### DIFF
--- a/featuretools/entityset/deserialize.py
+++ b/featuretools/entityset/deserialize.py
@@ -98,7 +98,7 @@ def description_to_entityset(description, **kwargs):
             last_time_index.append(entity['id'])
 
     for relationship in description['relationships']:
-        rel = Relationship.from_dictionary(relationship, entityset)
+        rel = Relationship.from_dictionary(relationship)
         entityset.add_relationship(relationship=rel)
 
     if len(last_time_index):

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -268,17 +268,20 @@ class EntitySet(object):
             raise ValueError("Cannot specify dataframe and column id values and also supply a Relationship")
 
         if not relationship:
-            relationship = Relationship(self,
-                                        parent_dataframe_id,
+            relationship = Relationship(parent_dataframe_id,
                                         parent_column_id,
                                         child_dataframe_id,
                                         child_column_id)
+        relationship.entityset = self
         if relationship in self.relationships:
             warnings.warn(
                 "Not adding duplicate relationship: " + str(relationship))
             return self
 
-        # _operations?
+        if (relationship.parent_entity.index is not None and
+                relationship._parent_column_id != relationship.parent_entity.index):
+            raise AttributeError(f"Parent variable '{relationship.parent_variable}' is not the index of "
+                                 f"entity {relationship.parent_entity}")
 
         # this is a new pair of entities
         child_e = relationship.child_entity

--- a/featuretools/entityset/relationship.py
+++ b/featuretools/entityset/relationship.py
@@ -5,36 +5,30 @@ class Relationship(object):
         :class:`.EntitySet`, :class:`.Entity`
     """
 
-    def __init__(self, entityset, parent_dataframe_id, parent_column_id,
+    def __init__(self, parent_dataframe_id, parent_column_id,
                  child_dataframe_id, child_column_id):
         """ Create a relationship
 
         Args:
-            entityset (:class:`.EntitySet`): EntitySet to which the relationship belongs
             parent_dataframe_id (str): Name of the parent dataframe in the EntitySet
             parent_column_id (str): Name of the parent column
             child_dataframe_id (str): Name of the child dataframe in the EntitySet
             child_column_id (str): Name of the child column
         """
 
-        self.entityset = entityset
+        self.entityset = None
         self._parent_dataframe_id = parent_dataframe_id
         self._child_dataframe_id = child_dataframe_id
         self._parent_column_id = parent_column_id
         self._child_column_id = child_column_id
 
-        if (self.parent_entity.index is not None and
-                self._parent_column_id != self.parent_entity.index):
-            raise AttributeError(f"Parent variable '{self.parent_variable}' is not the index of "
-                                 f"entity {self.parent_entity}")
-
     @classmethod
-    def from_dictionary(cls, arguments, es):
+    def from_dictionary(cls, arguments):
         parent_entity = arguments['parent_dataframe_id']
         child_entity = arguments['child_dataframe_id']
         parent_variable = arguments['parent_column_id']
         child_variable = arguments['child_column_id']
-        return cls(es, parent_entity, parent_variable, child_entity, child_variable)
+        return cls(parent_entity, parent_variable, child_entity, child_variable)
 
     def __repr__(self):
         ret = u"<Relationship: %s.%s -> %s.%s>" % \
@@ -127,19 +121,19 @@ class RelationshipPath(object):
 
     def entities(self):
         if self:
-            # Yield first entity.
+            # Yield first dataframe.
             is_forward, relationship = self[0]
             if is_forward:
-                yield relationship.child_entity.id
+                yield relationship._child_dataframe_id
             else:
-                yield relationship.parent_entity.id
+                yield relationship._parent_dataframe_id
 
-        # Yield the entity pointed to by each relationship.
+        # Yield the dataframe pointed to by each relationship.
         for is_forward, relationship in self:
             if is_forward:
-                yield relationship.parent_entity.id
+                yield relationship._parent_dataframe_id
             else:
-                yield relationship.child_entity.id
+                yield relationship._child_dataframe_id
 
     def __add__(self, other):
         return RelationshipPath(self._relationships_with_direction +

--- a/featuretools/entityset/relationship.py
+++ b/featuretools/entityset/relationship.py
@@ -121,19 +121,19 @@ class RelationshipPath(object):
 
     def entities(self):
         if self:
-            # Yield first dataframe.
+            # Yield first entity.
             is_forward, relationship = self[0]
             if is_forward:
-                yield relationship._child_dataframe_id
+                yield relationship.child_entity.id
             else:
-                yield relationship._parent_dataframe_id
+                yield relationship.parent_entity.id
 
-        # Yield the dataframe pointed to by each relationship.
+        # Yield the entity pointed to by each relationship.
         for is_forward, relationship in self:
             if is_forward:
-                yield relationship._parent_dataframe_id
+                yield relationship.parent_entity.id
             else:
-                yield relationship._child_dataframe_id
+                yield relationship.child_entity.id
 
     def __add__(self, other):
         return RelationshipPath(self._relationships_with_direction +

--- a/featuretools/feature_base/feature_base.py
+++ b/featuretools/feature_base/feature_base.py
@@ -429,7 +429,8 @@ class DirectFeature(FeatureBase):
     @classmethod
     def from_dictionary(cls, arguments, entityset, dependencies, primitives_deserializer):
         base_feature = dependencies[arguments['base_feature']]
-        relationship = Relationship.from_dictionary(arguments['relationship'], entityset)
+        relationship = Relationship.from_dictionary(arguments['relationship'])
+        relationship.entityset = entityset
         child_entity = relationship.child_entity
         return cls(base_feature=base_feature,
                    child_entity=child_entity,
@@ -568,8 +569,10 @@ class AggregationFeature(FeatureBase):
     @classmethod
     def from_dictionary(cls, arguments, entityset, dependencies, primitives_deserializer):
         base_features = [dependencies[name] for name in arguments['base_features']]
-        relationship_path = [Relationship.from_dictionary(r, entityset)
+        relationship_path = [Relationship.from_dictionary(r)
                              for r in arguments['relationship_path']]
+        for rel in relationship_path:
+            rel.entityset = entityset
         parent_entity = relationship_path[0].parent_entity
         relationship_path = RelationshipPath([(False, r) for r in relationship_path])
 

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -100,7 +100,8 @@ def test_add_relationship_errors_child_v_index(es):
 
 
 def test_add_relationship_empty_child_convert_dtype(es):
-    relationship = ft.Relationship(es, "sessions", "id", "log", "session_id")
+    relationship = ft.Relationship("sessions", "id", "log", "session_id")
+    es.add_relationship(relationship=relationship)
     es['log'].df = pd.DataFrame(columns=es['log'].df.columns)
     assert len(es['log'].df) == 0
     assert es['log'].df['session_id'].dtype == 'object'
@@ -113,19 +114,19 @@ def test_add_relationship_empty_child_convert_dtype(es):
 
 
 def test_add_relationship_with_relationship_object(es):
-    relationship = ft.Relationship(es, "sessions", "id", "log", "session_id")
+    relationship = ft.Relationship("sessions", "id", "log", "session_id")
     es.add_relationship(relationship=relationship)
     assert relationship in es.relationships
 
 
 def test_add_relationships_with_relationship_object(es):
-    relationships = [ft.Relationship(es, "sessions", "id", "log", "session_id")]
+    relationships = [ft.Relationship("sessions", "id", "log", "session_id")]
     es.add_relationships(relationships)
     assert relationships[0] in es.relationships
 
 
 def test_add_relationship_error(es):
-    relationship = ft.Relationship(es, "sessions", "id", "log", "session_id")
+    relationship = ft.Relationship("sessions", "id", "log", "session_id")
     error_message = "Cannot specify dataframe and column id values and also supply a Relationship"
     with pytest.raises(ValueError, match=error_message):
         es.add_relationship(parent_dataframe_id="sessions", relationship=relationship)

--- a/featuretools/tests/entityset_tests/test_relationship.py
+++ b/featuretools/tests/entityset_tests/test_relationship.py
@@ -2,8 +2,9 @@ from featuretools.entityset.relationship import Relationship, RelationshipPath
 
 
 def test_relationship_path(es):
-    log_to_sessions = Relationship(es, 'sessions', 'id', 'log', 'session_id')
-    sessions_to_customers = Relationship(es, 'customers', 'id', 'sessions', 'customer_id')
+    log_to_sessions = Relationship('sessions', 'id', 'log', 'session_id')
+    sessions_to_customers = Relationship('customers', 'id', 'sessions', 'customer_id')
+    es.add_relationships([log_to_sessions, sessions_to_customers])
     path_list = [(True, log_to_sessions),
                  (True, sessions_to_customers),
                  (False, sessions_to_customers)]
@@ -18,8 +19,9 @@ def test_relationship_path(es):
 def test_relationship_path_name(es):
     assert RelationshipPath([]).name == ''
 
-    log_to_sessions = Relationship(es, 'sessions', 'id', 'log', 'session_id')
-    sessions_to_customers = Relationship(es, 'customers', 'id', 'sessions', 'customer_id')
+    log_to_sessions = Relationship('sessions', 'id', 'log', 'session_id')
+    sessions_to_customers = Relationship('customers', 'id', 'sessions', 'customer_id')
+    es.add_relationships([log_to_sessions, sessions_to_customers])
 
     forward_path = [(True, log_to_sessions), (True, sessions_to_customers)]
     assert RelationshipPath(forward_path).name == 'sessions.customers'
@@ -34,8 +36,9 @@ def test_relationship_path_name(es):
 def test_relationship_path_entities(es):
     assert list(RelationshipPath([]).entities()) == []
 
-    log_to_sessions = Relationship(es, 'sessions', 'id', 'log', 'session_id')
-    sessions_to_customers = Relationship(es, 'customers', 'id', 'sessions', 'customer_id')
+    log_to_sessions = Relationship('sessions', 'id', 'log', 'session_id')
+    sessions_to_customers = Relationship('customers', 'id', 'sessions', 'customer_id')
+    es.add_relationships([log_to_sessions, sessions_to_customers])
 
     forward_path = [(True, log_to_sessions), (True, sessions_to_customers)]
     assert list(RelationshipPath(forward_path).entities()) == ['log', 'sessions', 'customers']
@@ -48,19 +51,22 @@ def test_relationship_path_entities(es):
 
 
 def test_names_when_multiple_relationships_between_entities(games_es):
-    relationship = Relationship(games_es, 'teams', 'id', 'games', 'home_team_id')
+    relationship = Relationship('teams', 'id', 'games', 'home_team_id')
+    games_es.add_relationship(relationship=relationship)
     assert relationship.child_name == 'games[home_team_id]'
     assert relationship.parent_name == 'teams[home_team_id]'
 
 
 def test_names_when_no_other_relationship_between_entities(home_games_es):
-    relationship = Relationship(home_games_es, 'teams', 'id', 'games', 'home_team_id')
+    relationship = Relationship('teams', 'id', 'games', 'home_team_id')
+    home_games_es.add_relationship(relationship=relationship)
     assert relationship.child_name == 'games'
     assert relationship.parent_name == 'teams'
 
 
 def test_relationship_serialization(es):
-    relationship = Relationship(es, 'sessions', 'id', 'log', 'session_id')
+    relationship = Relationship('sessions', 'id', 'log', 'session_id')
+    es.add_relationship(relationship=relationship)
 
     dictionary = {
         'parent_dataframe_id': 'sessions',
@@ -69,4 +75,4 @@ def test_relationship_serialization(es):
         'child_column_id': 'session_id',
     }
     assert relationship.to_dictionary() == dictionary
-    assert Relationship.from_dictionary(dictionary, es) == relationship
+    assert Relationship.from_dictionary(dictionary) == relationship


### PR DESCRIPTION
### Don't pass EntitySet to Relationship on init
This PR implements changes that would be needed if we did not pass an entityset to a relationship on init.