### PR TITLE
Clean up replace Entity Woodwork integration

### DIFF
--- a/featuretools/demo/flight.py
+++ b/featuretools/demo/flight.py
@@ -7,7 +7,6 @@ from tqdm import tqdm
 import woodwork as ww
 
 import featuretools as ft
-import featuretools.variable_types as vtypes
 
 
 def load_flight(month_filter=None,

--- a/featuretools/demo/retail.py
+++ b/featuretools/demo/retail.py
@@ -1,7 +1,8 @@
 import pandas as pd
 
-import featuretools as ft
 import woodwork as ww
+
+import featuretools as ft
 
 
 def load_retail(id='demo_retail_data', nrows=None, return_single_table=False):

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -521,7 +521,7 @@ class EntitySet(object):
             time_index (str, optional): Name of the column containing
                 time data. Type must be numeric or datetime in nature.
 
-            secondary_time_index (dict[str -> Series]): Name of column
+            secondary_time_index (dict[str -> list[str]]): Name of column
                 containing time data to use a second time index for the dataframe.
 
             already_sorted (bool, optional) : If True, assumes that input dataframe
@@ -1299,7 +1299,6 @@ class EntitySet(object):
             return
 
         time_type = self._get_time_type(dataframe, column_id)
-        # --> TODO need to make sure this is getting tested correctly for secondary and last time indexes because I think they dont have woodwork typing??
         if self.time_type is None:
             self.time_type = time_type
         elif self.time_type != time_type:

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -302,7 +302,7 @@ class EntitySet(object):
             msg = "Unable to add relationship because child column '{}' in '{}' is also its index"
             raise ValueError(msg.format(child_column, child_df.ww.name))
         parent_df = relationship.parent_dataframe
-        parent_column = relationship.parent_column.name
+        parent_column = relationship._parent_column_id
         if 'foreign_key' not in child_df.ww.semantic_tags[child_column]:
             child_df.ww.add_semantic_tags({child_column: 'foreign_key'})
 
@@ -581,9 +581,9 @@ class EntitySet(object):
                               already_sorted=already_sorted)
             # If no index column is specified, set the first column
             if dataframe.ww.index is None:
-                dataframe.ww.set_index(dataframe.columns[0])
                 warnings.warn(("Using first column as index. "
                                "To change this, specify the index parameter"))
+                dataframe.ww.set_index(dataframe.columns[0])
 
         else:
             if dataframe.ww.index is None:
@@ -668,14 +668,14 @@ class EntitySet(object):
                             .format(type(additional_columns)))
 
         if len(additional_columns) != len(set(additional_columns)):
-            raise ValueError("'additional_columns' contains duplicate variables. All variables must be unique.")
+            raise ValueError("'additional_columns' contains duplicate columns. All columns must be unique.")
 
         if not isinstance(copy_columns, list):
             raise TypeError("'copy_columns' must be a list, but received type {}"
                             .format(type(copy_columns)))
 
         if len(copy_columns) != len(set(copy_columns)):
-            raise ValueError("'copy_columns' contains duplicate variables. All variables must be unique.")
+            raise ValueError("'copy_columns' contains duplicate columns. All columns must be unique.")
 
         for v in additional_columns + copy_columns:
             if v == index:
@@ -701,7 +701,7 @@ class EntitySet(object):
             transfer_types[col_name] = (base_dataframe.ww.logical_types[col_name], base_dataframe.ww.semantic_tags[col_name] - {'time_index'})
 
         # create and add new dataframe
-        new_dataframe = self[base_dataframe_id].ww.copy()
+        new_dataframe = self[base_dataframe_id].copy()
 
         if make_time_index is None and base_dataframe.ww.time_index is not None:
             make_time_index = True
@@ -789,10 +789,9 @@ class EntitySet(object):
 
         self.dataframe_dict[base_dataframe_id] = self.dataframe_dict[base_dataframe_id].ww.drop(additional_columns)
 
-        new_dataframe = self.dataframe_dict[new_dataframe_id]
         self.dataframe_dict[base_dataframe_id].ww.add_semantic_tags({base_dataframe_index: 'foreign_key'})
 
-        self.add_relationship(new_dataframe.ww.name, index, base_dataframe.ww.name, base_dataframe_index)
+        self.add_relationship(new_dataframe_id, index, base_dataframe_id, base_dataframe_index)
         self.reset_data_description()
         return self
 

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -6,7 +6,6 @@ from collections import defaultdict
 import dask.dataframe as dd
 import numpy as np
 import pandas as pd
