### PR TITLE
Update EntitySet.plot to use Woodwork

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -15,6 +15,7 @@ Future Release
         * Replaced ``Entity.update_data`` with ``EntitySet.update_dataframe`` (:pr:`1398`)
         * Move validation check for uniform time index to ``EntitySet`` (:pr:`1400`)
         * Replace ``Entity`` objects in ``EntitySet`` with Woodwork dataframes (:pr:`1405`)
+        * Refactor ``EntitySet.plot`` to work with Woodwork dataframes (:pr:`1468`)
     * Documentation Changes
         * Improve formatting of release notes (:pr:`1396`)
     * Testing Changes

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -1145,7 +1145,7 @@ class EntitySet(object):
         # Draw entities
         for df in self.dataframes:
             # --> need to finda nice way to show this
-            columns_string = '\l'.join([col_name + ': ' + str(col_schema)[14:-1]  # noqa: W605
+            columns_string = '\l'.join([col_name + ' : ' + str(col_schema.logical_type) + ', ' + str(list(col_schema.semantic_tags))  # noqa: W605
                                           for col_name, col_schema in df.ww.columns.items()])
             if isinstance(df, dd.DataFrame):  # entity is a dask entity
                 label = '{%s |%s\l}' % (df.ww.name, columns_string)  # noqa: W605

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -1145,8 +1145,8 @@ class EntitySet(object):
         # Draw entities
         for df in self.dataframes:
             # --> need to finda nice way to show this
-            columns_string = '\l'.join([str(col_schema)  # noqa: W605
-                                          for col_schema in df.ww.columns])
+            columns_string = '\l'.join([col_name + ': ' + str(col_schema)[14:-1]  # noqa: W605
+                                          for col_name, col_schema in df.ww.columns.items()])
             if isinstance(df, dd.DataFrame):  # entity is a dask entity
                 label = '{%s |%s\l}' % (df.ww.name, columns_string)  # noqa: W605
             else:

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -1131,8 +1131,13 @@ class EntitySet(object):
 
         Returns:
             graphviz.Digraph : Graph object that can directly be displayed in
-                Jupyter notebooks.
+                Jupyter notebooks. Nodes of the graph correspond to the DataFrames
+                in the EntitySet, showing the typing information for each column.
 
+        Note:
+            The typing information displayed for each column is based off of the Woodwork
+            ColumnSchema for that column and is represented as ``LogicalType; semantic_tags``,
+            but the standard semantic tags have been removed for brevity.
         """
         graphviz = check_graphviz()
         format_ = get_graphviz_format(graphviz=graphviz,

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -1144,9 +1144,17 @@ class EntitySet(object):
 
         # Draw entities
         for df in self.dataframes:
-            # --> need to finda nice way to show this
-            columns_string = '\l'.join([col_name + ' : ' + str(col_schema.logical_type) + ', ' + str(list(col_schema.semantic_tags))  # noqa: W605
-                                          for col_name, col_schema in df.ww.columns.items()])
+            column_typing_info = []
+            for col_name, col_schema in df.ww.columns.items():
+                col_string = col_name + ' : ' + str(col_schema.logical_type)
+
+                tags = col_schema.semantic_tags - col_schema.logical_type.standard_tags
+                if tags:
+                    col_string += '; '
+                    col_string += ', '.join(tags)
+                column_typing_info.append(col_string)
+
+            columns_string = '\l'.join(column_typing_info)  # noqa: W605
             if isinstance(df, dd.DataFrame):  # entity is a dask entity
                 label = '{%s |%s\l}' % (df.ww.name, columns_string)  # noqa: W605
             else:

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -15,11 +15,11 @@ from featuretools.utils.gen_utils import import_or_none, is_instance
 # import pandas.api.types as pdtypes
 
 
-# from featuretools.utils.plot_utils import (
-#     check_graphviz,
-#     get_graphviz_format,
-#     save_graph
-# )
+from featuretools.utils.plot_utils import (
+    check_graphviz,
+    get_graphviz_format,
+    save_graph
+)
 # from featuretools.utils.wrangle import _check_timedelta
 
 ks = import_or_none('databricks.koalas')
@@ -1121,52 +1121,53 @@ class EntitySet(object):
 
         self.reset_data_description()
 
-    # def plot(self, to_file=None):
-    #     """
-    #     Create a UML diagram-ish graph of the EntitySet.
+    def plot(self, to_file=None):
+        """
+        Create a UML diagram-ish graph of the EntitySet.
 
-    #     Args:
-    #         to_file (str, optional) : Path to where the plot should be saved.
-    #             If set to None (as by default), the plot will not be saved.
+        Args:
+            to_file (str, optional) : Path to where the plot should be saved.
+                If set to None (as by default), the plot will not be saved.
 
-    #     Returns:
-    #         graphviz.Digraph : Graph object that can directly be displayed in
-    #             Jupyter notebooks.
+        Returns:
+            graphviz.Digraph : Graph object that can directly be displayed in
+                Jupyter notebooks.
 
-    #     """
-    #     graphviz = check_graphviz()
-    #     format_ = get_graphviz_format(graphviz=graphviz,
-    #                                   to_file=to_file)
+        """
+        graphviz = check_graphviz()
+        format_ = get_graphviz_format(graphviz=graphviz,
+                                      to_file=to_file)
 
-    #     # Initialize a new directed graph
-    #     graph = graphviz.Digraph(self.id, format=format_,
-    #                              graph_attr={'splines': 'ortho'})
+        # Initialize a new directed graph
+        graph = graphviz.Digraph(self.id, format=format_,
+                                 graph_attr={'splines': 'ortho'})
 
-    #     # Draw entities
-    #     for entity in self.dataframes:
-    #         variables_string = '\l'.join([var.id + ' : ' + var.type_string  # noqa: W605
-    #                                       for var in entity.variables])
-    #         if isinstance(entity.df, dd.DataFrame):  # entity is a dask entity
-    #             label = '{%s |%s\l}' % (entity.id, variables_string)  # noqa: W605
-    #         else:
-    #             nrows = entity.shape[0]
-    #             label = '{%s (%d row%s)|%s\l}' % (entity.id, nrows, 's' * (nrows > 1), variables_string)  # noqa: W605
-    #         graph.node(entity.id, shape='record', label=label)
+        # Draw entities
+        for df in self.dataframes:
+            # --> need to finda nice way to show this
+            columns_string = '\l'.join([str(col_schema)  # noqa: W605
+                                          for col_schema in df.ww.columns])
+            if isinstance(df, dd.DataFrame):  # entity is a dask entity
+                label = '{%s |%s\l}' % (df.ww.name, columns_string)  # noqa: W605
+            else:
+                nrows = df.shape[0]
+                label = '{%s (%d row%s)|%s\l}' % (df.ww.name, nrows, 's' * (nrows > 1), columns_string)  # noqa: W605
+            graph.node(df.ww.name, shape='record', label=label)
 
-    #     # Draw relationships
-    #     for rel in self.relationships:
-    #         # Display the key only once if is the same for both related entities
-    #         if rel._parent_column_name == rel._child_column_name:
-    #             label = rel._parent_column_name
-    #         else:
-    #             label = '%s -> %s' % (rel._parent_column_name,
-    #                                   rel._child_column_name)
+        # Draw relationships
+        for rel in self.relationships:
+            # Display the key only once if is the same for both related entities
+            if rel._parent_column_name == rel._child_column_name:
+                label = rel._parent_column_name
+            else:
+                label = '%s -> %s' % (rel._parent_column_name,
+                                      rel._child_column_name)
 
-    #         graph.edge(rel._child_dataframe_name, rel._parent_column_name, xlabel=label)
+            graph.edge(rel._child_dataframe_name, rel._parent_dataframe_name, xlabel=label)
 
-    #     if to_file:
-    #         save_graph(graph, to_file, format_)
-    #     return graph
+        if to_file:
+            save_graph(graph, to_file, format_)
+        return graph
 
     # def _handle_time(self, entity_id, df, time_last=None, training_window=None, include_cutoff_time=True):
     #     """

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -11,15 +11,15 @@ import woodwork as ww
 # from featuretools.entityset import deserialize, serialize
 from featuretools.entityset.relationship import Relationship, RelationshipPath
 from featuretools.utils.gen_utils import import_or_none, is_instance
-
-# import pandas.api.types as pdtypes
-
-
 from featuretools.utils.plot_utils import (
     check_graphviz,
     get_graphviz_format,
     save_graph
 )
+
+# import pandas.api.types as pdtypes
+
+
 # from featuretools.utils.wrangle import _check_timedelta
 
 ks = import_or_none('databricks.koalas')

--- a/featuretools/tests/entityset_tests/test_plotting.py
+++ b/featuretools/tests/entityset_tests/test_plotting.py
@@ -13,7 +13,7 @@ import featuretools as ft
 def pd_simple():
     es = ft.EntitySet("test")
     df = pd.DataFrame({"foo": [1]})
-    es.entity_from_dataframe("test", df)
+    es.add_dataframe(df, dataframe_name='test')
     return es
 
 
@@ -22,7 +22,7 @@ def dd_simple():
     es = ft.EntitySet("test")
     df = pd.DataFrame({"foo": [1]})
     df = dd.from_pandas(df, npartitions=2)
-    es.entity_from_dataframe("test", df)
+    es.add_dataframe(df, dataframe_name='test')
     return es
 
 
@@ -31,7 +31,7 @@ def ks_simple():
     ks = pytest.importorskip('databricks.koalas', reason="Koalas not installed, skipping")
     es = ft.EntitySet("test")
     df = ks.DataFrame({'foo': [1]})
-    es.entity_from_dataframe('test', df)
+    es.add_dataframe(df, dataframe_name='test')
     return es
 
 
@@ -76,8 +76,8 @@ def test_invalid_format(es):
 def test_multiple_rows(es):
     plot_ = es.plot()
     result = re.findall(r"\((\d+\srows?)\)", plot_.source)
-    expected = ["{} rows".format(str(i.shape[0])) for i in es.entities]
-    if any(isinstance(entity.df, dd.DataFrame) for entity in es.entities):
+    expected = ["{} rows".format(str(i.shape[0])) for i in es.dataframes]
+    if any(isinstance(df, dd.DataFrame) for df in es.dataframes):
         # Dask does not list number of rows in plot
         assert result == []
     else:
@@ -88,7 +88,7 @@ def test_single_row(simple_es):
     plot_ = simple_es.plot()
     result = re.findall(r"\((\d+\srows?)\)", plot_.source)
     expected = ["1 row"]
-    if any(isinstance(entity.df, dd.DataFrame) for entity in simple_es.entities):
+    if any(isinstance(df, dd.DataFrame) for df in simple_es.dataframes):
         # Dask does not list number of rows in plot
         assert result == []
     else:


### PR DESCRIPTION
Updates `EntitySet.plot` to use Woodwork logical types and semantic tags.

Here's a reminder of what the current plot looks like on Main:
![image](https://user-images.githubusercontent.com/64278226/121083899-fc3c1e00-c7ad-11eb-8b7c-35d2f27ae50e.png)



Here's a peek at the updated plot (open to other suggestions for how to handle the combination of logical types and semantic tags without being too busy):
![image](https://user-images.githubusercontent.com/64278226/121083874-f47c7980-c7ad-11eb-8f3f-4a0e556658d9.png)

closes #1418 
