### PR TITLE
Store last time index as column on DataFrame

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -16,6 +16,7 @@ Future Release
         * Move validation check for uniform time index to ``EntitySet`` (:pr:`1400`)
         * Replace ``Entity`` objects in ``EntitySet`` with Woodwork dataframes (:pr:`1405`)
         * Refactor ``EntitySet.plot`` to work with Woodwork dataframes (:pr:`1468`)
+        * Move ``last_time_index`` to be a column on the DataFrame (:pr:`1456`)
     * Documentation Changes
         * Improve formatting of release notes (:pr:`1396`)
     * Testing Changes

--- a/featuretools/entityset/api.py
+++ b/featuretools/entityset/api.py
@@ -1,6 +1,6 @@
 # flake8: noqa
 from .deserialize import read_entityset
 from .entity import Entity
-from .entityset import EntitySet
+from .entityset import LTI_COLUMN_NAME, EntitySet
 from .relationship import Relationship
 from .timedelta import Timedelta

--- a/featuretools/entityset/api.py
+++ b/featuretools/entityset/api.py
@@ -1,6 +1,6 @@
 # flake8: noqa
 from .deserialize import read_entityset
 from .entity import Entity
-from .entityset import LTI_COLUMN_NAME, EntitySet
+from .entityset import EntitySet
 from .relationship import Relationship
 from .timedelta import Timedelta

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -1056,8 +1056,8 @@ class EntitySet(object):
             lti = es_lti_dict[df.ww.name]
             if lti is not None:
                 if self.time_type == 'numeric':
-                    # --> don't totally understand why this is necessary when we can do the conversion normally?
                     if lti.dtype == 'datetime64[ns]':
+                        # Woodwork cannot convert from datetime to numeric
                         lti = lti.apply(lambda x: x.value)
                     lti = ww.init_series(lti, logical_type='Double')
                 else:

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -1055,7 +1055,6 @@ class EntitySet(object):
         for df in self.dataframes:
             lti = es_lti_dict[df.ww.name]
             if lti is not None:
-                # --> maybe do this conversaion after creating the df
                 if self.time_type == 'numeric':
                     # --> don't totally understand why this is necessary when we can do the conversion normally?
                     # --> need to make sure this works for dask and koalas
@@ -1398,7 +1397,6 @@ class EntitySet(object):
             if updated_series is not series:
                 df[col_name] = updated_series
 
-        # --> WW bug: if metadata has a series in it, cannot deepcopy
         df.ww.init(schema=self[dataframe_name].ww._schema)
         # Make sure column ordering matches original ordering
         df = df.ww[old_column_names]

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -1378,6 +1378,13 @@ class EntitySet(object):
         if not isinstance(df, type(self[dataframe_name])):
             raise TypeError('Incorrect DataFrame type used')
 
