### PR TITLE
Lower max depth to 1 if single entity

### DIFF
--- a/docs/source/guides/using_dask_entitysets.rst
+++ b/docs/source/guides/using_dask_entitysets.rst
@@ -49,7 +49,8 @@ We can pass the ``EntitySet`` we created above to ``featuretools.dfs`` in order 
 
     feature_matrix, features = ft.dfs(entityset=es,
                                       target_entity="dask_entity",
-                                      trans_primitives=["negate"])
+                                      trans_primitives=["negate"],
+                                      max_depth=1)
     feature_matrix
 
 

--- a/docs/source/guides/using_koalas_entitysets.rst
+++ b/docs/source/guides/using_koalas_entitysets.rst
@@ -51,7 +51,8 @@ We can pass the ``EntitySet`` we created above to ``featuretools.dfs`` in order 
 
     feature_matrix, features = ft.dfs(entityset=es,
                                       target_entity="koalas_entity",
-                                      trans_primitives=["negate"])
+                                      trans_primitives=["negate"],
+                                      max_depth=1)
     feature_matrix
 
 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -8,6 +8,7 @@ Future Release
     * Fixes
     * Changes
         * Add auto assign bot on GitHub (:pr:`1380`)
+        * Reduce DFS max_depth to 1 if single entity in entityset (:pr:`1412`)
     * Documentation Changes
         * Improve formatting of release notes (:pr:`1396`)
     * Testing Changes

--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 from collections import defaultdict
 
 from dask import dataframe as dd
@@ -152,7 +153,8 @@ class DeepFeatureSynthesis(object):
 
         # if just one entity, set max depth to 1 (transform stacking rule)
         if len(entityset.entity_dict) == 1 and (max_depth is None or max_depth > 1):
-            logger.info("single entity detected, setting max_depth to 1")
+            warnings.warn("Only one entity in entityset, changing max_depth to "
+                          "1 since deeper features cannot be created")
             max_depth = 1
 
         self.max_depth = max_depth

--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -149,6 +149,12 @@ class DeepFeatureSynthesis(object):
         # need to change max_depth to None because DFs terminates when  <0
         if max_depth == -1:
             max_depth = None
+
+        # if just one entity, set max depth to 1 (transform stacking rule)
+        if len(entityset.entity_dict) == 1 and (max_depth is None or max_depth > 1):
+            logger.info("single entity detected, setting max_depth to 1")
+            max_depth = 1
+
         self.max_depth = max_depth
 
         self.max_features = max_features

--- a/featuretools/tests/synthesis/test_deep_feature_synthesis.py
+++ b/featuretools/tests/synthesis/test_deep_feature_synthesis.py
@@ -451,7 +451,7 @@ def test_bad_groupby_feature(es):
 
 
 def test_abides_by_max_depth_param(es):
-    for i in [1, 2, 3]:
+    for i in [0, 1, 2, 3]:
         dfs_obj = DeepFeatureSynthesis(target_entity_id='sessions',
                                        entityset=es,
                                        agg_primitives=[Sum],
@@ -461,8 +461,22 @@ def test_abides_by_max_depth_param(es):
         features = dfs_obj.build_features()
         for f in features:
             # last feature is identity feature which doesn't count
-            assert (f.get_depth() <= i + 1)
+            assert (f.get_depth() <= i)
 
+
+def test_max_depth_single_table(transform_es):
+    assert len(transform_es.entity_dict) == 1
+    for i in [0, 1, 2]:
+        dfs_obj = DeepFeatureSynthesis(target_entity_id='first',
+                                       entityset=transform_es,
+                                       trans_primitives=[AddNumeric],
+                                       max_depth=i)
+
+        features = dfs_obj.build_features()
+        # check transform features made if max_depth>=1
+        assert any([f.get_depth() == min(i, 1) for f in features])
+        # check all features depth 1 or less
+        assert all([f.get_depth() <= min(i, 1) for f in features])
 
 def test_drop_contains(es):
     dfs_obj = DeepFeatureSynthesis(target_entity_id='sessions',

--- a/featuretools/tests/synthesis/test_deep_feature_synthesis.py
+++ b/featuretools/tests/synthesis/test_deep_feature_synthesis.py
@@ -612,7 +612,7 @@ def test_dfs_includes_seed_features_greater_than_max_depth(es):
                                    max_depth=1,
                                    seed_features=[customer_agg])
     features = dfs_obj.build_features()
-    assert customer_agg.get_name() in [f.get_name() for f in features]
+    assert feature_with_name(features=features, name=customer_agg.get_name())
 
 
 def test_allowed_paths(es):

--- a/featuretools/tests/synthesis/test_deep_feature_synthesis.py
+++ b/featuretools/tests/synthesis/test_deep_feature_synthesis.py
@@ -468,9 +468,9 @@ def test_max_depth_single_table(transform_es):
 
     def make_dfs_obj(max_depth):
         dfs_obj = DeepFeatureSynthesis(target_entity_id='first',
-                                        entityset=transform_es,
-                                        trans_primitives=[AddNumeric],
-                                        max_depth=max_depth)
+                                       entityset=transform_es,
+                                       trans_primitives=[AddNumeric],
+                                       max_depth=max_depth)
         return dfs_obj
 
     for i in [-1, 0, 1, 2]:

