### PR TITLE
Fix numpy installation for minimum unit tests

### DIFF
--- a/.github/workflows/unit_tests_with_minimum_deps.yml
+++ b/.github/workflows/unit_tests_with_minimum_deps.yml
@@ -36,14 +36,16 @@ jobs:
         name: Get numpy version for koalas
         run: |
           NUMPY_VERSION=$(cat featuretools/tests/requirement_files/minimum_koalas_requirements.txt | grep numpy)
+          python -m pip uninstall numpy -y
+          python -m pip install $NUMPY_VERSION --no-build-isolation
       - if: ${{ matrix.libraries == 'core' }}
         name: Get numpy version for core
         run: |
           NUMPY_VERSION=$(cat featuretools/tests/requirement_files/minimum_core_requirements.txt | grep numpy)
-      - name: Install featuretools - minimum tests dependencies
-        run: |
           python -m pip uninstall numpy -y
           python -m pip install $NUMPY_VERSION --no-build-isolation
+      - name: Install featuretools - minimum tests dependencies
+        run: |
           python -m pip install -r featuretools/tests/requirement_files/minimum_test_requirements.txt
       - if: ${{ matrix.libraries == 'koalas' }}
         name: Install featuretools - minimum koalas, core dependencies

--- a/.github/workflows/unit_tests_with_minimum_deps.yml
+++ b/.github/workflows/unit_tests_with_minimum_deps.yml
@@ -39,7 +39,7 @@ jobs:
           python -m pip uninstall numpy -y
           python -m pip install $NUMPY_VERSION --no-build-isolation
       - if: ${{ matrix.libraries == 'core' }}
-        name: Install numpy version for core
+        name: Install numpy for core
         run: |
           NUMPY_VERSION=$(cat featuretools/tests/requirement_files/minimum_core_requirements.txt | grep numpy)
           python -m pip uninstall numpy -y

--- a/.github/workflows/unit_tests_with_minimum_deps.yml
+++ b/.github/workflows/unit_tests_with_minimum_deps.yml
@@ -34,7 +34,8 @@ jobs:
           python -m pip install -e . --no-dependencies
       - name: Install featuretools - minimum tests dependencies
         run: |
-          python -m pip install numpy==1.16.6 --no-build-isolation
+          NUMPY_VERSION=$(cat featuretools/tests/requirement_files/minimum_core_requirements.txt | grep numpy)
+          python -m pip install $NUMPY_VERSION --no-build-isolation
           python -m pip install -r featuretools/tests/requirement_files/minimum_test_requirements.txt
       - if: ${{ matrix.libraries == 'koalas' }}
         name: Install featuretools - minimum koalas, core dependencies

--- a/.github/workflows/unit_tests_with_minimum_deps.yml
+++ b/.github/workflows/unit_tests_with_minimum_deps.yml
@@ -33,13 +33,13 @@ jobs:
         run: |
           python -m pip install -e . --no-dependencies
       - if: ${{ matrix.libraries == 'koalas' }}
-        name: Get numpy version for koalas
+        name: Install numpy for koalas
         run: |
           NUMPY_VERSION=$(cat featuretools/tests/requirement_files/minimum_koalas_requirements.txt | grep numpy)
           python -m pip uninstall numpy -y
           python -m pip install $NUMPY_VERSION --no-build-isolation
       - if: ${{ matrix.libraries == 'core' }}
-        name: Get numpy version for core
+        name: Install numpy version for core
         run: |
           NUMPY_VERSION=$(cat featuretools/tests/requirement_files/minimum_core_requirements.txt | grep numpy)
           python -m pip uninstall numpy -y

--- a/.github/workflows/unit_tests_with_minimum_deps.yml
+++ b/.github/workflows/unit_tests_with_minimum_deps.yml
@@ -43,14 +43,14 @@ jobs:
           python -m pip install -r featuretools/tests/requirement_files/minimum_koalas_requirements.txt
           NUMPY_VERSION=$(cat featuretools/tests/requirement_files/minimum_koalas_requirements.txt | grep numpy)
           python -m pip uninstall numpy -y
