### PR TITLE
Use builtin secret token with create pull request

### DIFF
--- a/.github/workflows/dependency_check.yml
+++ b/.github/workflows/dependency_check.yml
@@ -22,6 +22,7 @@ jobs:
     - name: Create Pull Request
       uses: FeatureLabs/create-pull-request@v3
       with:
+        token: ${{ secrets.GITHUB_TOKEN }}
         commit-message: Update latest_dependencies.txt
         title: Automated Update to latest_dependencies.txt
         author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -15,7 +15,7 @@ Future Release
         * Update Spark config in test fixtures and docs (:pr:`1387`, :pr:`1389`)
         * Don't cancel other CI jobs if one fails (:pr:`1386`)
         * Update boto3 and urllib3 version requirements (:pr:`1394`)
-        * Change from GitHub PAT to auto generated GitHub Token for dependency checker (:pr:`1402`)
+        * Change from GitHub PAT to auto generated GitHub Token for dependency checker (:pr:`1402`, :pr:`1407`)
         
     Thanks to the following people for contributing to this release:
     :user:`gsheni`, :user:`rwedge`, :user:`thehomebrewnerd`


### PR DESCRIPTION
We tried deleting the `token` attribute entirely but the PR put up by dependency bot isn't running the CI tests for the PR.  Passing in the github token secret instead.