--- a/featuretools/tests/synthesis/test_deep_feature_synthesis.py
+++ b/featuretools/tests/synthesis/test_deep_feature_synthesis.py
@@ -465,15 +465,16 @@ def test_abides_by_max_depth_param(es):
 
 def test_max_depth_single_table(transform_es):
     assert len(transform_es.entity_dict) == 1
-    for i in [-1, 0, 1, 2, None]:
-        def make_dfs_obj(max_depth=i):
-            dfs_obj = DeepFeatureSynthesis(target_entity_id='first',
-                                           entityset=transform_es,
-                                           trans_primitives=[AddNumeric],
-                                           max_depth=max_depth)
-            return dfs_obj
 
-        if i in [-1, 2, None]:
+    def make_dfs_obj(max_depth):
+        dfs_obj = DeepFeatureSynthesis(target_entity_id='first',
+                                        entityset=transform_es,
+                                        trans_primitives=[AddNumeric],
+                                        max_depth=max_depth)
+        return dfs_obj
+
+    for i in [-1, 0, 1, 2]:
+        if i in [-1, 2]:
             match = ("Only one entity in entityset, changing max_depth to 1 "
                      "since deeper features cannot be created")
             with pytest.warns(UserWarning, match=match):

--- a/featuretools/tests/synthesis/test_deep_feature_synthesis.py
+++ b/featuretools/tests/synthesis/test_deep_feature_synthesis.py
@@ -482,11 +482,15 @@ def test_max_depth_single_table(transform_es):
             dfs_obj = make_dfs_obj(i)
 
         features = dfs_obj.build_features()