-          python -m pip install $NUMPY_VERSION --no-binary :all:
+          python -m pip install $NUMPY_VERSION --no-build-isolation
       - if: ${{ matrix.libraries == 'core' }}
         name: Install featuretools - minimum core dependencies
         run: |
           python -m pip install -r featuretools/tests/requirement_files/minimum_core_requirements.txt
           NUMPY_VERSION=$(cat featuretools/tests/requirement_files/minimum_core_requirements.txt | grep numpy)
           python -m pip uninstall numpy -y
-          python -m pip install $NUMPY_VERSION --no-binary :all:
+          python -m pip install $NUMPY_VERSION --no-build-isolation
       - name: Run unit tests without code coverage
         run: |
           python -m pytest -x -n 2 featuretools/tests/

--- a/.github/workflows/unit_tests_with_minimum_deps.yml
+++ b/.github/workflows/unit_tests_with_minimum_deps.yml
@@ -32,6 +32,18 @@ jobs:
       - name: Install featuretools with no dependencies
         run: |
           python -m pip install -e . --no-dependencies
+      - if: ${{ matrix.libraries == 'koalas' }}
+        name: Install numpy
+        run: |
+          NUMPY_VERSION=$(cat featuretools/tests/requirement_files/minimum_koalas_requirements.txt | grep numpy)
+          python -m pip uninstall numpy -y
+          python -m pip install $NUMPY_VERSION --no-build-isolation
+      - if: ${{ matrix.libraries == 'core' }}
+        name: Install numpy
+        run: |
+          NUMPY_VERSION=$(cat featuretools/tests/requirement_files/minimum_core_requirements.txt | grep numpy)
+          python -m pip uninstall numpy -y
+          python -m pip install $NUMPY_VERSION --no-build-isolation
       - name: Install featuretools - minimum tests dependencies
         run: |
           python -m pip install -r featuretools/tests/requirement_files/minimum_test_requirements.txt
@@ -41,16 +53,12 @@ jobs:
           sudo apt install -y openjdk-11-jre-headless
           JAVA_HOME="/usr/lib/jvm/java-11-openjdk-amd64"
           python -m pip install -r featuretools/tests/requirement_files/minimum_koalas_requirements.txt
-          NUMPY_VERSION=$(cat featuretools/tests/requirement_files/minimum_koalas_requirements.txt | grep numpy)
           python -m pip uninstall numpy -y
           python -m pip install $NUMPY_VERSION --no-build-isolation
       - if: ${{ matrix.libraries == 'core' }}
         name: Install featuretools - minimum core dependencies
         run: |
           python -m pip install -r featuretools/tests/requirement_files/minimum_core_requirements.txt
-          NUMPY_VERSION=$(cat featuretools/tests/requirement_files/minimum_core_requirements.txt | grep numpy)
-          python -m pip uninstall numpy -y
-          python -m pip install $NUMPY_VERSION --no-build-isolation
       - name: Run unit tests without code coverage
         run: |
           python -m pytest -x -n 2 featuretools/tests/

--- a/.github/workflows/unit_tests_with_minimum_deps.yml
+++ b/.github/workflows/unit_tests_with_minimum_deps.yml
@@ -34,6 +34,7 @@ jobs:
           python -m pip install -e . --no-dependencies
       - name: Install featuretools - minimum tests dependencies
         run: |
+          python -m pip install "$(cat featuretools/tests/requirement_files/minimum_test_requirements.txt | grep numpy)" --no-build-isolation
           python -m pip install -r featuretools/tests/requirement_files/minimum_test_requirements.txt
       - if: ${{ matrix.libraries == 'koalas' }}
         name: Install featuretools - minimum koalas, core dependencies