-from pandas.api.types import is_dtype_equal
 
 import woodwork as ww
 
@@ -51,10 +50,10 @@ class EntitySet(object):
             Args:
                 id (str) : Unique identifier to associate with this instance
 
-                dataframes (dict[str -> tuple(DataFrame, str, str, 
-                                              dict[str -> str/Woodwork.LogicalType], 
-                                              dict[str->str/set], 
-                                              boolean)]): dictionary of DataFrames. 
+                dataframes (dict[str -> tuple(DataFrame, str, str,
+                                              dict[str -> str/Woodwork.LogicalType],
+                                              dict[str->str/set],
+                                              boolean)]): dictionary of DataFrames.
                     Entries take the format dataframe id -> (dataframe, index column, time_index, logical_types, semantic_tags, make_index)}.
                     Note that only the dataframe is required. If a Woodwork DataFrame is supplied, any other parameters
                     will be ignored.
@@ -1237,7 +1236,7 @@ class EntitySet(object):
 
     def update_dataframe(self, dataframe_id, df, already_sorted=False, recalculate_last_time_indexes=True):
         '''Update the internal dataframe of an EntitySet table, keeping Woodwork typing information the same.
-        Optionally makes sure that data is sorted, that reference indexes to other dataframes are consistent, 
+        Optionally makes sure that data is sorted, that reference indexes to other dataframes are consistent,
         and that last_time_indexes are updated to reflect the new data.
         '''
         if not isinstance(df, type(self[dataframe_id])):

--- a/featuretools/entityset/relationship.py
+++ b/featuretools/entityset/relationship.py
@@ -71,13 +71,11 @@ class Relationship(object):
     @property
     def parent_column(self):
         """Column in parent dataframe"""
-        # --> WW bug - keep index tags here
         return self.parent_dataframe.ww[self._parent_column_id]
 
     @property
     def child_column(self):
         """Column in child dataframe"""
-        # --> WW bug - keep index tags here
         return self.child_dataframe.ww[self._child_column_id]
 
     @property

--- a/featuretools/tests/conftest.py
+++ b/featuretools/tests/conftest.py
@@ -58,9 +58,7 @@ def dask_es(make_es):
     for df in make_es.dataframes:
         dd_df = dd.from_pandas(df.reset_index(drop=True), npartitions=4)
         dd_df.ww.init(schema=df.ww.schema)