-        # check transform features made if max_depth>=1
-        assert any([f.get_depth() == min(i, 1) for f in features])
-        # check all features depth 1 or less
-        assert all([f.get_depth() <= min(i, 1) for f in features])
-
+        assert len(features) > 0
+        if i > 0:
+            # at least one depth 1 feature made
+            assert any([f.get_depth() == 1 for f in features])
+            # no depth 2 or higher even with max_depth=2
+            assert all([f.get_depth() <= 1 for f in features])
+        else:
+            # no depth 1 or higher features with max_depth=0
+            assert all([f.get_depth() == 0 for f in features])
 
 def test_drop_contains(es):
     dfs_obj = DeepFeatureSynthesis(target_entity_id='sessions',

--- a/featuretools/tests/synthesis/test_deep_feature_synthesis.py
+++ b/featuretools/tests/synthesis/test_deep_feature_synthesis.py
@@ -465,7 +465,7 @@ def test_abides_by_max_depth_param(es):
 
 def test_max_depth_single_table(transform_es):
     assert len(transform_es.entity_dict) == 1
-    for i in [0, 1, 2]:
+    for i in [-1, 0, 1, 2, None]:
         def make_dfs_obj(max_depth=i):
             dfs_obj = DeepFeatureSynthesis(target_entity_id='first',
                                            entityset=transform_es,
@@ -473,7 +473,7 @@ def test_max_depth_single_table(transform_es):
                                            max_depth=max_depth)
             return dfs_obj
 
-        if i == 2:
+        if i in [-1, 2, None]:
             match = ("Only one entity in entityset, changing max_depth to 1 "
                      "since deeper features cannot be created")
             with pytest.warns(UserWarning, match=match):
@@ -483,7 +483,7 @@ def test_max_depth_single_table(transform_es):
 
         features = dfs_obj.build_features()
         assert len(features) > 0
-        if i > 0:
+        if i != 0:
             # at least one depth 1 feature made
             assert any([f.get_depth() == 1 for f in features])
             # no depth 2 or higher even with max_depth=2

--- a/featuretools/tests/synthesis/test_deep_feature_synthesis.py
+++ b/featuretools/tests/synthesis/test_deep_feature_synthesis.py
@@ -488,6 +488,7 @@ def test_max_depth_single_table(transform_es):
         # check all features depth 1 or less
         assert all([f.get_depth() <= min(i, 1) for f in features])
 
+
 def test_drop_contains(es):
     dfs_obj = DeepFeatureSynthesis(target_entity_id='sessions',
                                    entityset=es,

--- a/featuretools/tests/synthesis/test_deep_feature_synthesis.py
+++ b/featuretools/tests/synthesis/test_deep_feature_synthesis.py
@@ -460,7 +460,6 @@ def test_abides_by_max_depth_param(es):
 
         features = dfs_obj.build_features()
         for f in features:
-            # last feature is identity feature which doesn't count
             assert (f.get_depth() <= i)
 
 

--- a/featuretools/tests/synthesis/test_deep_feature_synthesis.py
+++ b/featuretools/tests/synthesis/test_deep_feature_synthesis.py
@@ -572,6 +572,21 @@ def test_dfs_builds_on_seed_features_more_than_max_depth(es):
                                                 for f in features]
 
 
+def test_dfs_includes_seed_features_greater_than_max_depth(es):
+    session_agg = ft.Feature(es['log']['value'], parent_entity=es['sessions'], primitive=Sum)
+    customer_agg = ft.Feature(session_agg, parent_entity=es["customers"], primitive=Mean)
+    assert customer_agg.get_depth() == 2
+
+    dfs_obj = DeepFeatureSynthesis(target_entity_id='customers',
+                                   entityset=es,
+                                   agg_primitives=[Mean],
+                                   trans_primitives=[],
+                                   max_depth=1,
+                                   seed_features=[customer_agg])
+    features = dfs_obj.build_features()
+    assert customer_agg.get_name() in [f.get_name() for f in features]
+
+
 def test_allowed_paths(es):
     # TODO: Update to work with Dask and Koalas supported primitive
     if not all(isinstance(entity.df, pd.DataFrame) for entity in es.entities):

--- a/featuretools/tests/synthesis/test_deep_feature_synthesis.py
+++ b/featuretools/tests/synthesis/test_deep_feature_synthesis.py
@@ -467,10 +467,20 @@ def test_abides_by_max_depth_param(es):
 def test_max_depth_single_table(transform_es):
     assert len(transform_es.entity_dict) == 1
     for i in [0, 1, 2]:
-        dfs_obj = DeepFeatureSynthesis(target_entity_id='first',
-                                       entityset=transform_es,
-                                       trans_primitives=[AddNumeric],
-                                       max_depth=i)
+        def make_dfs_obj(max_depth=i):
+            dfs_obj = DeepFeatureSynthesis(target_entity_id='first',
+                                           entityset=transform_es,
+                                           trans_primitives=[AddNumeric],
+                                           max_depth=max_depth)
+            return dfs_obj
+
+        if i == 2:
+            match = ("Only one entity in entityset, changing max_depth to 1 "
+                     "since deeper features cannot be created")
+            with pytest.warns(UserWarning, match=match):
+                dfs_obj = make_dfs_obj(i)
+        else:
+            dfs_obj = make_dfs_obj(i)
 
         features = dfs_obj.build_features()
         # check transform features made if max_depth>=1

--- a/featuretools/tests/synthesis/test_deep_feature_synthesis.py
+++ b/featuretools/tests/synthesis/test_deep_feature_synthesis.py
@@ -492,6 +492,7 @@ def test_max_depth_single_table(transform_es):
             # no depth 1 or higher features with max_depth=0
             assert all([f.get_depth() == 0 for f in features])
 
+
 def test_drop_contains(es):
     dfs_obj = DeepFeatureSynthesis(target_entity_id='sessions',
                                    entityset=es,


### PR DESCRIPTION
Due to the constraints we've added that prevents transform features being stacked on other transform features directly, if an entityset has a single entity, features beyond depth 1 cannot be created (can't stack transforms on each other and no other entities to get direct or aggregation features from).  Currently in such a scenario, DFS will spend time creating stacked transform features and throwing them out due to the stacking rules.

This PR will update our build features logic to lower the max depth to 1 if there is only a single entity so that DFS skips looking at depth 2 features it won't include

With this change, ensuring seed features greater than max_depth are still included is a concern since max_depth is being changed, so I added a test with a complex seed feature to confirm it was still included in the returned features 