--- a/.github/workflows/unit_tests_with_minimum_deps.yml
+++ b/.github/workflows/unit_tests_with_minimum_deps.yml
@@ -34,18 +34,20 @@ jobs:
           python -m pip install -e . --no-dependencies
       - name: Install featuretools - minimum tests dependencies
         run: |
-          NUMPY_VERSION=$(cat featuretools/tests/requirement_files/minimum_core_requirements.txt | grep numpy)
-          python -m pip install $NUMPY_VERSION --no-build-isolation
           python -m pip install -r featuretools/tests/requirement_files/minimum_test_requirements.txt
       - if: ${{ matrix.libraries == 'koalas' }}
         name: Install featuretools - minimum koalas, core dependencies
         run: |
           sudo apt install -y openjdk-11-jre-headless
           JAVA_HOME="/usr/lib/jvm/java-11-openjdk-amd64"
+          NUMPY_VERSION=$(cat featuretools/tests/requirement_files/minimum_koalas_requirements.txt | grep numpy)
+          python -m pip install $NUMPY_VERSION --no-build-isolation
           python -m pip install -r featuretools/tests/requirement_files/minimum_koalas_requirements.txt
       - if: ${{ matrix.libraries == 'core' }}
         name: Install featuretools - minimum core dependencies
         run: |
+          NUMPY_VERSION=$(cat featuretools/tests/requirement_files/minimum_core_requirements.txt | grep numpy)
+          python -m pip install $NUMPY_VERSION --no-build-isolation
           python -m pip install -r featuretools/tests/requirement_files/minimum_core_requirements.txt
       - name: Run unit tests without code coverage
         run: |

--- a/.github/workflows/unit_tests_with_minimum_deps.yml
+++ b/.github/workflows/unit_tests_with_minimum_deps.yml
@@ -53,8 +53,6 @@ jobs:
           sudo apt install -y openjdk-11-jre-headless
           JAVA_HOME="/usr/lib/jvm/java-11-openjdk-amd64"
           python -m pip install -r featuretools/tests/requirement_files/minimum_koalas_requirements.txt
-          python -m pip uninstall numpy -y
-          python -m pip install $NUMPY_VERSION --no-build-isolation
       - if: ${{ matrix.libraries == 'core' }}
         name: Install featuretools - minimum core dependencies
         run: |

--- a/.github/workflows/unit_tests_with_minimum_deps.yml
+++ b/.github/workflows/unit_tests_with_minimum_deps.yml
@@ -34,7 +34,7 @@ jobs:
           python -m pip install -e . --no-dependencies
       - name: Install featuretools - minimum tests dependencies
         run: |
-          python -m pip install "$(cat featuretools/tests/requirement_files/minimum_test_requirements.txt | grep numpy)" --no-build-isolation
+          python -m pip install numpy==1.16.6 --no-build-isolation
           python -m pip install -r featuretools/tests/requirement_files/minimum_test_requirements.txt
       - if: ${{ matrix.libraries == 'koalas' }}
         name: Install featuretools - minimum koalas, core dependencies

--- a/.github/workflows/unit_tests_with_minimum_deps.yml
+++ b/.github/workflows/unit_tests_with_minimum_deps.yml
@@ -36,16 +36,14 @@ jobs:
         name: Install numpy
         run: |
           NUMPY_VERSION=$(cat featuretools/tests/requirement_files/minimum_koalas_requirements.txt | grep numpy)
-          python -m pip uninstall numpy -y
-          python -m pip install $NUMPY_VERSION --no-build-isolation
       - if: ${{ matrix.libraries == 'core' }}
         name: Install numpy
         run: |
           NUMPY_VERSION=$(cat featuretools/tests/requirement_files/minimum_core_requirements.txt | grep numpy)
-          python -m pip uninstall numpy -y
-          python -m pip install $NUMPY_VERSION --no-build-isolation
       - name: Install featuretools - minimum tests dependencies
         run: |