-        es.add_dataframe(df.ww.name,
-                         dd_df,
-                         secondary_time_index=df.ww.metadata.get('secondary_time_index'))
+        es.add_dataframe(df.ww.name, dd_df)
 
     for rel in make_es.relationships:
         es.add_relationship(rel.parent_dataframe.ww.name, rel.parent_column.name,
@@ -76,10 +74,7 @@ def ks_es(make_es):
         cleaned_df = pd_to_ks_clean(df).reset_index(drop=True)
         ks_df = ks.from_pandas(cleaned_df)
         ks_df.ww.init(schema=df.ww.schema)
-        es.add_dataframe(df.ww.name,
-                         ks_df,
-                         # --> TODO might be redundant since the metadata will already have it or necessary - test this
-                         secondary_time_index=df.ww.metadata.get('secondary_time_index'))
+        es.add_dataframe(df.ww.name, ks_df)
 
     for rel in make_es.relationships:
         es.add_relationship(rel.parent_dataframe.ww.name, rel.parent_column.name,

--- a/featuretools/tests/conftest.py
+++ b/featuretools/tests/conftest.py
@@ -8,7 +8,6 @@ import pytest
 import featuretools as ft
 from featuretools import variable_types as vtypes
 from featuretools.tests.testing_utils import (
-    get_df_tags,
     make_ecommerce_entityset,
     to_pandas
 )
@@ -77,8 +76,8 @@ def ks_es(make_es):
         es.add_dataframe(df.ww.name, ks_df)
 
     for rel in make_es.relationships:
-        es.add_relationship(rel.parent_dataframe.ww.name, rel.parent_column.name,
-                            rel.child_dataframe.ww.name, rel.child_column.name)
+        es.add_relationship(rel._parent_dataframe_id, rel._parent_column_id,
+                            rel._child_dataframe_id, rel._child_column_id)
     return es
 
 
@@ -143,12 +142,14 @@ def pd_diamond_es():
 def dask_diamond_es(pd_diamond_es):
     dataframes = {}
     for df in pd_diamond_es.dataframes:
-        dataframes[df.ww.name] = (dd.from_pandas(df, npartitions=2), df.ww.index, None, df.ww.logical_types, get_df_tags(df))
+        dd_df = dd.from_pandas(df, npartitions=2)
+        dd_df.ww.init(schema=df.ww.schema)
+        dataframes[df.ww.name] = (dd_df,)
 
-    relationships = [(rel.parent_dataframe.ww.name,
-                      rel.parent_column.name,
-                      rel.child_dataframe.ww.name,
-                      rel.child_column.name) for rel in pd_diamond_es.relationships]
+    relationships = [(rel._parent_dataframe_id,
+                      rel._parent_column_id,
+                      rel._child_dataframe_id,
+                      rel._child_column_id) for rel in pd_diamond_es.relationships]
 
     return ft.EntitySet(id=pd_diamond_es.id, dataframes=dataframes, relationships=relationships)
 
@@ -158,12 +159,14 @@ def ks_diamond_es(pd_diamond_es):
     ks = pytest.importorskip('databricks.koalas', reason="Koalas not installed, skipping")
     dataframes = {}
     for df in pd_diamond_es.dataframes:
-        dataframes[df.ww.name] = (ks.from_pandas(pd_to_ks_clean(df)), df.ww.index, None, df.ww.logical_types, get_df_tags(df))
+        ks_df = ks.from_pandas(pd_to_ks_clean(df))
+        ks_df.ww.init(schema=df.ww.schema)
+        dataframes[df.ww.name] = (ks_df,)
 
-    relationships = [(rel.parent_dataframe.ww.name,
-                      rel.parent_column.name,
-                      rel.child_dataframe.ww.name,
-                      rel.child_column.name) for rel in pd_diamond_es.relationships]
+    relationships = [(rel._parent_dataframe_id,
+                      rel._parent_column_id,
+                      rel._child_dataframe_id,
+                      rel._child_column_id) for rel in pd_diamond_es.relationships]
 
     return ft.EntitySet(id=pd_diamond_es.id, dataframes=dataframes, relationships=relationships)
 
@@ -201,12 +204,14 @@ def pd_default_value_es():
 def dask_default_value_es(pd_default_value_es):
     dataframes = {}
     for df in pd_default_value_es.dataframes:
-        dataframes[df.ww.name] = (dd.from_pandas(df, npartitions=4), df.ww.index, None, df.ww.logical_types, get_df_tags(df))
+        dd_df = dd.from_pandas(df, npartitions=4)
+        dd_df.ww.init(schema=df.ww.schema)
+        dataframes[df.ww.name] = (dd_df,)
 
-    relationships = [(rel.parent_dataframe.ww.name,
-                      rel.parent_column.name,
-                      rel.child_dataframe.ww.name,
-                      rel.child_column.name) for rel in pd_default_value_es.relationships]
+    relationships = [(rel._parent_dataframe_id,
+                      rel._parent_column_id,
+                      rel._child_dataframe_id,
+                      rel._child_column_id) for rel in pd_default_value_es.relationships]
 
     return ft.EntitySet(id=pd_default_value_es.id, dataframes=dataframes, relationships=relationships)
 
@@ -216,12 +221,14 @@ def ks_default_value_es(pd_default_value_es):
     ks = pytest.importorskip('databricks.koalas', reason="Koalas not installed, skipping")
     dataframes = {}
     for df in pd_default_value_es.dataframes:
-        dataframes[df.ww.name] = (ks.from_pandas(pd_to_ks_clean(df)), df.ww.index, None, df.ww.logical_types, get_df_tags(df))
+        ks_df = ks.from_pandas(pd_to_ks_clean(df))
+        ks_df.ww.init(schema=df.ww.schema)
+        dataframes[df.ww.name] = (ks_df,)
 
-    relationships = [(rel.parent_dataframe.ww.name,
-                      rel.parent_column.name,
-                      rel.child_dataframe.ww.name,
-                      rel.child_column.name) for rel in pd_default_value_es.relationships]
+    relationships = [(rel._parent_dataframe_id,
+                      rel._parent_column_id,
+                      rel._child_dataframe_id,
+                      rel._child_column_id) for rel in pd_default_value_es.relationships]
 
     return ft.EntitySet(id=pd_default_value_es.id, dataframes=dataframes, relationships=relationships)
 
@@ -254,12 +261,14 @@ def pd_home_games_es():
 def dask_home_games_es(pd_home_games_es):
     dataframes = {}
     for df in pd_home_games_es.dataframes:
-        dataframes[df.ww.name] = (dd.from_pandas(df, npartitions=2), df.ww.index, None, df.ww.logical_types, get_df_tags(df))
+        dd_df = dd.from_pandas(df, npartitions=2)
+        dd_df.ww.init(schema=df.ww.schema)
+        dataframes[df.ww.name] = (dd_df,)
 
-    relationships = [(rel.parent_dataframe.ww.name,
-                      rel.parent_column.name,
-                      rel.child_dataframe.ww.name,
-                      rel.child_column.name) for rel in pd_home_games_es.relationships]
+    relationships = [(rel._parent_dataframe_id,
+                      rel._parent_column_id,
+                      rel._child_dataframe_id,
+                      rel._child_column_id) for rel in pd_home_games_es.relationships]
 
     return ft.EntitySet(id=pd_home_games_es.id, dataframes=dataframes, relationships=relationships)
 
@@ -269,12 +278,14 @@ def ks_home_games_es(pd_home_games_es):
     ks = pytest.importorskip('databricks.koalas', reason="Koalas not installed, skipping")
     dataframes = {}
     for df in pd_home_games_es.dataframes:
-        dataframes[df.ww.name] = (ks.from_pandas(pd_to_ks_clean(df)), df.ww.index, None, df.ww.logical_types, get_df_tags(df))
+        ks_df = ks.from_pandas(pd_to_ks_clean(df))
+        ks_df.ww.init(schema=df.ww.schema)
+        dataframes[df.ww.name] = (ks_df,)
 
-    relationships = [(rel.parent_dataframe.ww.name,
-                      rel.parent_column.name,
-                      rel.child_dataframe.ww.name,
-                      rel.child_column.name) for rel in pd_home_games_es.relationships]
+    relationships = [(rel._parent_dataframe_id,
+                      rel._parent_column_id,
+                      rel._child_dataframe_id,
+                      rel._child_column_id) for rel in pd_home_games_es.relationships]
 
     return ft.EntitySet(id=pd_home_games_es.id, dataframes=dataframes, relationships=relationships)
 

--- a/featuretools/tests/entityset_tests/test_dask_es.py
+++ b/featuretools/tests/entityset_tests/test_dask_es.py
@@ -4,7 +4,6 @@ import pytest
 
 import woodwork.logical_types as ltypes
 
-import featuretools as ft
 from featuretools.entityset import EntitySet
 from featuretools.tests.testing_utils import get_df_tags
 

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -1230,24 +1230,26 @@ def test_normalize_time_index_from_none(normalize_es):
 
 
 def test_raise_error_if_dupicate_additional_variables_passed(es):
-    error_text = "'additional_columns' contains duplicate variables. All variables must be unique."
+    error_text = "'additional_columns' contains duplicate columns. All columns must be unique."
     with pytest.raises(ValueError, match=error_text):
         es.normalize_dataframe('sessions', 'device_types', 'device_type',
                                additional_columns=['device_name', 'device_name'])
 
 
-def test_raise_error_if_dupicate_copy_variables_passed(es):
-    error_text = "'copy_columns' contains duplicate variables. All variables must be unique."
+def test_raise_error_if_dupicate_copy_columns_passed(es):
+    error_text = "'copy_columns' contains duplicate columns. All columns must be unique."
     with pytest.raises(ValueError, match=error_text):
         es.normalize_dataframe('sessions', 'device_types', 'device_type',
                                copy_columns=['device_name', 'device_name'])
 
 
-def test_normalize_dataframe_copies_variable_types(es):
+def test_normalize_dataframe_copies_logical_types(es):
     es['log'].ww.set_types(logical_types={'value': ltypes.Ordinal(order=[0.0, 1.0, 2.0, 3.0, 5.0, 7.0, 10.0, 14.0, 15.0, 20.0])})
 
     assert isinstance(es['log'].ww.logical_types['value'], ltypes.Ordinal)
+    assert len(es['log'].ww.logical_types['value'].order) == 10
     assert isinstance(es['log'].ww.logical_types['priority_level'], ltypes.Ordinal)
+    assert len(es['log'].ww.logical_types['priority_level'].order) == 3
     es.normalize_dataframe('log', 'values_2', 'value_2',
                            additional_columns=['priority_level'],
                            copy_columns=['value'],
@@ -1262,7 +1264,9 @@ def test_normalize_dataframe_copies_variable_types(es):
     assert 'value' in es['log'].columns
     assert 'value_2' in es['values_2'].columns
     assert isinstance(es['values_2'].ww.logical_types['priority_level'], ltypes.Ordinal)
+    assert len(es['values_2'].ww.logical_types['priority_level'].order) == 3
     assert isinstance(es['values_2'].ww.logical_types['value'], ltypes.Ordinal)
+    assert len(es['values_2'].ww.logical_types['value'].order) == 10
 
 
 # sorting not supported in Dask, Koalas

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -20,7 +20,7 @@ from featuretools.utils.koalas_utils import pd_to_ks_clean
 ks = import_or_none('databricks.koalas')
 
 
-def test_normalize_time_index_as_additional_variable(es):
+def test_normalize_time_index_as_additional_column(es):
     error_text = "Not moving signup_date as it is the base time index column. Perhaps, move the column to the copy_columns."
     with pytest.raises(ValueError, match=error_text):
         assert "signup_date" in es["customers"].columns
@@ -343,7 +343,7 @@ def df(request):
     return request.getfixturevalue(request.param)
 
 
-def test_check_variables_and_dataframe(df):
+def test_check_columns_and_dataframe(df):
     # matches
     logical_types = {'id': ltypes.Integer,
                      'category': ltypes.Categorical}
@@ -387,8 +387,8 @@ def test_index_any_location(df):
     assert es.dataframe_dict['test_dataframe'].ww.index == 'category'
 
 
-def test_extra_variable_type(df):
-    # more variables
+def test_extra_column_type(df):
+    # more columns
     logical_types = {'id': ltypes.Integer,
                      'category': ltypes.Categorical,
                      'category2': ltypes.Categorical}
@@ -489,7 +489,7 @@ def test_doesnt_remake_index(df):
                          logical_types=logical_types)
 
 
-def test_bad_time_index_variable(df3):
+def test_bad_time_index_column(df3):
     logical_types = {'category': 'Categorical'}
     error_text = "Specified time index column `time` not found in dataframe"
     with pytest.raises(LookupError, match=error_text):
@@ -690,7 +690,6 @@ def test_handles_datetime_format(datetime2):
     assert (col_format == actual).all()
 
 
-# Inferring variable types and verifying typing not supported in Dask, Koalas
 def test_handles_datetime_mismatch():
     # can't convert arbitrary strings
     df = pd.DataFrame({'id': [0, 1, 2], 'time': ['a', 'b', 'tomorrow']})
@@ -705,8 +704,6 @@ def test_handles_datetime_mismatch():
 
 
 def test_dataframe_init(es):
-    # Note: to convert the time column directly either the variable type
-    # or convert_date_columns must be specifie
     df = pd.DataFrame({'id': ['0', '1', '2'],
                        'time': [datetime(2011, 4, 9, 10, 31, 3 * i)
                                 for i in range(3)],
@@ -1145,7 +1142,7 @@ def test_normalize_dataframe_new_time_index_in_base_entity_error_check(es):
                                make_time_index="non-existent")
 
 
-def test_normalize_entity_new_time_index_in_variable_list_error_check(es):
+def test_normalize_entity_new_time_index_in_column_list_error_check(es):
     error_text = "'make_time_index' must be specified in 'additional_columns' or 'copy_columns'"
     with pytest.raises(ValueError, match=error_text):
         es.normalize_dataframe(base_dataframe_id='customers',
@@ -1229,7 +1226,7 @@ def test_normalize_time_index_from_none(normalize_es):
         assert df['time'].is_monotonic_increasing
 
 
-def test_raise_error_if_dupicate_additional_variables_passed(es):
+def test_raise_error_if_dupicate_additional_columns_passed(es):
     error_text = "'additional_columns' contains duplicate columns. All columns must be unique."
     with pytest.raises(ValueError, match=error_text):
         es.normalize_dataframe('sessions', 'device_types', 'device_type',

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -1036,11 +1036,19 @@ def test_sets_time_when_adding_entity(transactions_df):
                              time_index="signup_date")
 
 
-def test_checks_time_type_setting_time_index(es):
+def test_secondary_time_index_no_primary_time_index(es):
+    es['products'].ww.set_types(logical_types={'rating': 'Datetime'})
+    assert es['products'].ww.time_index is None
+    es.set_secondary_time_index('products', {'rating': ['url']})
+
+    assert 'secondary_time_index' in es['products'].ww.metadata
+    assert es['products'].ww.time_index is None
+
+
+def test_set_non_valid_time_index_type(es):
     error_text = 'Time index column must be a Datetime or numeric column.'
     with pytest.raises(TypeError, match=error_text):
         es['log'].ww.set_time_index('purchased')
-        es._check_uniform_time_index(es['log'])
 
 
 def test_checks_time_type_setting_secondary_time_index(es):

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -8,8 +8,8 @@ import numpy as np
 import pandas as pd
 import pytest
 
-import woodwork.logical_types as ltypes
 import woodwork as ww
+import woodwork.logical_types as ltypes
 
 import featuretools as ft
 from featuretools.entityset import EntitySet
@@ -89,10 +89,6 @@ def test_add_relationship_instantiated_logical_types(es):
     assert es['log2'].ww.logical_types['product_id'] == ltypes.Categorical()
     assert es['products'].ww.logical_types['id'] == ltypes.Categorical
 
-    category_dtype = 'category'
-    if ks and isinstance(es['customers'], ks.DataFrame):
-        category_dtype = 'string'
-
     warning_text = f'Logical type Categorical for child column product_id does not match parent column id logical type Categorical. Changing child logical type to match parent.'
     with pytest.warns(UserWarning, match=warning_text):
         es.add_relationship(u'products', 'id', 'log2', 'product_id')
@@ -135,10 +131,6 @@ def test_add_relationship_different_logical_types_same_dtype(es):
     assert es['log2'].ww.logical_types['product_id'] == ltypes.CountryCode
     assert es['products'].ww.logical_types['id'] == ltypes.Categorical
 
-    category_dtype = 'category'
-    if ks and isinstance(es['customers'], ks.DataFrame):
-        category_dtype = 'string'
-
     warning_text = f'Logical type CountryCode for child column product_id does not match parent column id logical type Categorical. Changing child logical type to match parent.'
     with pytest.warns(UserWarning, match=warning_text):
         es.add_relationship(u'products', 'id', 'log2', 'product_id')
@@ -180,10 +172,6 @@ def test_add_relationship_different_compatible_dtypes(es):
     assert es['log2'].ww.schema is not None
     assert es['log2'].ww.logical_types['session_id'] == ltypes.Datetime
     assert es['customers'].ww.logical_types['id'] == ltypes.Integer
-
-    category_dtype = 'category'
-    if ks and isinstance(es['customers'], ks.DataFrame):
-        category_dtype = 'string'
 
     warning_text = f'Logical type Datetime for child column session_id does not match parent column id logical type Integer. Changing child logical type to match parent.'
     with pytest.warns(UserWarning, match=warning_text):

--- a/featuretools/tests/entityset_tests/test_es_metadata.py
+++ b/featuretools/tests/entityset_tests/test_es_metadata.py
@@ -159,8 +159,7 @@ def employee_df(request):
 
 
 def test_find_forward_paths_ignores_loops(employee_df):
-    dataframes = {'employees': (employee_df, 'id', None, None, {'id': 'foreign_key',
-                                                                'manager_id': 'foreign_key'})}
+    dataframes = {'employees': (employee_df, 'id')}
     relationships = [('employees', 'id', 'employees', 'manager_id')]
     es = ft.EntitySet(dataframes=dataframes, relationships=relationships)
 

--- a/featuretools/tests/entityset_tests/test_es_metadata.py
+++ b/featuretools/tests/entityset_tests/test_es_metadata.py
@@ -1,7 +1,6 @@
 import pandas as pd
 import pytest
 from dask import dataframe as dd
-import woodwork.logical_types as ltypes
 
 import featuretools as ft
 from featuretools import EntitySet

--- a/featuretools/tests/entityset_tests/test_koalas_es.py
+++ b/featuretools/tests/entityset_tests/test_koalas_es.py
@@ -3,7 +3,6 @@ import pytest
 
 import woodwork.logical_types as ltypes
 
-import featuretools as ft
 from featuretools.entityset import EntitySet
 from featuretools.tests.testing_utils import get_df_tags
 from featuretools.utils.gen_utils import import_or_none

--- a/featuretools/tests/entityset_tests/test_timedelta.py
+++ b/featuretools/tests/entityset_tests/test_timedelta.py
@@ -2,9 +2,8 @@ import pandas as pd
 import pytest
 from dateutil.relativedelta import relativedelta
 
-import featuretools as ft
 from featuretools.entityset import Timedelta
-from featuretools.primitives import Count
+# from featuretools.primitives import Count
 from featuretools.tests.testing_utils import to_pandas
 from featuretools.utils.wrangle import _check_timedelta
 

--- a/featuretools/tests/entityset_tests/test_ww_es.py
+++ b/featuretools/tests/entityset_tests/test_ww_es.py
@@ -135,7 +135,7 @@ def test_init_es_with_relationships(pd_df):
     second_df = pd.DataFrame({'id': [0, 1, 2, 3], 'first_table_id': [1, 2, 2, 1]})
 
     pd_df.ww.init(name='first_table', index='id')
-    second_df.ww.init(name='second_table', index='id', semantic_tags={'first_table_id': 'foreign_key'})
+    second_df.ww.init(name='second_table', index='id')
 
     es = EntitySet('es',
                    dataframes={'first_table': (pd_df,), 'second_table': (second_df,)},
@@ -145,6 +145,10 @@ def test_init_es_with_relationships(pd_df):
 
     forward_dataframes = [name for name, _ in es.get_forward_dataframes('second_table')]
     assert forward_dataframes[0] == 'first_table'
+
+    relationship = es.relationships[0]
+    assert 'foreign_key' in relationship.child_column.ww.semantic_tags
+    assert 'index' in relationship.parent_column.ww.semantic_tags
 
 
 def test_add_secondary_time_index():

--- a/featuretools/tests/entityset_tests/test_ww_es.py
+++ b/featuretools/tests/entityset_tests/test_ww_es.py
@@ -1,11 +1,17 @@
 from datetime import datetime
+
 import dask.dataframe as dd
 import numpy as np
 import pandas as pd
 import pytest
 
-from woodwork.logical_types import Categorical, Integer, NaturalLanguage, Datetime
 import woodwork as ww
+from woodwork.logical_types import (
+    Categorical,
+    Datetime,
+    Integer,
+    NaturalLanguage
+)
 
 from featuretools.entityset import EntitySet
 from featuretools.tests.testing_utils import to_pandas

--- a/featuretools/tests/testing_utils/mock_ds.py
+++ b/featuretools/tests/testing_utils/mock_ds.py
@@ -247,7 +247,7 @@ def make_logical_types(with_integer_time_index=False):
 
     product_logical_types = {
         'id': ltypes.Categorical,
-        'rating': ltypes.Integer,  # confirm this is integer
+        'rating': ltypes.Integer,
         'department': ltypes.Categorical,
         'url': ltypes.URL,
     }

--- a/featuretools/utils/wrangle.py
+++ b/featuretools/utils/wrangle.py
@@ -99,6 +99,7 @@ def _check_time_against_column(time, time_column):
         return False
 
 
+# --> TODO possibly remove this or convert to Woodwork
 def _check_time_type(time):
     '''
     Checks if `time` is an instance of common int, float, or datetime types.

--- a/featuretools/variable_types/variable.py
+++ b/featuretools/variable_types/variable.py
@@ -429,6 +429,7 @@ class FilePath(Variable):
     _default_pandas_dtype = str
 
 
+# --> TODO Remove when Entity class is removed
 DEFAULT_DTYPE_VALUES = {
     'datetime64[ns]': pd.Timestamp.now(),
     'int64': 0,

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ distributed>=2.12.0
 dask[dataframe]>=2.12.0
 psutil>=5.4.8
 click>=7.0.0
-woodwork>=0.1.0
+woodwork>=0.3.0


### PR DESCRIPTION
- Adds some tests in areas that were under-tested with respect to Woodwork's behavior in featuretools.
- cleans up Entity/Variable usage in docstrings, tests, and errors
- Brings up a few behavior questions