### PR TITLE
WW/FT Serialization Updates

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -17,6 +17,7 @@ Future Release
         * Replace ``Entity`` objects in ``EntitySet`` with Woodwork dataframes (:pr:`1405`)
         * Refactor ``EntitySet.plot`` to work with Woodwork dataframes (:pr:`1468`)
         * Move ``last_time_index`` to be a column on the DataFrame (:pr:`1456`)
+        * Update serialization/deserialization to work with Woodwork (:pr:`1452`)
     * Documentation Changes
         * Improve formatting of release notes (:pr:`1396`)
     * Testing Changes

--- a/featuretools/entityset/deserialize.py
+++ b/featuretools/entityset/deserialize.py
@@ -41,10 +41,6 @@ def description_to_entityset(description, **kwargs):
 
         entityset.add_dataframe(dataframe)
 
-        # description_to_dataframe(df, entityset, path=path)
-        # if entity['properties']['last_time_index']:
-        #     last_time_index.append(entity['id'])
-
     for relationship in description['relationships']:
         rel = Relationship.from_dictionary(relationship, entityset)
         entityset.add_relationship(relationship=rel)

--- a/featuretools/entityset/deserialize.py
+++ b/featuretools/entityset/deserialize.py
@@ -57,7 +57,7 @@ def empty_dataframe(description):
         df (DataFrame) : Empty dataframe with Woodwork initialized.
     '''
     # TODO: Can we update Woodwork to return an empty initialized dataframe from a description
-    # instead of using this function?
+    # instead of using this function? Or otherwise eliminate? Issue #1476
     logical_types = {}
     semantic_tags = {}
     column_descriptions = {}

--- a/featuretools/entityset/deserialize.py
+++ b/featuretools/entityset/deserialize.py
@@ -63,6 +63,7 @@ def empty_dataframe(description):
     column_descriptions = {}
     column_metadata = {}
     use_standard_tags = {}
+    category_dtypes = {}
     columns = []
     for col in description['column_typing_info']:
         col_name = col['name']
@@ -84,7 +85,14 @@ def empty_dataframe(description):
         column_metadata[col_name] = col['metadata']
         use_standard_tags[col_name] = col['use_standard_tags']
 
-    dataframe = pd.DataFrame(columns=columns)
+        if col['physical_type']['type'] == 'category':
+            # Make sure categories are recreated properly
+            cat_values = col['physical_type']['cat_values']
+            cat_dtype = col['physical_type']['cat_dtype']
+            cat_object = pd.CategoricalDtype(pd.Index(cat_values, dtype=cat_dtype))
+            category_dtypes[col_name] = cat_object
+    dataframe = pd.DataFrame(columns=columns).astype(category_dtypes)
+
     dataframe.ww.init(
         name=description.get('name'),
         index=description.get('index'),

--- a/featuretools/entityset/deserialize.py
+++ b/featuretools/entityset/deserialize.py
@@ -31,7 +31,6 @@ def description_to_entityset(description, **kwargs):
     path = description.get('path')
     entityset = EntitySet(description['id'])
 
-    last_time_index = []
     for df in description['dataframes'].values():
         if path is not None:
             data_path = os.path.join(path, 'data', df['name'])
@@ -44,9 +43,6 @@ def description_to_entityset(description, **kwargs):
     for relationship in description['relationships']:
         rel = Relationship.from_dictionary(relationship, entityset)
         entityset.add_relationship(relationship=rel)
-
-    if len(last_time_index):
-        entityset.add_last_time_indexes(updated_entities=last_time_index)
 
     return entityset
 
@@ -62,14 +58,11 @@ def empty_dataframe(description):
     '''
     # TODO: Can we update Woodwork to return an empty initialized dataframe from a description
     # instead of using this function?
-    loading_info = description['loading_info']
-    table_type = loading_info.get('table_type', 'pandas')
     logical_types = {}
     semantic_tags = {}
     column_descriptions = {}
     column_metadata = {}
     use_standard_tags = {}
-    category_dtypes = {}
     columns = []
     for col in description['column_typing_info']:
         col_name = col['name']