+          python -m pip uninstall numpy -y
+          python -m pip install $NUMPY_VERSION --no-build-isolation
           python -m pip install -r featuretools/tests/requirement_files/minimum_test_requirements.txt
       - if: ${{ matrix.libraries == 'koalas' }}
         name: Install featuretools - minimum koalas, core dependencies

--- a/.github/workflows/unit_tests_with_minimum_deps.yml
+++ b/.github/workflows/unit_tests_with_minimum_deps.yml
@@ -41,14 +41,14 @@ jobs:
           sudo apt install -y openjdk-11-jre-headless
           JAVA_HOME="/usr/lib/jvm/java-11-openjdk-amd64"
           NUMPY_VERSION=$(cat featuretools/tests/requirement_files/minimum_koalas_requirements.txt | grep numpy)
-          python -m pip install $NUMPY_VERSION --no-build-isolation
           python -m pip install -r featuretools/tests/requirement_files/minimum_koalas_requirements.txt
+          python -m pip install $NUMPY_VERSION --no-build-isolation
       - if: ${{ matrix.libraries == 'core' }}
         name: Install featuretools - minimum core dependencies
         run: |
           NUMPY_VERSION=$(cat featuretools/tests/requirement_files/minimum_core_requirements.txt | grep numpy)
-          python -m pip install $NUMPY_VERSION --no-build-isolation
           python -m pip install -r featuretools/tests/requirement_files/minimum_core_requirements.txt
+          python -m pip install $NUMPY_VERSION --no-build-isolation
       - name: Run unit tests without code coverage
         run: |
           python -m pytest -x -n 2 featuretools/tests/

--- a/.github/workflows/unit_tests_with_minimum_deps.yml
+++ b/.github/workflows/unit_tests_with_minimum_deps.yml
@@ -40,15 +40,17 @@ jobs:
         run: |
           sudo apt install -y openjdk-11-jre-headless
           JAVA_HOME="/usr/lib/jvm/java-11-openjdk-amd64"
-          NUMPY_VERSION=$(cat featuretools/tests/requirement_files/minimum_koalas_requirements.txt | grep numpy)
           python -m pip install -r featuretools/tests/requirement_files/minimum_koalas_requirements.txt
-          python -m pip install $NUMPY_VERSION --no-build-isolation
+          NUMPY_VERSION=$(cat featuretools/tests/requirement_files/minimum_koalas_requirements.txt | grep numpy)
+          python -m pip uninstall numpy -y
+          python -m pip install $NUMPY_VERSION --no-binary :all:
       - if: ${{ matrix.libraries == 'core' }}
         name: Install featuretools - minimum core dependencies
         run: |
-          NUMPY_VERSION=$(cat featuretools/tests/requirement_files/minimum_core_requirements.txt | grep numpy)
           python -m pip install -r featuretools/tests/requirement_files/minimum_core_requirements.txt
-          python -m pip install $NUMPY_VERSION --no-build-isolation
+          NUMPY_VERSION=$(cat featuretools/tests/requirement_files/minimum_core_requirements.txt | grep numpy)
+          python -m pip uninstall numpy -y
+          python -m pip install $NUMPY_VERSION --no-binary :all:
       - name: Run unit tests without code coverage
         run: |
           python -m pytest -x -n 2 featuretools/tests/

--- a/.github/workflows/unit_tests_with_minimum_deps.yml
+++ b/.github/workflows/unit_tests_with_minimum_deps.yml
@@ -33,11 +33,11 @@ jobs:
         run: |
           python -m pip install -e . --no-dependencies
       - if: ${{ matrix.libraries == 'koalas' }}
-        name: Install numpy
+        name: Get numpy version for koalas
         run: |
           NUMPY_VERSION=$(cat featuretools/tests/requirement_files/minimum_koalas_requirements.txt | grep numpy)
       - if: ${{ matrix.libraries == 'core' }}