+        # If the original DataFrame has a last time index column and the new one doesnt
+        # remove the column and the reference to last time index from that dataframe
+        last_time_index_column = self[dataframe_name].ww.metadata.get('last_time_index')
+        if last_time_index_column is not None and last_time_index_column not in df.columns:
+            self[dataframe_name].ww.pop(last_time_index_column)
+            del self[dataframe_name].ww.metadata['last_time_index']
+
         old_column_names = list(self[dataframe_name].columns)
         if len(df.columns) != len(old_column_names):
             raise ValueError("Updated dataframe contains {} columns, expecting {}".format(len(df.columns),
@@ -1411,7 +1418,7 @@ class EntitySet(object):
 
         df_metadata = self[dataframe_name].ww.metadata
         self.set_secondary_time_index(dataframe_name, df_metadata.get('secondary_time_index'))
-        if recalculate_last_time_indexes and df_metadata.get('last_time_index') is not None:
+        if recalculate_last_time_indexes and last_time_index_column is not None:
             self.add_last_time_indexes(updated_dataframes=[dataframe_name])
         self.reset_data_description()
 

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -935,6 +935,7 @@ class EntitySet(object):
 
         for df in queue:
             # --> should we also be putting a column in the df yet? probs not
+            # --> maybbe need to drop a last_time column here to reset all ltis
             df.ww.metadata['last_time_index'] = None
 
         # We will explore children of dataframes on the queue,

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -354,7 +354,6 @@ class EntitySet(object):
             "Cannot set secondary time index if Woodwork is not initialized"
         self._check_secondary_time_index(dataframe, secondary_time_index)
         if secondary_time_index is not None:
-            # --> WW bug: series in Metadata can be problematic
             dataframe.ww.metadata['secondary_time_index'] = secondary_time_index
 
     ###########################################################################
@@ -744,7 +743,7 @@ class EntitySet(object):
 
                 time_index_types = (base_dataframe.ww.logical_types[base_dataframe.ww.time_index],
                                     base_dataframe.ww.semantic_tags[base_dataframe.ww.time_index],
-                                    base_dataframe.ww.columns[base_dataframe.ww.time_index].metadata,  # --> not sure we want to maintain metadata here - first time index might be clunkly
+                                    base_dataframe.ww.columns[base_dataframe.ww.time_index].metadata,
                                     base_dataframe.ww.columns[base_dataframe.ww.time_index].description)
             else:
                 # If base_time_index is in copy_columns then we've already added the transfer types
@@ -941,9 +940,6 @@ class EntitySet(object):
             es_lti_dict[df.ww.name] = lti_col
 
         for df in queue:
-            # --> maybbe need to drop a last_time column here to reset all ltis if present
-            # --> plus if creating a dict do ltis[df.ww.name] = None
-
             es_lti_dict[df.ww.name] = None
 
         # We will explore children of dataframes on the queue,
@@ -972,9 +968,6 @@ class EntitySet(object):
                         lti = lti.astype('object')
                         lti[:] = None
 
-                # --> this isn't the final lti, right? so maybe wait until the end to store on the dataframe?
-                # maybe a bit weird to change whats stored on metadata, but as long as we're ok with temp having series, then we can
-                # probably takes longer to add to the whole df
                 es_lti_dict[dataframe.ww.name] = lti
 
             if dataframe.ww.name in children:

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -1054,6 +1054,16 @@ class EntitySet(object):
         for df in self.dataframes:
             lti = es_lti_dict[df.ww.name]
             if lti is not None:
+                if self.time_type == 'numeric':
+                    # --> don't totally understand why this is necessary when we can do the conversion normally?
+                    # --> need to make sure this works for dask and koalas
+                    if lti.dtype == 'datetime64[ns]':
+                        lti = lti.apply(lambda x: x.value)
+                    # --> nullable shouldn't be necessary once we fix index issue
+                    lti = ww.init_series(lti, logical_type='IntegerNullable')
+                else:
+                    lti = ww.init_series(lti, logical_type='Datetime')
+
                 df.ww['last_time'] = lti
                 df.ww.add_semantic_tags({'last_time': 'last_time_index'})
                 df.ww.metadata['last_time_index'] = 'last_time'

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -1055,16 +1055,15 @@ class EntitySet(object):
         for df in self.dataframes:
             lti = es_lti_dict[df.ww.name]
             if lti is not None:
-                # # --> maybe do this conversaion after creating the df
-                # if self.time_type == 'numeric':
-                #     # --> don't totally understand why this is necessary when we can do the conversion normally?
-                #     # --> need to make sure this works for dask and koalas
-                #     if lti.dtype == 'datetime64[ns]':
-                #         lti = lti.apply(lambda x: x.value)
-                #     # --> nullable shouldn't be necessary once we fix index issue
-                #     lti = ww.init_series(lti, logical_type='IntegerNullable')
-                # else:
-                #     lti = ww.init_series(lti, logical_type='Datetime')
+                # --> maybe do this conversaion after creating the df
+                if self.time_type == 'numeric':
+                    # --> don't totally understand why this is necessary when we can do the conversion normally?
+                    # --> need to make sure this works for dask and koalas
+                    if lti.dtype == 'datetime64[ns]':
+                        lti = lti.apply(lambda x: x.value)
+                    lti = ww.init_series(lti, logical_type='Double')
+                else:
+                    lti = ww.init_series(lti, logical_type='Datetime')
 
                 # Add the new column to the DataFrame
                 lti.name = 'last_time'

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -1068,9 +1068,12 @@ class EntitySet(object):
 
                 # Add the new column to the DataFrame
                 lti.name = 'last_time'
+                if 'last_time' in df.columns:
+                    df.pop('last_time')
                 if isinstance(df, dd.DataFrame):
                     new_df = df.merge(lti.reset_index(), on=df.ww.index)
                     new_df.ww.init(
+                        name=df.ww.name,
                         index=df.ww.index,
                         time_index=df.ww.time_index,
                         logical_types=df.ww.logical_types,
@@ -1079,6 +1082,7 @@ class EntitySet(object):
                         column_metadata={col_name: col_schema.metadata for col_name, col_schema in df.ww.columns.items()},
                         use_standard_tags=df.ww.use_standard_tags
                     )
+                    new_df.index = new_df[new_df.ww.index]
                     dfs_to_update[df.ww.name] = new_df
                 elif is_instance(df, ks, 'DataFrame'):
                     new_df = df.merge(lti, left_on=df.ww.index, right_index=True)
@@ -1103,6 +1107,7 @@ class EntitySet(object):
         for df in dfs_to_update.values():
             df.ww.add_semantic_tags({'last_time': 'last_time_index'})
             df.ww.metadata['last_time_index'] = 'last_time'
+            # --> note this means we have new dataframe objects
             self.dataframe_dict[df.ww.name] = df
 
         self.reset_data_description()

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -1057,7 +1057,6 @@ class EntitySet(object):
             if lti is not None:
                 if self.time_type == 'numeric':
                     # --> don't totally understand why this is necessary when we can do the conversion normally?
-                    # --> need to make sure this works for dask and koalas
                     if lti.dtype == 'datetime64[ns]':
                         lti = lti.apply(lambda x: x.value)
                     lti = ww.init_series(lti, logical_type='Double')

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -937,7 +937,8 @@ class EntitySet(object):
         for df in self.dataframes:
             lti_col = df.ww.metadata.get('last_time_index')
             if lti_col is not None:
-                es_lti_dict[df.ww.name] = df[lti_col]
+                lti_col = df[lti_col]
+            es_lti_dict[df.ww.name] = lti_col
 
         for df in queue:
             # --> maybbe need to drop a last_time column here to reset all ltis if present

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -27,6 +27,8 @@ ks = import_or_none('databricks.koalas')
 pd.options.mode.chained_assignment = None  # default='warn'
 logger = logging.getLogger('featuretools.entityset')
 
+LTI_COLUMN_NAME = '_ft_last_time'
+
 
 class EntitySet(object):
     """
@@ -904,7 +906,6 @@ class EntitySet(object):
             updated_dataframes (list[str]): List of dataframe names to update last_time_index for
                 (will update all parents of those dataframes as well)
         """
-        LTI_COLUMN_NAME = '_ft_last_time'
         # Generate graph of dataframes to find leaf dataframes
         children = defaultdict(list)  # parent --> child mapping
         child_cols = defaultdict(dict)

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -1049,6 +1049,9 @@ class EntitySet(object):
         for df in self.dataframes:
             lti = df.ww.metadata.get('last_time_index')
             if lti is not None:
+                # --> bug!!
+                # Dask will not reorder the indices, so if they do not match,
+                # values will be replaced with nans
                 df.ww['last_time'] = lti
                 df.ww.add_semantic_tags({'last_time': 'last_time_index'})
                 df.ww.metadata['last_time_index'] = 'last_time'

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -1,6 +1,5 @@
 import copy
 import logging
-from pdb import set_trace
 import warnings
 from collections import defaultdict
 

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -898,7 +898,8 @@ class EntitySet(object):
         """
         Calculates the last time index values for each dataframe (the last time
         an instance or children of that instance were observed).  Used when
-        calculating features using training windows
+        calculating features using training windows. Adds the last time index as
+        a series named _ft_last_time on the dataframe.
         Args:
             updated_dataframes (list[str]): List of dataframe names to update last_time_index for
                 (will update all parents of those dataframes as well)

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -1065,10 +1065,12 @@ class EntitySet(object):
                 else:
                     lti = ww.init_series(lti, logical_type='Datetime')
 
-                # Add the new column to the DataFrame
+                # Remove any existing last_time column to prevent collisions
                 lti.name = 'last_time'
                 if 'last_time' in df.columns:
-                    df.pop('last_time')
+                    df.ww.pop('last_time')
+
+                # Add the new column to the DataFrame
                 if isinstance(df, dd.DataFrame):
                     new_df = df.merge(lti.reset_index(), on=df.ww.index)
                     new_df.ww.init(
@@ -1089,7 +1091,6 @@ class EntitySet(object):
                 elif is_instance(df, ks, 'DataFrame'):
                     new_df = df.merge(lti, left_on=df.ww.index, right_index=True)
 
-                    # --> this is bad and makes it easy to screw up
                     new_df.ww.init(
                         name=df.ww.name,
                         index=df.ww.index,
@@ -1109,7 +1110,6 @@ class EntitySet(object):
         for df in dfs_to_update.values():
             df.ww.add_semantic_tags({'last_time': 'last_time_index'})
             df.ww.metadata['last_time_index'] = 'last_time'
-            # --> note this means we have new dataframe objects
             self.dataframe_dict[df.ww.name] = df
 
         self.reset_data_description()

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -115,7 +115,7 @@ class EntitySet(object):
         self.reset_data_description()
 
     def __sizeof__(self):
-        return sum([df.__sizeof__() + df.ww.metadata.get('last_time_index').__sizeof__() for df in self.dataframes])
+        return sum([df.__sizeof__() for df in self.dataframes])
 
 # --> Add back later: needs to wait till serialization is implemented
     # def __dask_tokenize__(self):

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -1082,7 +1082,10 @@ class EntitySet(object):
                         column_metadata={col_name: col_schema.metadata for col_name, col_schema in df.ww.columns.items()},
                         use_standard_tags=df.ww.use_standard_tags
                     )
-                    new_df.index = new_df[new_df.ww.index]
+
+                    new_idx = new_df[new_df.ww.index]
+                    new_idx.name = None
+                    new_df.index = new_idx
                     dfs_to_update[df.ww.name] = new_df
                 elif is_instance(df, ks, 'DataFrame'):
                     new_df = df.merge(lti, left_on=df.ww.index, right_index=True)

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -1054,9 +1054,6 @@ class EntitySet(object):
         for df in self.dataframes:
             lti = es_lti_dict[df.ww.name]
             if lti is not None:
-                # --> bug!!
-                # Dask will not reorder the indices, so if they do not match,
-                # values will be replaced with nans
                 df.ww['last_time'] = lti
                 df.ww.add_semantic_tags({'last_time': 'last_time_index'})
                 df.ww.metadata['last_time_index'] = 'last_time'

--- a/featuretools/tests/entityset_tests/test_dask_es.py
+++ b/featuretools/tests/entityset_tests/test_dask_es.py
@@ -126,8 +126,11 @@ def test_add_last_time_indexes():
     pd_es.add_last_time_indexes()
     dask_es.add_last_time_indexes()
 
-    pd.testing.assert_series_equal(pd_es['sessions'].ww.metadata.get('last_time_index').sort_index(),
-                                   dask_es['sessions'].ww.metadata.get('last_time_index').compute(), check_names=False)
+    pd_lti_name = pd_es['sessions'].ww.metadata.get('last_time_index')
+    ks_lti_name = dask_es['sessions'].ww.metadata.get('last_time_index')
+    assert pd_lti_name == ks_lti_name
+    pd.testing.assert_series_equal(pd_es['sessions'][pd_lti_name].sort_index(),
+                                   dask_es['sessions'][ks_lti_name].compute().sort_index(), check_names=False)
 
 
 def test_add_dataframe_with_make_index():

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -1405,7 +1405,6 @@ def test_sizeof(es):
     total_size = 0
     for df in es.dataframes:
         total_size += df.__sizeof__()
-        total_size += df.ww.metadata.get('last_time_index').__sizeof__()
 
     assert es.__sizeof__() == total_size
 

--- a/featuretools/tests/entityset_tests/test_koalas_es.py
+++ b/featuretools/tests/entityset_tests/test_koalas_es.py
@@ -132,8 +132,11 @@ def test_add_last_time_indexes():
     pd_es.add_last_time_indexes()
     ks_es.add_last_time_indexes()
 
-    pd.testing.assert_series_equal(pd_es['sessions'].ww.metadata.get('last_time_index').sort_index(),
-                                   ks_es['sessions'].ww.metadata.get('last_time_index').to_pandas().sort_index(), check_names=False)
+    pd_lti_name = pd_es['sessions'].ww.metadata.get('last_time_index')
+    ks_lti_name = ks_es['sessions'].ww.metadata.get('last_time_index')
+    assert pd_lti_name == ks_lti_name
+    pd.testing.assert_series_equal(pd_es['sessions'][pd_lti_name].sort_index(),
+                                   ks_es['sessions'][ks_lti_name].to_pandas().sort_index(), check_names=False)
 
 
 @pytest.mark.skipif('not ks')

--- a/featuretools/tests/entityset_tests/test_last_time_index.py
+++ b/featuretools/tests/entityset_tests/test_last_time_index.py
@@ -5,6 +5,7 @@ import pytest
 import woodwork.logical_types as ltypes
 from dask import dataframe as dd
 
+from featuretools.entityset import LTI_COLUMN_NAME
 from featuretools.tests.testing_utils import to_pandas
 from featuretools.utils.gen_utils import import_or_none
 
@@ -87,7 +88,7 @@ class TestLastTimeIndex(object):
         log = es['log']
         lti_name = log.ww.metadata.get('last_time_index')
 
-        assert lti_name == '_ft_last_time'
+        assert lti_name == LTI_COLUMN_NAME
         assert len(log[lti_name]) == 17
 
         log_df = to_pandas(log)
@@ -100,9 +101,9 @@ class TestLastTimeIndex(object):
         stores = es['stores']
         true_lti = pd.Series([None for x in range(6)], dtype='datetime64[ns]')
 
-        assert len(true_lti) == len(stores['_ft_last_time'])
+        assert len(true_lti) == len(stores[LTI_COLUMN_NAME])
 
-        stores_lti = to_pandas(stores['_ft_last_time'])
+        stores_lti = to_pandas(stores[LTI_COLUMN_NAME])
 
         for v1, v2 in zip(stores_lti, true_lti):
             assert (pd.isnull(v1) and pd.isnull(v2)) or v1 == v2

--- a/featuretools/tests/entityset_tests/test_last_time_index.py
+++ b/featuretools/tests/entityset_tests/test_last_time_index.py
@@ -85,18 +85,25 @@ class TestLastTimeIndex(object):
     def test_leaf(self, es):
         es.add_last_time_indexes()
         log = es['log']
-        assert len(log.ww.metadata.get('last_time_index')) == 17
+        lti_name = log.ww.metadata.get('last_time_index')
+
+        assert lti_name == 'last_time'
+        assert len(log[lti_name]) == 17
+
         log_df = to_pandas(log)
-        log_lti = to_pandas(log.ww.metadata.get('last_time_index'))
-        for v1, v2 in zip(log_lti, log_df['datetime']):
+
+        for v1, v2 in zip(log_df[lti_name], log_df['datetime']):
             assert (pd.isnull(v1) and pd.isnull(v2)) or v1 == v2
 
     def test_leaf_no_time_index(self, es):
         es.add_last_time_indexes()
         stores = es['stores']
         true_lti = pd.Series([None for x in range(6)], dtype='datetime64[ns]')
-        assert len(true_lti) == len(stores.ww.metadata.get('last_time_index'))
-        stores_lti = to_pandas(stores.ww.metadata.get('last_time_index'))
+
+        assert len(true_lti) == len(stores['last_time'])
+
+        stores_lti = to_pandas(stores['last_time'])
+
         for v1, v2 in zip(stores_lti, true_lti):
             assert (pd.isnull(v1) and pd.isnull(v2)) or v1 == v2
 
@@ -107,8 +114,9 @@ class TestLastTimeIndex(object):
             pytest.xfail('possible issue with either normalize_dataframe or add_last_time_indexes')
         values_es.add_last_time_indexes()
         values = values_es['values']
-        assert len(values.ww.metadata.get('last_time_index')) == 11
-        sorted_lti = to_pandas(values.ww.metadata.get('last_time_index')).sort_index()
+        lti_name = values.ww.metadata.get('last_time_index')
+        assert len(values[lti_name]) == 11
+        sorted_lti = to_pandas(values[lti_name]).sort_index()
         for v1, v2 in zip(sorted_lti, true_values_lti):
             assert (pd.isnull(v1) and pd.isnull(v2)) or v1 == v2
 
@@ -136,8 +144,9 @@ class TestLastTimeIndex(object):
         true_values_lti[11] = pd.Timestamp("2011-04-10 11:10:03")
 
         values = values_es['values']
-        assert len(values.ww.metadata.get('last_time_index')) == 12
-        sorted_lti = values.ww.metadata.get('last_time_index').sort_index()
+        lti_name = values.ww.metadata.get('last_time_index')
+        assert len(values[lti_name]) == 12
+        sorted_lti = values[lti_name].sort_index()
         for v1, v2 in zip(sorted_lti, true_values_lti):
             assert (pd.isnull(v1) and pd.isnull(v2)) or v1 == v2
 
@@ -145,8 +154,9 @@ class TestLastTimeIndex(object):
         # test dataframe without time index and all instances have children
         es.add_last_time_indexes()
         sessions = es['sessions']
-        assert len(sessions.ww.metadata.get('last_time_index')) == 6
-        sorted_lti = to_pandas(sessions.ww.metadata.get('last_time_index')).sort_index()
+        lti_name = sessions.ww.metadata.get('last_time_index')
+        assert len(sessions[lti_name]) == 6
+        sorted_lti = to_pandas(sessions[lti_name]).sort_index()
         for v1, v2 in zip(sorted_lti, true_sessions_lti):
             assert (pd.isnull(v1) and pd.isnull(v2)) or v1 == v2
 
@@ -161,8 +171,9 @@ class TestLastTimeIndex(object):
         true_sessions_lti[6] = pd.NaT
         sessions = es['sessions']
 
-        assert len(sessions.ww.metadata.get('last_time_index')) == 7
-        sorted_lti = to_pandas(sessions.ww.metadata.get('last_time_index')).sort_index()
+        lti_name = sessions.ww.metadata.get('last_time_index')
+        assert len(sessions[lti_name]) == 7
+        sorted_lti = to_pandas(sessions[lti_name]).sort_index()
         for v1, v2 in zip(sorted_lti, true_sessions_lti):
             assert (pd.isnull(v1) and pd.isnull(v2)) or v1 == v2
 
@@ -189,8 +200,9 @@ class TestLastTimeIndex(object):
         true_sessions_lti[1] = pd.Timestamp("2011-4-9 10:31:30")
         true_sessions_lti[3] = pd.Timestamp("2011-4-10 10:41:00")
 
-        assert len(sessions.ww.metadata.get('last_time_index')) == 6
-        sorted_lti = to_pandas(sessions.ww.metadata.get('last_time_index')).sort_index()
+        lti_name = sessions.ww.metadata.get('last_time_index')
+        assert len(sessions[lti_name]) == 6
+        sorted_lti = to_pandas(sessions[lti_name]).sort_index()
         for v1, v2 in zip(sorted_lti, true_sessions_lti):
             assert (pd.isnull(v1) and pd.isnull(v2)) or v1 == v2
 
@@ -220,8 +232,9 @@ class TestLastTimeIndex(object):
         # now only session id 1 has newer event in wishlist_log
         true_sessions_lti[1] = pd.Timestamp("2011-4-9 10:31:30")
 
-        assert len(sessions.ww.metadata.get('last_time_index')) == 6
-        sorted_lti = to_pandas(sessions.ww.metadata.get('last_time_index')).sort_index()
+        lti_name = sessions.ww.metadata.get('last_time_index')
+        assert len(sessions[lti_name]) == 6
+        sorted_lti = to_pandas(sessions[lti_name]).sort_index()
         for v1, v2 in zip(sorted_lti, true_sessions_lti):
             assert (pd.isnull(v1) and pd.isnull(v2)) or v1 == v2
 
@@ -261,8 +274,9 @@ class TestLastTimeIndex(object):
         true_sessions_lti[3] = pd.Timestamp("2011-4-10 10:41:00")
         true_sessions_lti[6] = pd.Timestamp("2011-04-11 11:11:11")
 
-        assert len(sessions.ww.metadata.get('last_time_index')) == 7
-        sorted_lti = to_pandas(sessions.ww.metadata.get('last_time_index')).sort_index()
+        lti_name = sessions.ww.metadata.get('last_time_index')
+        assert len(sessions[lti_name]) == 7
+        sorted_lti = to_pandas(sessions[lti_name]).sort_index()
         for v1, v2 in zip(sorted_lti, true_sessions_lti):
             assert (pd.isnull(v1) and pd.isnull(v2)) or v1 == v2
 
@@ -304,8 +318,9 @@ class TestLastTimeIndex(object):
         true_sessions_lti[1] = pd.Timestamp("2011-4-9 10:31:30")
         true_sessions_lti[6] = pd.Timestamp("2011-04-11 11:11:11")
 
-        assert len(sessions.ww.metadata.get('last_time_index')) == 7
-        sorted_lti = to_pandas(sessions.ww.metadata.get('last_time_index')).sort_index()
+        lti_name = sessions.ww.metadata.get('last_time_index')
+        assert len(sessions[lti_name]) == 7
+        sorted_lti = to_pandas(sessions[lti_name]).sort_index()
         for v1, v2 in zip(sorted_lti, true_sessions_lti):
             assert (pd.isnull(v1) and pd.isnull(v2)) or v1 == v2
 
@@ -340,8 +355,9 @@ class TestLastTimeIndex(object):
         true_sessions_lti[3] = pd.Timestamp("2011-4-10 10:41:00")
         true_sessions_lti[6] = pd.NaT
 
-        assert len(sessions.ww.metadata.get('last_time_index')) == 7
-        sorted_lti = to_pandas(sessions.ww.metadata.get('last_time_index')).sort_index()
+        lti_name = sessions.ww.metadata.get('last_time_index')
+        assert len(sessions[lti_name]) == 7
+        sorted_lti = to_pandas(sessions[lti_name]).sort_index()
         for v1, v2 in zip(sorted_lti, true_sessions_lti):
             assert (pd.isnull(v1) and pd.isnull(v2)) or v1 == v2
 
@@ -369,7 +385,8 @@ class TestLastTimeIndex(object):
                                         datetime(2011, 4, 10, 10, 41, 6),
                                         datetime(2011, 4, 10, 11, 10, 3)])
 
-        assert len(customers.ww.metadata.get('last_time_index')) == 3
-        sorted_lti = to_pandas(customers.ww.metadata.get('last_time_index')).sort_index()
+        lti_name = customers.ww.metadata.get('last_time_index')
+        assert len(customers[lti_name]) == 3
+        sorted_lti = to_pandas(customers[lti_name]).sort_index()
         for v1, v2 in zip(sorted_lti, true_customers_lti):
             assert (pd.isnull(v1) and pd.isnull(v2)) or v1 == v2

--- a/featuretools/tests/entityset_tests/test_last_time_index.py
+++ b/featuretools/tests/entityset_tests/test_last_time_index.py
@@ -5,7 +5,7 @@ import pytest
 import woodwork.logical_types as ltypes
 from dask import dataframe as dd
 
-from featuretools.entityset import LTI_COLUMN_NAME
+from featuretools.entityset.entityset import LTI_COLUMN_NAME
 from featuretools.tests.testing_utils import to_pandas
 from featuretools.utils.gen_utils import import_or_none
 

--- a/featuretools/tests/entityset_tests/test_last_time_index.py
+++ b/featuretools/tests/entityset_tests/test_last_time_index.py
@@ -387,10 +387,6 @@ class TestLastTimeIndex(object):
 
         lti_name = customers.ww.metadata.get('last_time_index')
         assert len(customers[lti_name]) == 3
-        if ks and isinstance(customers, ks.DataFrame):
-            # Koalas doesn't reorder indexes the same way
-            sorted_lti = to_pandas(customers).sort_values('id')[lti_name]
-        else:
-            sorted_lti = to_pandas(customers[lti_name]).sort_index()
+        sorted_lti = to_pandas(customers).sort_values('id')[lti_name]
         for v1, v2 in zip(sorted_lti, true_customers_lti):
             assert (pd.isnull(v1) and pd.isnull(v2)) or v1 == v2

--- a/featuretools/tests/entityset_tests/test_last_time_index.py
+++ b/featuretools/tests/entityset_tests/test_last_time_index.py
@@ -87,7 +87,7 @@ class TestLastTimeIndex(object):
         log = es['log']
         lti_name = log.ww.metadata.get('last_time_index')
 
-        assert lti_name == 'last_time'
+        assert lti_name == '_ft_last_time'
         assert len(log[lti_name]) == 17
 
         log_df = to_pandas(log)
@@ -100,9 +100,9 @@ class TestLastTimeIndex(object):
         stores = es['stores']
         true_lti = pd.Series([None for x in range(6)], dtype='datetime64[ns]')
 
-        assert len(true_lti) == len(stores['last_time'])
+        assert len(true_lti) == len(stores['_ft_last_time'])
 
-        stores_lti = to_pandas(stores['last_time'])
+        stores_lti = to_pandas(stores['_ft_last_time'])
 
         for v1, v2 in zip(stores_lti, true_lti):
             assert (pd.isnull(v1) and pd.isnull(v2)) or v1 == v2

--- a/featuretools/tests/entityset_tests/test_ww_es.py
+++ b/featuretools/tests/entityset_tests/test_ww_es.py
@@ -303,11 +303,12 @@ def test_add_last_time_non_numeric_index(pd_es, ks_es, dask_es):
     # --> might also be the case any non pandas non numeric bc it both cant replace and also won't match
     # koalas and dask don't set the underlying index to match the woodwork index
     pd_es.add_last_time_indexes(['products'])
-    dask_es.add_last_time_indexes(['products'])
+    # dask_es.add_last_time_indexes(['products'])
     ks_es.add_last_time_indexes(['products'])
 
     assert list(to_pandas(pd_es['products']['last_time'], sort_index=True)) == list(to_pandas(dask_es['products']['last_time'], sort_index=True))
     assert list(to_pandas(pd_es['products']['last_time'], sort_index=True)) == list(to_pandas(ks_es['products']['last_time'], sort_index=True))
+    # --> confirm schemas match as well
 
 
 def test_lti_already_has_last_time_column(es):

--- a/featuretools/tests/entityset_tests/test_ww_es.py
+++ b/featuretools/tests/entityset_tests/test_ww_es.py
@@ -679,7 +679,7 @@ def test_update_dataframe_dont_recalculate_last_time_index(es):
 
 
 def test_update_dataframe_recalculate_last_time_index(es):
-    es.add_last_time_indexes(['customers'])
+    es.add_last_time_indexes()
 
     original_time_index = es['customers']['signup_date'].copy()
 
@@ -694,6 +694,16 @@ def test_update_dataframe_recalculate_last_time_index(es):
     # --> dask groupby fails
     es.update_dataframe('customers', new_dataframe, recalculate_last_time_indexes=True)
     pd.testing.assert_series_equal(to_pandas(es['customers']['last_time']), to_pandas(new_time_index), check_names=False)
+
+
+def test_repeat_lti_calls_working(pd_es):
+    pd_es.add_last_time_indexes(['products'])
+    pd_es.add_last_time_indexes(['products'])
+
+
+def test_repeat_lti_calls_broken(pd_es):
+    pd_es.add_last_time_indexes(['régions'])
+    pd_es.add_last_time_indexes(['régions'])
 
 # --> update where time indexes don't change at all - confirm no ltis change
 

--- a/featuretools/tests/entityset_tests/test_ww_es.py
+++ b/featuretools/tests/entityset_tests/test_ww_es.py
@@ -312,22 +312,21 @@ def test_add_last_time_non_numeric_index(pd_es, ks_es, dask_es):
     assert pd_es['products'].ww.schema == ks_es['products'].ww.schema
 
 
-# --> handle later
-# def test_lti_already_has_last_time_column(es):
-    # col = es['customers'].ww.pop('loves_ice_cream')
-    # col.name = 'last_time'
+def test_lti_already_has_last_time_column(es):
+    col = es['customers'].ww.pop('loves_ice_cream')
+    col.name = 'last_time'
 
-    # es['customers'].ww['last_time'] = col
+    es['customers'].ww['last_time'] = col
 
-    # assert 'last_time' in es['customers'].columns
-    # assert isinstance(es['customers'].ww.logical_types['last_time'], Boolean)
+    assert 'last_time' in es['customers'].columns
+    assert isinstance(es['customers'].ww.logical_types['last_time'], Boolean)
 
-    # es.add_last_time_indexes(['customers'])
+    es.add_last_time_indexes(['customers'])
 
-    # # Current behavior will attempt to overwrite this column.
-    # assert es['customers'].ww.metadata['last_time_index'] == 'last_time'
-    # assert isinstance(es['customers'].ww.logical_types['last_time'], Datetime)
-    # assert es['customers'].ww.semantic_tags['last_time'] == {'last_time_index'}
+    # Current behavior will attempt to overwrite this column.
+    assert es['customers'].ww.metadata['last_time_index'] == 'last_time'
+    assert isinstance(es['customers'].ww.logical_types['last_time'], Datetime)
+    assert es['customers'].ww.semantic_tags['last_time'] == {'last_time_index'}
 
 # --> add a test where we deep copy a ww dataframe with lti
 

--- a/featuretools/tests/entityset_tests/test_ww_es.py
+++ b/featuretools/tests/entityset_tests/test_ww_es.py
@@ -330,24 +330,24 @@ def test_lti_already_has_last_time_column(es):
 # --> add a test where we deep copy a ww dataframe with lti
 
 
-def test_numeric_es_last_time_index_logical_type(int_es):
-    assert int_es.time_type == 'numeric'
+# def test_numeric_es_last_time_index_logical_type(int_es):
+#     assert int_es.time_type == 'numeric'
 
-    int_es.add_last_time_indexes()
+#     int_es.add_last_time_indexes()
 
-    for df in int_es.dataframes:
-        assert isinstance(df.ww.logical_types['last_time'], IntegerNullable)
-        int_es._check_uniform_time_index(df, 'last_time')
+#     for df in int_es.dataframes:
+#         assert isinstance(df.ww.logical_types['last_time'], IntegerNullable)
+#         int_es._check_uniform_time_index(df, 'last_time')
 
 
-def test_datetime_es_last_time_index_logical_type(es):
-    assert es.time_type == Datetime
+# def test_datetime_es_last_time_index_logical_type(es):
+#     assert es.time_type == Datetime
 
-    es.add_last_time_indexes()
+#     es.add_last_time_indexes()
 
-    for df in es.dataframes:
-        assert isinstance(df.ww.logical_types['last_time'], Datetime)
-        es._check_uniform_time_index(df, 'last_time')
+#     for df in es.dataframes:
+#         assert isinstance(df.ww.logical_types['last_time'], Datetime)
+#         es._check_uniform_time_index(df, 'last_time')
 
 
 def test_dataframe_without_name(es):

--- a/featuretools/tests/entityset_tests/test_ww_es.py
+++ b/featuretools/tests/entityset_tests/test_ww_es.py
@@ -292,10 +292,10 @@ def test_add_last_time_index(es):
 
     assert 'last_time_index' in es['products'].ww.metadata
 
-    assert es['products'].ww.metadata['last_time_index'] == 'last_time'
-    assert 'last_time' in es['products']
-    assert 'last_time_index' in es['products'].ww.semantic_tags['last_time']
-    assert isinstance(es['products'].ww.logical_types['last_time'], Datetime)
+    assert es['products'].ww.metadata['last_time_index'] == '_ft_last_time'
+    assert '_ft_last_time' in es['products']
+    assert 'last_time_index' in es['products'].ww.semantic_tags['_ft_last_time']
+    assert isinstance(es['products'].ww.logical_types['_ft_last_time'], Datetime)
 
 
 def test_add_last_time_non_numeric_index(pd_es, ks_es, dask_es):
@@ -303,28 +303,26 @@ def test_add_last_time_non_numeric_index(pd_es, ks_es, dask_es):
     dask_es.add_last_time_indexes(['products'])
     ks_es.add_last_time_indexes(['products'])
 
-    assert list(to_pandas(pd_es['products']['last_time']).sort_index()) == list(to_pandas(dask_es['products']['last_time']).sort_index())
-    assert list(to_pandas(pd_es['products']['last_time']).sort_index()) == list(to_pandas(ks_es['products']).sort_values('id')['last_time'])
+    assert list(to_pandas(pd_es['products']['_ft_last_time']).sort_index()) == list(to_pandas(dask_es['products']['_ft_last_time']).sort_index())
+    assert list(to_pandas(pd_es['products']['_ft_last_time']).sort_index()) == list(to_pandas(ks_es['products']).sort_values('id')['_ft_last_time'])
 
     assert pd_es['products'].ww.schema == dask_es['products'].ww.schema
     assert pd_es['products'].ww.schema == ks_es['products'].ww.schema
 
 
-def test_lti_already_has_last_time_column(es):
+def test_lti_already_has_last_time_column_name(es):
     col = es['customers'].ww.pop('loves_ice_cream')
-    col.name = 'last_time'
+    col.name = '_ft_last_time'
 
-    es['customers'].ww['last_time'] = col
+    es['customers'].ww['_ft_last_time'] = col
 
-    assert 'last_time' in es['customers'].columns
-    assert isinstance(es['customers'].ww.logical_types['last_time'], Boolean)
+    assert '_ft_last_time' in es['customers'].columns
+    assert isinstance(es['customers'].ww.logical_types['_ft_last_time'], Boolean)
 
-    es.add_last_time_indexes(['customers'])
-
-    # Current behavior will attempt to overwrite this column.
-    assert es['customers'].ww.metadata['last_time_index'] == 'last_time'
-    assert isinstance(es['customers'].ww.logical_types['last_time'], Datetime)
-    assert es['customers'].ww.semantic_tags['last_time'] == {'last_time_index'}
+    error = ("Cannot add a last time index on DataFrame with an existing "
+             f"'_ft_last_time' column. Please rename '_ft_last_time'.")
+    with pytest.raises(ValueError, match=error):
+        es.add_last_time_indexes(['customers'])
 
 
 def test_numeric_es_last_time_index_logical_type(int_es):
@@ -333,8 +331,8 @@ def test_numeric_es_last_time_index_logical_type(int_es):
     int_es.add_last_time_indexes()
 
     for df in int_es.dataframes:
-        assert isinstance(df.ww.logical_types['last_time'], Double)
-        int_es._check_uniform_time_index(df, 'last_time')
+        assert isinstance(df.ww.logical_types['_ft_last_time'], Double)
+        int_es._check_uniform_time_index(df, '_ft_last_time')
 
 
 def test_datetime_es_last_time_index_logical_type(es):
@@ -343,8 +341,8 @@ def test_datetime_es_last_time_index_logical_type(es):
     es.add_last_time_indexes()
 
     for df in es.dataframes:
-        assert isinstance(df.ww.logical_types['last_time'], Datetime)
-        es._check_uniform_time_index(df, 'last_time')
+        assert isinstance(df.ww.logical_types['_ft_last_time'], Datetime)
+        es._check_uniform_time_index(df, '_ft_last_time')
 
 
 def test_dataframe_without_name(es):
@@ -683,7 +681,7 @@ def test_update_dataframe_and_min_last_time_index(es):
     es.add_last_time_indexes(['products'])
 
     original_time_index = es['log']['datetime'].copy()
-    original_last_time_index = es['products']['last_time'].copy()
+    original_last_time_index = es['products']['_ft_last_time'].copy()
 
     if ks and isinstance(original_time_index, ks.Series):
         new_time_index = ks.from_pandas(original_time_index.to_pandas() + pd.Timedelta(days=1))
@@ -694,20 +692,20 @@ def test_update_dataframe_and_min_last_time_index(es):
 
     new_dataframe = es['log'].copy()
     new_dataframe['datetime'] = new_time_index
-    new_dataframe.pop('last_time')
+    new_dataframe.pop('_ft_last_time')
 
     es.update_dataframe('log', new_dataframe, recalculate_last_time_indexes=True)
 
     # Koalas reorders indices during last time index, so we sort to confirm individual values are the same
-    pd.testing.assert_series_equal(to_pandas(es['products']['last_time']).sort_index(), to_pandas(expected_last_time_index).sort_index())
-    pd.testing.assert_series_equal(to_pandas(es['log']['last_time']).sort_index(), to_pandas(new_time_index).sort_index(), check_names=False)
+    pd.testing.assert_series_equal(to_pandas(es['products']['_ft_last_time']).sort_index(), to_pandas(expected_last_time_index).sort_index())
+    pd.testing.assert_series_equal(to_pandas(es['log']['_ft_last_time']).sort_index(), to_pandas(new_time_index).sort_index(), check_names=False)
 
 
 def test_update_dataframe_dont_recalculate_last_time_index_present(es):
     es.add_last_time_indexes()
 
     original_time_index = es['customers']['signup_date'].copy()
-    original_last_time_index = es['customers']['last_time'].copy()
+    original_last_time_index = es['customers']['_ft_last_time'].copy()
 
     if ks and isinstance(original_time_index, ks.Series):
         new_time_index = ks.from_pandas(original_time_index.to_pandas() + pd.Timedelta(days=10))
@@ -718,7 +716,7 @@ def test_update_dataframe_dont_recalculate_last_time_index_present(es):
     new_dataframe['signup_date'] = new_time_index
 
     es.update_dataframe('customers', new_dataframe, recalculate_last_time_indexes=False)
-    pd.testing.assert_series_equal(to_pandas(es['customers']['last_time'], sort_index=True), to_pandas(original_last_time_index, sort_index=True))
+    pd.testing.assert_series_equal(to_pandas(es['customers']['_ft_last_time'], sort_index=True), to_pandas(original_last_time_index, sort_index=True))
 
 
 def test_update_dataframe_dont_recalculate_last_time_index_not_present(es):
@@ -735,7 +733,7 @@ def test_update_dataframe_dont_recalculate_last_time_index_not_present(es):
 
     new_dataframe = es['customers'].copy()
     new_dataframe['signup_date'] = new_time_index
-    new_dataframe.pop('last_time')
+    new_dataframe.pop('_ft_last_time')
 
     es.update_dataframe('customers', new_dataframe, recalculate_last_time_indexes=False)
     assert 'last_time_index' not in es['customers'].ww.metadata
@@ -754,7 +752,7 @@ def test_update_dataframe_recalculate_last_time_index_not_present(es):
 
     new_dataframe = es['log'].copy()
     new_dataframe['datetime'] = new_time_index
-    new_dataframe.pop('last_time')
+    new_dataframe.pop('_ft_last_time')
 
     es.update_dataframe('log', new_dataframe, recalculate_last_time_indexes=True)
     pd.testing.assert_series_equal(to_pandas(es['log']['datetime']).sort_index(), to_pandas(new_time_index).sort_index(), check_names=False)
@@ -772,7 +770,7 @@ def test_update_dataframe_recalcuate_last_time_index_present(es):
 
     new_dataframe = es['log'].copy()
     new_dataframe['datetime'] = new_time_index
-    assert 'last_time' in new_dataframe.columns
+    assert '_ft_last_time' in new_dataframe.columns
 
     es.update_dataframe('log', new_dataframe, recalculate_last_time_indexes=True)
     pd.testing.assert_series_equal(to_pandas(es['log']['datetime']).sort_index(), to_pandas(new_time_index).sort_index(), check_names=False)

--- a/featuretools/tests/entityset_tests/test_ww_es.py
+++ b/featuretools/tests/entityset_tests/test_ww_es.py
@@ -14,7 +14,7 @@ from woodwork.logical_types import (
     NaturalLanguage
 )
 
-from featuretools.entityset import LTI_COLUMN_NAME, EntitySet
+from featuretools.entityset.entityset import LTI_COLUMN_NAME, EntitySet
 from featuretools.tests.testing_utils import to_pandas
 from featuretools.utils.gen_utils import import_or_none
 

--- a/featuretools/tests/entityset_tests/test_ww_es.py
+++ b/featuretools/tests/entityset_tests/test_ww_es.py
@@ -291,6 +291,14 @@ def test_add_last_time_indexes(es):
 
     assert 'last_time_index' in es['products'].ww.metadata
 
+    assert es['products'].ww.metadata['last_time_index'] == 'last_time'
+    assert 'last_time' in es['products']
+    assert 'last_time_index' in es['products'].ww.semantic_tags['last_time']
+    assert isinstance(es['products'].ww.logical_types['last_time'], Datetime)
+
+# --> add a test where there's already a last_time column and it gets replaced
+# --> add a test where we deep copy a ww dataframe with lti
+
 
 def test_dataframe_without_name(es):
     new_es = EntitySet()

--- a/featuretools/tests/entityset_tests/test_ww_es.py
+++ b/featuretools/tests/entityset_tests/test_ww_es.py
@@ -758,9 +758,10 @@ def test_update_dataframe_recalculate_last_time_index_not_present(es):
 
     es.update_dataframe('log', new_dataframe, recalculate_last_time_indexes=True)
     pd.testing.assert_series_equal(to_pandas(es['log']['datetime']).sort_index(), to_pandas(new_time_index).sort_index(), check_names=False)
+    pd.testing.assert_series_equal(to_pandas(es['log'][LTI_COLUMN_NAME]).sort_index(), to_pandas(new_time_index).sort_index(), check_names=False)
 
 
-def test_update_dataframe_recalcuate_last_time_index_present(es):
+def test_update_dataframe_recalculate_last_time_index_present(es):
     es.add_last_time_indexes()
 
     original_time_index = es['log']['datetime'].copy()
@@ -776,6 +777,7 @@ def test_update_dataframe_recalcuate_last_time_index_present(es):
 
     es.update_dataframe('log', new_dataframe, recalculate_last_time_indexes=True)
     pd.testing.assert_series_equal(to_pandas(es['log']['datetime']).sort_index(), to_pandas(new_time_index).sort_index(), check_names=False)
+    pd.testing.assert_series_equal(to_pandas(es['log'][LTI_COLUMN_NAME]).sort_index(), to_pandas(new_time_index).sort_index(), check_names=False)
 
 
 def test_normalize_dataframe_loses_column_metadata(es):

--- a/featuretools/tests/entityset_tests/test_ww_es.py
+++ b/featuretools/tests/entityset_tests/test_ww_es.py
@@ -328,8 +328,6 @@ def test_lti_already_has_last_time_column(es):
     assert isinstance(es['customers'].ww.logical_types['last_time'], Datetime)
     assert es['customers'].ww.semantic_tags['last_time'] == {'last_time_index'}
 
-# --> add a test where we deep copy a ww dataframe with lti
-
 
 def test_numeric_es_last_time_index_logical_type(int_es):
     assert int_es.time_type == 'numeric'
@@ -739,8 +737,6 @@ def test_update_dataframe_recalculate_last_time_index(es):
 
     es.update_dataframe('log', new_dataframe, recalculate_last_time_indexes=True)
     pd.testing.assert_series_equal(to_pandas(es['log']['datetime']).sort_index(), to_pandas(new_time_index).sort_index(), check_names=False)
-
-# --> test koalas index reordering
 
 
 def test_normalize_dataframe_loses_column_metadata(es):

--- a/featuretools/tests/entityset_tests/test_ww_es.py
+++ b/featuretools/tests/entityset_tests/test_ww_es.py
@@ -296,6 +296,29 @@ def test_add_last_time_indexes(es):
     assert 'last_time_index' in es['products'].ww.semantic_tags['last_time']
     assert isinstance(es['products'].ww.logical_types['last_time'], Datetime)
 
+
+def test_update_dataframe_and_lti(pd_es):
+    pd_es.add_last_time_indexes(['products'])
+
+    # dfs_with_lti = [df.ww.metadata.get('last_time_index') is None for df in pd_es.dataframes]
+
+    original_time_index = pd_es['log']['datetime'].copy()
+    new_time_index = original_time_index + pd.Timedelta(days=1)
+    new_dataframe = pd_es['log'].copy()
+    new_dataframe['datetime'] = new_time_index
+
+    original_last_time_index = pd_es['products']['last_time'].copy()
+    expected_last_time_index = original_last_time_index + pd.Timedelta(days=1)
+
+    pd_es.update_dataframe('log', new_dataframe, recalculate_last_time_indexes=True)
+    # dfs_with_lti_after_update = [df.ww.metadata.get('last_time_index') is None for df in pd_es.dataframes]
+
+    # assert dfs_with_lti == dfs_with_lti_after_update
+
+    assert pd_es['products']['last_time'].equals(expected_last_time_index)
+    assert pd_es['log']['last_time'].equals(new_time_index)
+
+
 # --> add a test where there's already a last_time column and it gets replaced
 # --> add a test where we deep copy a ww dataframe with lti
 # --> test lti logical types matching time type

--- a/featuretools/tests/entityset_tests/test_ww_es.py
+++ b/featuretools/tests/entityset_tests/test_ww_es.py
@@ -299,6 +299,8 @@ def test_add_last_time_index(es):
 
 
 def test_add_last_time_non_numeric_index(pd_es, ks_es, dask_es):
+    # Confirm that add_last_time_index works for indices that aren't numeric
+    # since numeric underlying indices can accidentally match the Woodwork index
     pd_es.add_last_time_indexes(['products'])
     dask_es.add_last_time_indexes(['products'])
     ks_es.add_last_time_indexes(['products'])

--- a/featuretools/tests/entityset_tests/test_ww_es.py
+++ b/featuretools/tests/entityset_tests/test_ww_es.py
@@ -298,6 +298,7 @@ def test_add_last_time_indexes(es):
 
 # --> add a test where there's already a last_time column and it gets replaced
 # --> add a test where we deep copy a ww dataframe with lti
+# --> test lti logical types matching time type
 
 
 def test_dataframe_without_name(es):

--- a/featuretools/tests/entityset_tests/test_ww_es.py
+++ b/featuretools/tests/entityset_tests/test_ww_es.py
@@ -297,26 +297,27 @@ def test_add_last_time_indexes(es):
     assert isinstance(es['products'].ww.logical_types['last_time'], Datetime)
 
 
-def test_update_dataframe_and_lti(pd_es):
-    pd_es.add_last_time_indexes(['products'])
+def test_update_dataframe_and_lti(es):
+    # --> ks doesn't work because of index order and timedelta adding
+    es.add_last_time_indexes(['products'])
 
     # dfs_with_lti = [df.ww.metadata.get('last_time_index') is None for df in pd_es.dataframes]
 
-    original_time_index = pd_es['log']['datetime'].copy()
+    original_time_index = es['log']['datetime'].copy()
     new_time_index = original_time_index + pd.Timedelta(days=1)
-    new_dataframe = pd_es['log'].copy()
+    new_dataframe = es['log'].copy()
     new_dataframe['datetime'] = new_time_index
 
-    original_last_time_index = pd_es['products']['last_time'].copy()
+    original_last_time_index = es['products']['last_time'].copy()
     expected_last_time_index = original_last_time_index + pd.Timedelta(days=1)
 
-    pd_es.update_dataframe('log', new_dataframe, recalculate_last_time_indexes=True)
+    es.update_dataframe('log', new_dataframe, recalculate_last_time_indexes=True)
     # dfs_with_lti_after_update = [df.ww.metadata.get('last_time_index') is None for df in pd_es.dataframes]
 
     # assert dfs_with_lti == dfs_with_lti_after_update
 
-    assert pd_es['products']['last_time'].equals(expected_last_time_index)
-    assert pd_es['log']['last_time'].equals(new_time_index)
+    pd.testing.assert_series_equal(to_pandas(es['products']['last_time']), to_pandas(expected_last_time_index))
+    pd.testing.assert_series_equal(to_pandas(es['log']['last_time']), to_pandas(new_time_index), check_names=False)
 
 
 # --> add a test where there's already a last_time column and it gets replaced
@@ -659,7 +660,7 @@ def test_update_dataframe_different_dataframe_types():
 
 def test_update_dataframe_last_time_index(es):
     # --> koalas currently fails bc we can't get the schema because it deepcopies
-    # --> broken because I havent yet figured out how to do this when ltis already exist
+    # --> giving some bugs - something seems to have changed. need to check.
     es.add_last_time_indexes()
     df = es['customers'].copy()
 

--- a/featuretools/tests/entityset_tests/test_ww_es.py
+++ b/featuretools/tests/entityset_tests/test_ww_es.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from pdb import set_trace
 
 import dask.dataframe as dd
 import numpy as np
@@ -12,7 +11,6 @@ from woodwork.logical_types import (
     Datetime,
     Double,
     Integer,
-    IntegerNullable,
     NaturalLanguage
 )
 

--- a/featuretools/tests/entityset_tests/test_ww_es.py
+++ b/featuretools/tests/entityset_tests/test_ww_es.py
@@ -297,6 +297,17 @@ def test_add_last_time_index(es):
     assert isinstance(es['products'].ww.logical_types['last_time'], Datetime)
 
 
+def test_add_last_time_non_numeric_index(pd_es, ks_es, dask_es):
+    # --> might also be the case any non pandas non numeric bc it both cant replace and also won't match
+    # koalas and dask don't set the underlying index to match the woodwork index
+    pd_es.add_last_time_indexes(['products'])
+    dask_es.add_last_time_indexes(['products'])
+    ks_es.add_last_time_indexes(['products'])
+
+    assert list(to_pandas(pd_es['products']['last_time'], sort_index=True)) == list(to_pandas(dask_es['products']['last_time'], sort_index=True))
+    assert list(to_pandas(pd_es['products']['last_time'], sort_index=True)) == list(to_pandas(ks_es['products']['last_time'], sort_index=True))
+
+
 # --> add a test where there's already a last_time column and it gets replaced
 # --> add a test where we deep copy a ww dataframe with lti
 # --> test lti logical types matching time type

--- a/featuretools/tests/entityset_tests/test_ww_es.py
+++ b/featuretools/tests/entityset_tests/test_ww_es.py
@@ -332,24 +332,24 @@ def test_add_last_time_non_numeric_index(pd_es, ks_es, dask_es):
 # --> add a test where we deep copy a ww dataframe with lti
 
 
-# def test_numeric_es_last_time_index_logical_type(int_es):
-#     assert int_es.time_type == 'numeric'
+def test_numeric_es_last_time_index_logical_type(int_es):
+    assert int_es.time_type == 'numeric'
 
-#     int_es.add_last_time_indexes()
+    int_es.add_last_time_indexes()
 
-#     for df in int_es.dataframes:
-#         assert isinstance(df.ww.logical_types['last_time'], IntegerNullable)
-#         int_es._check_uniform_time_index(df, 'last_time')
+    for df in int_es.dataframes:
+        assert isinstance(df.ww.logical_types['last_time'], Double)
+        int_es._check_uniform_time_index(df, 'last_time')
 
 
-# def test_datetime_es_last_time_index_logical_type(es):
-#     assert es.time_type == Datetime
+def test_datetime_es_last_time_index_logical_type(es):
+    assert es.time_type == Datetime
 
-#     es.add_last_time_indexes()
+    es.add_last_time_indexes()
 
-#     for df in es.dataframes:
-#         assert isinstance(df.ww.logical_types['last_time'], Datetime)
-#         es._check_uniform_time_index(df, 'last_time')
+    for df in es.dataframes:
+        assert isinstance(df.ww.logical_types['last_time'], Datetime)
+        es._check_uniform_time_index(df, 'last_time')
 
 
 def test_dataframe_without_name(es):


### PR DESCRIPTION
Stores `last_time_index` as a column in the Woodwork dataframe.

Identifying factors of the last time index column:
- Name of the column stored in `df.ww.metadata` under `'last_time_index'`
- The column will be names `last_time` (unless there's overlap between names - tbd what we'll do there)
- The semantic tag `last_time_index` will be added to the column in the woodwork table 

Some of these (the semantic tag) might be overkill, but I figured more things that indicate that the column is additional data the better.

To Do:

- [x] Determine why we started having to add `astype('object')` before converting to datetime (possibly related to the dtype being different somehow when the lti is coming off a woodwork dataframe??)
- [x] Unexplained bugs for `add_last_time_indexes` when called from update_dataframe
  - [x] In `test_update_dataframe_and_lti` find way to test koalas with timedelta and/or mismatched index
  - [x] `test_update_dataframe_last_time_index` koalas and dask failures
- [x] Fix koalas inability to reorder indices (check calculate feature matrix to see if there's something there)
- [x] Additional woodwork testing for last time index in `test_ww_es`
- [x] Update `__sizeof__` to no longer look at metadata for the last time index
- [x] confirm `test_to_parquet_with_lti` and `test_operations_invalidate_metadata` are working correctly (might have to wait till after) #1452 
- [x] confirm bug with not being able to deepcopy koalas dataframes is gone

 
closes #1254 