@@ -91,15 +84,6 @@ def empty_dataframe(description):
         column_metadata[col_name] = col['metadata']
         use_standard_tags[col_name] = col['use_standard_tags']
 
-        if col['physical_type']['type'] == 'category':
-            # Make sure categories are recreated properly
-            cat_values = col['physical_type']['cat_values']
-            cat_dtype = col['physical_type']['cat_dtype']
-            if table_type == 'pandas':
-                cat_object = pd.CategoricalDtype(pd.Index(cat_values, dtype=cat_dtype))
-            else:
-                cat_object = pd.CategoricalDtype(pd.Series(cat_values))
-            category_dtypes[col_name] = cat_object
     dataframe = pd.DataFrame(columns=columns)
     dataframe.ww.init(
         name=description.get('name'),

--- a/featuretools/entityset/deserialize.py
+++ b/featuretools/entityset/deserialize.py
@@ -58,7 +58,7 @@ def empty_dataframe(description):
         description (dict) : Description of dataframe.
 
     Returns:
-        df (DataFrame) : Empty dataframe for entity with Woodwork initialized.
+        df (DataFrame) : Empty dataframe with Woodwork initialized.
     '''
     # TODO: Can we update Woodwork to return an empty initialized dataframe from a description
     # instead of using this function?

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -8,7 +8,7 @@ import numpy as np
 import pandas as pd
 import woodwork as ww
 
-# from featuretools.entityset import deserialize, serialize
+from featuretools.entityset import deserialize, serialize
 from featuretools.entityset.relationship import Relationship, RelationshipPath
 from featuretools.utils.gen_utils import import_or_none, is_instance
 
@@ -117,9 +117,8 @@ class EntitySet(object):
     def __sizeof__(self):
         return sum([df.__sizeof__() + df.ww.metadata.get('last_time_index').__sizeof__() for df in self.dataframes])
 
-# --> Add back later: needs to wait till serialization is implemented
-    # def __dask_tokenize__(self):
-    #     return (EntitySet, serialize.entityset_to_description(self.metadata))
+    def __dask_tokenize__(self):
+        return (EntitySet, serialize.entityset_to_description(self.metadata))
 
     def __eq__(self, other, deep=False):
         if len(self.dataframe_dict) != len(other.dataframe_dict):
@@ -157,67 +156,65 @@ class EntitySet(object):
     def dataframes(self):
         return list(self.dataframe_dict.values())
 
-# --> Add back later: needs to wait till serialization is implemented
-    # @property
-    # def metadata(self):
-    #     '''Returns the metadata for this EntitySet. The metadata will be recomputed if it does not exist.'''
-    #     if self._data_description is None:
-    #         description = serialize.entityset_to_description(self)
-    #         self._data_description = deserialize.description_to_entityset(description)
+    @property
+    def metadata(self):
+        '''Returns the metadata for this EntitySet. The metadata will be recomputed if it does not exist.'''
+        if self._data_description is None:
+            description = serialize.entityset_to_description(self)
+            self._data_description = deserialize.description_to_entityset(description)
 
-    #     return self._data_description
+        return self._data_description
 
     def reset_data_description(self):
         self._data_description = None
 
-# --> Add back later: when updating serialization for Woodwork
-    # def to_pickle(self, path, compression=None, profile_name=None):
-    #     '''Write entityset in the pickle format, location specified by `path`.
-    #         Path could be a local path or a S3 path.
-    #         If writing to S3 a tar archive of files will be written.
+    def to_pickle(self, path, compression=None, profile_name=None):
+        '''Write entityset in the pickle format, location specified by `path`.
+            Path could be a local path or a S3 path.
+            If writing to S3 a tar archive of files will be written.
 
-    #         Args:
-    #             path (str): location on disk to write to (will be created as a directory)
-    #             compression (str) : Name of the compression to use. Possible values are: {'gzip', 'bz2', 'zip', 'xz', None}.
-    #             profile_name (str) : Name of AWS profile to use, False to use an anonymous profile, or None.
-    #     '''
-    #     serialize.write_data_description(self, path, format='pickle', compression=compression, profile_name=profile_name)
-    #     return self
+            Args:
+                path (str): location on disk to write to (will be created as a directory)
+                compression (str) : Name of the compression to use. Possible values are: {'gzip', 'bz2', 'zip', 'xz', None}.
+                profile_name (str) : Name of AWS profile to use, False to use an anonymous profile, or None.
+        '''
+        serialize.write_data_description(self, path, format='pickle', compression=compression, profile_name=profile_name)
+        return self
 
-    # def to_parquet(self, path, engine='auto', compression=None, profile_name=None):
-    #     '''Write entityset to disk in the parquet format, location specified by `path`.
-    #         Path could be a local path or a S3 path.
-    #         If writing to S3 a tar archive of files will be written.
+    def to_parquet(self, path, engine='auto', compression=None, profile_name=None):
+        '''Write entityset to disk in the parquet format, location specified by `path`.
+            Path could be a local path or a S3 path.
+            If writing to S3 a tar archive of files will be written.
 
-    #         Args:
-    #             path (str): location on disk to write to (will be created as a directory)
-    #             engine (str) : Name of the engine to use. Possible values are: {'auto', 'pyarrow', 'fastparquet'}.
-    #             compression (str) : Name of the compression to use. Possible values are: {'snappy', 'gzip', 'brotli', None}.
-    #             profile_name (str) : Name of AWS profile to use, False to use an anonymous profile, or None.
-    #     '''
-    #     serialize.write_data_description(self, path, format='parquet', engine=engine, compression=compression, profile_name=profile_name)
-    #     return self
+            Args:
+                path (str): location on disk to write to (will be created as a directory)
+                engine (str) : Name of the engine to use. Possible values are: {'auto', 'pyarrow', 'fastparquet'}.
+                compression (str) : Name of the compression to use. Possible values are: {'snappy', 'gzip', 'brotli', None}.
+                profile_name (str) : Name of AWS profile to use, False to use an anonymous profile, or None.
+        '''
+        serialize.write_data_description(self, path, format='parquet', engine=engine, compression=compression, profile_name=profile_name)
+        return self
 
-    # def to_csv(self, path, sep=',', encoding='utf-8', engine='python', compression=None, profile_name=None):
-    #     '''Write entityset to disk in the csv format, location specified by `path`.
-    #         Path could be a local path or a S3 path.
-    #         If writing to S3 a tar archive of files will be written.
+    def to_csv(self, path, sep=',', encoding='utf-8', engine='python', compression=None, profile_name=None):
+        '''Write entityset to disk in the csv format, location specified by `path`.
+            Path could be a local path or a S3 path.
+            If writing to S3 a tar archive of files will be written.
 
-    #         Args:
-    #             path (str) : Location on disk to write to (will be created as a directory)
-    #             sep (str) : String of length 1. Field delimiter for the output file.
-    #             encoding (str) : A string representing the encoding to use in the output file, defaults to 'utf-8'.
-    #             engine (str) : Name of the engine to use. Possible values are: {'c', 'python'}.
-    #             compression (str) : Name of the compression to use. Possible values are: {'gzip', 'bz2', 'zip', 'xz', None}.
-    #             profile_name (str) : Name of AWS profile to use, False to use an anonymous profile, or None.
-    #     '''
-    #     if is_instance(self.dataframes[0], ks, 'DataFrame'):
-    #         compression = str(compression)
-    #     serialize.write_data_description(self, path, format='csv', index=False, sep=sep, encoding=encoding, engine=engine, compression=compression, profile_name=profile_name)
-    #     return self
+            Args:
+                path (str) : Location on disk to write to (will be created as a directory)
+                sep (str) : String of length 1. Field delimiter for the output file.
+                encoding (str) : A string representing the encoding to use in the output file, defaults to 'utf-8'.
+                engine (str) : Name of the engine to use. Possible values are: {'c', 'python'}.
+                compression (str) : Name of the compression to use. Possible values are: {'gzip', 'bz2', 'zip', 'xz', None}.
+                profile_name (str) : Name of AWS profile to use, False to use an anonymous profile, or None.
+        '''
+        if is_instance(self.dataframes[0], ks, 'DataFrame'):
+            compression = str(compression)
+        serialize.write_data_description(self, path, format='csv', index=False, sep=sep, encoding=encoding, engine=engine, compression=compression, profile_name=profile_name)
+        return self
 
-    # def to_dictionary(self):
-    #     return serialize.entityset_to_description(self)
+    def to_dictionary(self):
+        return serialize.entityset_to_description(self)
 
     ###########################################################################
     #   Public getter/setter methods  #########################################

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -553,10 +553,10 @@ class EntitySet(object):
                                                 "transaction_time": pd.date_range(start="10:00", periods=6, freq="10s"),
                                                 "fraud": [True, False, True, False, True, True]})
                 es = ft.EntitySet("example")
-                es.add_dataframe(entity_id="transactions",
-                                         index="id",
-                                         time_index="transaction_time",
-                                         dataframe=transactions_df)
+                es.add_dataframe(dataframe_id="transactions",
+                                 index="id",
+                                 time_index="transaction_time",
+                                 dataframe=transactions_df)
 
                 es["transactions"]
                 es["transactions"].df

--- a/featuretools/entityset/serialize.py
+++ b/featuretools/entityset/serialize.py
@@ -42,7 +42,7 @@ def write_data_description(entityset, path, profile_name=None, **kwargs):
 
     Args:
         entityset (EntitySet) : Instance of :class:`.EntitySet`.
-        path (str) : Location on disk or S3 path to write `data_description.json` and entity data.
+        path (str) : Location on disk or S3 path to write `data_description.json` and dataframe data.
         profile_name (str, bool): The AWS profile specified to write to S3. Will default to None and search for AWS credentials.
             Set to False to use an anonymous profile.
         kwargs (keywords) : Additional keyword arguments to pass as keywords arguments to the underlying serialization method or to specify AWS profile.

--- a/featuretools/entityset/serialize.py
+++ b/featuretools/entityset/serialize.py
@@ -4,55 +4,16 @@ import os
 import tarfile
 import tempfile
 
-import dask.dataframe as dd
+from woodwork.serialize import typing_info_to_dict
 
-from featuretools.utils.gen_utils import import_or_none, is_instance
+from featuretools.utils.gen_utils import import_or_none
 from featuretools.utils.s3_utils import get_transport_params, use_smartopen_es
 from featuretools.utils.wrangle import _is_s3, _is_url
 
 ks = import_or_none('databricks.koalas')
 
 FORMATS = ['csv', 'pickle', 'parquet']
-SCHEMA_VERSION = "6.0.0"
-
-
-def entity_to_description(entity):
-    '''Serialize entity to data description.
-
-    Args:
-        entity (Entity) : Instance of :class:`.Entity`.
-
-    Returns:
-        dictionary (dict) : Description of :class:`.Entity`.
-    '''
-    index = entity.df.columns.isin([variable.id for variable in entity.variables])
-    indexer = entity.df.columns[index].to_list() if is_instance(entity.df, ks, 'DataFrame') else entity.df.columns[index]
-    dtypes = entity.df[indexer].dtypes.astype(str).to_dict()
-    if isinstance(entity.df, dd.DataFrame):
-        entity_type = 'dask'
-    elif is_instance(entity.df, ks, 'DataFrame'):
-        entity_type = 'koalas'
-    else:
-        entity_type = 'pandas'
-    description = {
-        "id": entity.id,
-        "index": entity.index,
-        "time_index": entity.time_index,
-        "properties": {
-            'secondary_time_index': entity.secondary_time_index,
-            'last_time_index': entity.last_time_index is not None,
-        },
-        "variables": [variable.to_data_description() for variable in entity.variables],
-        "loading_info": {
-            'entity_type': entity_type,
-            'params': {},
-            'properties': {
-                'dtypes': dtypes
-            }
-        }
-    }
-
-    return description
+SCHEMA_VERSION = "7.0.0"
 
 
 def entityset_to_description(entityset):
@@ -64,70 +25,16 @@ def entityset_to_description(entityset):
     Returns:
         description (dict) : Description of :class:`.EntitySet`.
     '''
-    entities = {entity.id: entity_to_description(entity) for entity in
-                sorted(entityset.entities, key=lambda entity: entity.id)}
+
+    dataframes = {dataframe.ww.name: typing_info_to_dict(dataframe) for dataframe in entityset.dataframes}
     relationships = [relationship.to_dictionary() for relationship in entityset.relationships]
     data_description = {
         'schema_version': SCHEMA_VERSION,
         'id': entityset.id,
-        'entities': entities,
+        'dataframes': dataframes,
         'relationships': relationships,
     }
     return data_description
-
-
-def write_entity_data(entity, path, format='csv', **kwargs):
-    '''Write entity data to disk or S3 path.
-
-    Args:
-        entity (Entity) : Instance of :class:`.Entity`.
-        path (str) : Location on disk to write entity data.
-        format (str) : Format to use for writing entity data. Defaults to csv.
-        kwargs (keywords) : Additional keyword arguments to pass as keywords arguments to the underlying serialization method.
-
-    Returns:
-        loading_info (dict) : Information on storage location and format of entity data.
-    '''
-    format = format.lower()
-    if isinstance(entity.df, dd.DataFrame) and format == 'csv':
-        basename = "{}-*.{}".format(entity.id, format)
-    else:
-        basename = '.'.join([entity.id, format])
-    location = os.path.join('data', basename)
-    file = os.path.join(path, location)
-    df = entity.df
-
-    if format == 'csv':
-        if is_instance(df, ks, 'DataFrame'):
-            df = df.copy()
-            columns = list(df.select_dtypes('object').columns)
-            df[columns] = df[columns].astype(str)
-        df.to_csv(
-            file,
-            index=kwargs['index'],
-            sep=kwargs['sep'],
-            encoding=kwargs['encoding'],
-            compression=kwargs['compression'],
-        )
-    elif format == 'parquet':
-        # Serializing to parquet format raises an error when columns contain tuples.
-        # Columns containing tuples are mapped as dtype object.
-        # Issue is resolved by casting columns of dtype object to string.
-        df = df.copy()
-        columns = list(df.select_dtypes('object').columns)
-        df[columns] = df[columns].astype(str)
-        df.to_parquet(file, **kwargs)
-    elif format == 'pickle':
-        # Dask currently does not support to_pickle
-        if isinstance(df, dd.DataFrame):
-            msg = 'Cannot serialize Dask EntitySet to pickle'
-            raise ValueError(msg)
-        else:
-            df.to_pickle(file, **kwargs)
-    else:
-        error = 'must be one of the following formats: {}'
-        raise ValueError(error.format(', '.join(FORMATS)))
-    return {'location': location, 'type': format, 'params': kwargs}
 
 
 def write_data_description(entityset, path, profile_name=None, **kwargs):
@@ -158,9 +65,10 @@ def write_data_description(entityset, path, profile_name=None, **kwargs):
 
 def dump_data_description(entityset, path, **kwargs):
     description = entityset_to_description(entityset)
-    for entity in entityset.entities:
-        loading_info = write_entity_data(entity, path, **kwargs)
-        description['entities'][entity.id]['loading_info'].update(loading_info)
+    for df in entityset.dataframes:
+        data_path = os.path.join(path, 'data', df.ww.name)
+        os.makedirs(os.path.join(data_path, 'data'), exist_ok=True)
+        df.ww.to_disk(data_path, **kwargs)
     file = os.path.join(path, 'data_description.json')
     with open(file, 'w') as file:
         json.dump(description, file)

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -1424,10 +1424,9 @@ def test_getitem_without_id():
         ft.EntitySet()['test']
 
 
-# --> wait till serialization implemented
-# def test_metadata_without_id():
-#     es = ft.EntitySet()
-#     assert es.metadata.id is None
+def test_metadata_without_id():
+    es = ft.EntitySet()
+    assert es.metadata.id is None
 
 
 @pytest.fixture

--- a/featuretools/tests/entityset_tests/test_serialization.py
+++ b/featuretools/tests/entityset_tests/test_serialization.py
@@ -175,13 +175,11 @@ def test_to_parquet_interesting_values(pd_es, tmpdir):
     assert pd_es.__eq__(new_es, deep=True)
 
 
-# TODO: Fix this test after last time index is stored on DataFrame
-# instead of as series in metadata
-# def test_to_parquet_with_lti(tmpdir, pd_mock_customer):
-#     es = pd_mock_customer
-#     es.to_parquet(str(tmpdir))
-#     new_es = deserialize.read_entityset(str(tmpdir))
-#     assert es.__eq__(new_es, deep=True)
+def test_to_parquet_with_lti(tmpdir, pd_mock_customer):
+    es = pd_mock_customer
+    es.to_parquet(str(tmpdir))
+    new_es = deserialize.read_entityset(str(tmpdir))
+    assert es.__eq__(new_es, deep=True)
 
 
 def test_to_pickle_id_none(tmpdir):
@@ -400,8 +398,6 @@ def test_operations_invalidate_metadata(es):
     assert new_es.metadata is not None
     assert new_es._data_description is not None
 
-    # This fails for Koalas due to deepcopy attempted on schema containing koalas series
-    # TODO Verify this works after moving last time indexes out of metadata
     new_es.add_last_time_indexes()
     assert new_es._data_description is None
     assert new_es.metadata is not None

--- a/featuretools/tests/entityset_tests/test_serialization.py
+++ b/featuretools/tests/entityset_tests/test_serialization.py
@@ -47,7 +47,6 @@ def test_all_ww_logical_types():
     assert es.__eq__(_es, deep=True)
 
 
-# TODO: Add test that checks serialization with a custom WW logical type
 def test_with_custom_ww_logical_type():
     class CustomLogicalType(ww.logical_types.LogicalType):
         pass
@@ -83,7 +82,6 @@ def test_empty_dataframe(es):
         assert all(dataframe.columns == df.columns)
 
 
-# TODO: Verify this works after WW Issue #950 is closed
 def test_to_csv(es, tmpdir):
     es.to_csv(str(tmpdir), encoding='utf-8', engine='python')
     new_es = deserialize.read_entityset(str(tmpdir))
@@ -102,7 +100,6 @@ def test_to_csv_interesting_values(pd_es, tmpdir):
     assert pd_es.__eq__(new_es, deep=True)
 
 
-# TODO: Verify this works after WW Issue #950 is closed
 def test_to_csv_manual_interesting_values(es, tmpdir):
     es.add_interesting_values(dataframe_name='log', values={'product_id': ['coke_zero']})
     es.to_csv(str(tmpdir))

--- a/featuretools/tests/entityset_tests/test_ww_es.py
+++ b/featuretools/tests/entityset_tests/test_ww_es.py
@@ -81,7 +81,7 @@ def test_init_es_with_woodwork_table_diff_name_error(df):
     df.ww.init(index='id', name='table')
     error = "Naming conflict in dataframes dictionary: dictionary key 'diff_name' does not match dataframe name 'table'"
     with pytest.raises(ValueError, match=error):
-        es = EntitySet('es', dataframes={'diff_name': (df,)})
+        EntitySet('es', dataframes={'diff_name': (df,)})
 
 
 def test_init_es_with_dataframe_and_params(df):


### PR DESCRIPTION
### WW/FT Serialization Updates
Closes #1266 
Closes #1261 

Updates entityset serialization to work with Woodwork dataframes.

To Do:
 - [x] Verify to_csv tests work with koalas after [woodwork issue 950](https://github.com/alteryx/woodwork/issues/950) is resolved
 - [x] Confirm `test_to_parquet_with_lti` passes after last time index is moved out of WW metadata
 - [x] Confirm `test_operations_invalidate_metadata` passes for Koalas after last time index is moved out of WW metadata