### PR TITLE
Move default variable description logic to generate_description

### DIFF
--- a/featuretools/feature_base/feature_descriptions.py
+++ b/featuretools/feature_base/feature_descriptions.py
@@ -39,7 +39,10 @@ def generate_description(feature, feature_descriptions, primitive_templates):
 
     # Check if identity feature:
     if isinstance(feature, ft.IdentityFeature):
-        return feature.variable.description
+        description = feature.variable.description
+        if description is None:
+            description = 'the "{}"'.format(feature.variable.name)
+        return description
 
     # Handle direct features
     if isinstance(feature, ft.DirectFeature):

--- a/featuretools/variable_types/variable.py
+++ b/featuretools/variable_types/variable.py
@@ -100,7 +100,7 @@ class Variable(object):
 
     @property
     def description(self):
-        return self._description if self._description is not None else 'the "{}"'.format(self.name)
+        return self._description
 
     @description.setter
     def description(self, description):


### PR DESCRIPTION
Since `ColumnAccessor.description` defaults to `None`, updated `generate_description` to expect `None` as the default.  The `None` to default string conversion now happens inside `generate_description` instead of on `Variable`