-        name: Install numpy
+        name: Get numpy version for core
         run: |
           NUMPY_VERSION=$(cat featuretools/tests/requirement_files/minimum_core_requirements.txt | grep numpy)
       - name: Install featuretools - minimum tests dependencies

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -14,7 +14,7 @@ Future Release
     * Testing Changes
         * Create separate worksflows for each CI job (:pr:`1422`)
         * Add minimum dependency checker to generate minimum requirement files (:pr:`1428`)
-        * Add unit tests against minimum dependencies for python 3.7 on PRs and main (:pr:`1432`)
+        * Add unit tests against minimum dependencies for python 3.7 on PRs and main (:pr:`1432`, :pr:`1445`)
 
     Thanks to the following people for contributing to this release:
     :user:`gsheni`, :user:`rwedge`, :user:`thehomebrewnerd`

--- a/featuretools/tests/requirement_files/minimum_core_requirements.txt
+++ b/featuretools/tests/requirement_files/minimum_core_requirements.txt
@@ -1,5 +1,5 @@
 scipy==1.3.2
-numpy
+numpy==1.16.6
 pandas==1.2.0
 tqdm==4.32.0
 pyyaml==5.4

--- a/featuretools/tests/requirement_files/minimum_core_requirements.txt
+++ b/featuretools/tests/requirement_files/minimum_core_requirements.txt
@@ -1,5 +1,5 @@
 scipy==1.3.2
-numpy>=1.16.5
+numpy==1.16.5
 pandas==1.2.0
 tqdm==4.32.0
 pyyaml==5.4

--- a/featuretools/tests/requirement_files/minimum_core_requirements.txt
+++ b/featuretools/tests/requirement_files/minimum_core_requirements.txt
@@ -1,5 +1,5 @@
 scipy==1.3.2
-numpy==1.16.5
+numpy==1.16.6
 pandas==1.2.0
 tqdm==4.32.0
 pyyaml==5.4

--- a/featuretools/tests/requirement_files/minimum_core_requirements.txt
+++ b/featuretools/tests/requirement_files/minimum_core_requirements.txt
@@ -1,5 +1,5 @@
 scipy==1.3.2
-numpy==1.16.6
+numpy
 pandas==1.2.0
 tqdm==4.32.0
 pyyaml==5.4

--- a/featuretools/tests/requirement_files/minimum_koalas_requirements.txt
+++ b/featuretools/tests/requirement_files/minimum_koalas_requirements.txt
@@ -1,7 +1,7 @@
 pyspark==3.0.0
 koalas==1.1.0
 scipy==1.3.2
-numpy>=1.16.5
+numpy==1.16.5
 pandas==1.2.0
 tqdm==4.32.0
 pyyaml==5.4

--- a/featuretools/tests/requirement_files/minimum_koalas_requirements.txt
+++ b/featuretools/tests/requirement_files/minimum_koalas_requirements.txt
@@ -1,7 +1,7 @@
 pyspark==3.0.0
 koalas==1.1.0
 scipy==1.3.2
-numpy==1.16.5
+numpy==1.16.6
 pandas==1.2.0
 tqdm==4.32.0
 pyyaml==5.4

--- a/featuretools/tests/requirement_files/minimum_test_requirements.txt
+++ b/featuretools/tests/requirement_files/minimum_test_requirements.txt
@@ -1,5 +1,5 @@
 pip==19.0.2
-wheel==0.32.3
+wheel==0.33.0
 pytest==5.2.0
 pympler==0.8
 pytest-xdist==1.26.1

--- a/featuretools/tests/requirement_files/minimum_test_requirements.txt
+++ b/featuretools/tests/requirement_files/minimum_test_requirements.txt
@@ -1,5 +1,5 @@
 pip==19.0.2
-wheel==0.33.1
+wheel
 pytest==5.2.0
 pympler==0.8
 pytest-xdist==1.26.1

--- a/featuretools/tests/requirement_files/minimum_test_requirements.txt
+++ b/featuretools/tests/requirement_files/minimum_test_requirements.txt
@@ -1,5 +1,5 @@
 pip==19.0.2
-wheel
+wheel==0.30.0
 pytest==5.2.0
 pympler==0.8
 pytest-xdist==1.26.1

--- a/featuretools/tests/requirement_files/minimum_test_requirements.txt
+++ b/featuretools/tests/requirement_files/minimum_test_requirements.txt
@@ -1,5 +1,5 @@
 pip==19.0.2
-wheel==0.34.0
+wheel==0.35.0
 pytest==5.2.0
 pympler==0.8
 pytest-xdist==1.26.1

--- a/featuretools/tests/requirement_files/minimum_test_requirements.txt
+++ b/featuretools/tests/requirement_files/minimum_test_requirements.txt
@@ -1,5 +1,5 @@
 pip==19.0.2
-wheel==0.32.0
+wheel==0.32.1
 pytest==5.2.0
 pympler==0.8
 pytest-xdist==1.26.1

--- a/featuretools/tests/requirement_files/minimum_test_requirements.txt
+++ b/featuretools/tests/requirement_files/minimum_test_requirements.txt
@@ -1,5 +1,5 @@
 pip==19.0.2
-wheel==0.33.0
+wheel==0.34.0
 pytest==5.2.0
 pympler==0.8
 pytest-xdist==1.26.1

--- a/featuretools/tests/requirement_files/minimum_test_requirements.txt
+++ b/featuretools/tests/requirement_files/minimum_test_requirements.txt
@@ -1,5 +1,5 @@
 pip==19.0.2
-wheel==0.31.0
+wheel==0.31.1
 pytest==5.2.0
 pympler==0.8
 pytest-xdist==1.26.1

--- a/featuretools/tests/requirement_files/minimum_test_requirements.txt
+++ b/featuretools/tests/requirement_files/minimum_test_requirements.txt
@@ -1,5 +1,5 @@
 pip==19.0.2
-wheel==0.32.2
+wheel==0.32.3
 pytest==5.2.0
 pympler==0.8
 pytest-xdist==1.26.1

--- a/featuretools/tests/requirement_files/minimum_test_requirements.txt
+++ b/featuretools/tests/requirement_files/minimum_test_requirements.txt
@@ -1,5 +1,5 @@
 pip==19.0.2
-wheel==0.31.1
+wheel==0.32.0
 pytest==5.2.0
 pympler==0.8
 pytest-xdist==1.26.1

--- a/featuretools/tests/requirement_files/minimum_test_requirements.txt
+++ b/featuretools/tests/requirement_files/minimum_test_requirements.txt
@@ -1,5 +1,5 @@
 pip==19.0.2
-wheel==0.32.1
+wheel==0.32.2
 pytest==5.2.0
 pympler==0.8
 pytest-xdist==1.26.1

--- a/featuretools/tests/requirement_files/minimum_test_requirements.txt
+++ b/featuretools/tests/requirement_files/minimum_test_requirements.txt
@@ -1,5 +1,5 @@
 pip==19.0.2
-wheel==0.30.0
+wheel==0.31.0
 pytest==5.2.0
 pympler==0.8
 pytest-xdist==1.26.1

--- a/featuretools/tests/requirement_files/minimum_test_requirements.txt
+++ b/featuretools/tests/requirement_files/minimum_test_requirements.txt
@@ -1,5 +1,5 @@
 pip==19.0.2
-wheel==0.35.0
+wheel==0.33.1
 pytest==5.2.0
 pympler==0.8
 pytest-xdist==1.26.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 scipy>=1.3.2
-numpy>=1.16.5
+numpy>=1.16.6
 pandas>=1.2.0,<2.0.0
 tqdm>=4.32.0
 pyyaml>=5.4


### PR DESCRIPTION
- Using a low numpy version causes the following issue with the unit tests, serialization, and fastparquet (which uses numpy header files):
```python
E   ValueError: numpy.ndarray size changed, may indicate binary incompatibility. Expected 88 from C header, got 80 from PyObject
```
- This MR solves this, according to the following: https://stackoverflow.com/a/66743692/2512385