### PR TITLE
Replace list_variable_types with list_logical_types

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -17,6 +17,7 @@ Future Release
         * Replace ``Entity`` objects in ``EntitySet`` with Woodwork dataframes (:pr:`1405`)
         * Refactor ``EntitySet.plot`` to work with Woodwork dataframes (:pr:`1468`)
         * Move ``last_time_index`` to be a column on the DataFrame (:pr:`1456`)
+        * Replace ``list_variable_types`` with ``list_logical_types`` (:pr:`1477`)
     * Documentation Changes
         * Improve formatting of release notes (:pr:`1396`)
     * Testing Changes
@@ -69,6 +70,8 @@ Breaking Changes
 * ``last_time_index``, ``secondary_time_index``, and ``interesting_values`` are no longer attributes
   of an entityset’s tables that can be accessed directly. Now they must be accessed through the metadata
   of the Woodwork DataFrame, which is a dictionary.
+* The helper function ``list_variable_types`` has been replaced with ``list_logical_types``.
+  To help minimize breaking changes, ``list_variable_types`` will return the same output as ``list_logical_types``.
 
 What's New in this Release
 ++++++++++++++++++++++++++

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -70,8 +70,8 @@ Breaking Changes
 * ``last_time_index``, ``secondary_time_index``, and ``interesting_values`` are no longer attributes
   of an entityset’s tables that can be accessed directly. Now they must be accessed through the metadata
   of the Woodwork DataFrame, which is a dictionary.
-* The helper function ``list_variable_types`` has been replaced with ``list_logical_types``.
-  To help minimize breaking changes, ``list_variable_types`` will return the same output as ``list_logical_types``.
+* The helper function ``list_variable_types`` will be removed in a future release and replaced by ``list_logical_types``.
+  In the meantime, ``list_variable_types`` will return the same output as ``list_logical_types``.
 
 What's New in this Release
 ++++++++++++++++++++++++++

--- a/featuretools/__init__.py
+++ b/featuretools/__init__.py
@@ -32,6 +32,7 @@ import pkg_resources
 import sys
 import traceback
 import warnings
+from woodwork import list_logical_types
 
 logger = logging.getLogger('featuretools')
 

--- a/featuretools/tests/utils_tests/test_gen_utils.py
+++ b/featuretools/tests/utils_tests/test_gen_utils.py
@@ -1,7 +1,9 @@
 import dask.dataframe as dd
 import pandas as pd
 import pytest
+import woodwork as ww
 
+import featuretools as ft
 from featuretools.utils.gen_utils import (
     import_or_none,
     import_or_raise,
@@ -54,3 +56,9 @@ def test_is_instance_none_module(df):
     assert not is_instance(df, None, 'DataFrame')
     assert is_instance(df, (None, pd), 'DataFrame')
     assert is_instance(df, (None, pd), ('Series', 'DataFrame'))
+
+
+def test_list_logical_types():
+    ft_ltypes = ft.list_logical_types()
+    ww_ltypes = ww.list_logical_types()
+    assert ft_ltypes.equals(ww_ltypes)

--- a/featuretools/tests/variables/test_variables_utils.py
+++ b/featuretools/tests/variables/test_variables_utils.py
@@ -3,6 +3,7 @@ import os
 
 import graphviz
 import pytest
+from woodwork import list_logical_types
 
 from featuretools import variable_types as v_types
 from featuretools.variable_types import (
@@ -30,13 +31,9 @@ def test_find_variable_types():
 
 
 def test_list_variables():
-    df = list_variable_types()
-    for v_name, v_type in find_variable_types().items():
-        assert v_type.__name__ in df['name'].values
-        assert v_type.__doc__ in df['description'].values
-        assert v_type.type_string in df['type_string'].values
-    assert 'text' not in df['type_string']
-    assert Text not in df['name']
+    vtypes = list_variable_types()
+    ltypes = list_logical_types()
+    assert vtypes.equals(ltypes)
 
 
 def test_returns_digraph_object():

--- a/featuretools/tests/variables/test_variables_utils.py
+++ b/featuretools/tests/variables/test_variables_utils.py
@@ -3,6 +3,7 @@ import os
 
 import graphviz
 import pytest
+from pytest import warns
 from woodwork import list_logical_types
 
 from featuretools import variable_types as v_types
@@ -31,7 +32,9 @@ def test_find_variable_types():
 
 
 def test_list_variables():
-    vtypes = list_variable_types()
+    match = 'list_variable_types has been deprecated. Please use featuretools.list_logical_types instead.'
+    with warns(FutureWarning, match=match):
+        vtypes = list_variable_types()
     ltypes = list_logical_types()
     assert vtypes.equals(ltypes)
 

--- a/featuretools/variable_types/api.py
+++ b/featuretools/variable_types/api.py
@@ -2,6 +2,7 @@
 from .utils import (
     find_variable_types,
     graph_variable_types,
+    list_logical_types,
     list_variable_types
 )
 from .variable import *

--- a/featuretools/variable_types/api.py
+++ b/featuretools/variable_types/api.py
@@ -2,7 +2,6 @@
 from .utils import (
     find_variable_types,
     graph_variable_types,
-    list_logical_types,
     list_variable_types
 )
 from .variable import *

--- a/featuretools/variable_types/utils.py
+++ b/featuretools/variable_types/utils.py
@@ -1,3 +1,5 @@
+from warnings import warn
+
 from woodwork import list_logical_types
 
 from featuretools.utils.gen_utils import find_descendents
@@ -37,6 +39,8 @@ def list_variable_types():
         variable_types (pd.DataFrame): a DataFrame with column headers of
             name, type_strings, and description.
     """
+    message = 'list_variable_types has been deprecated. Please use featuretools.list_logical_types instead.'
+    warn(message=message, category=FutureWarning)
     return list_logical_types()
 
 

--- a/featuretools/variable_types/utils.py
+++ b/featuretools/variable_types/utils.py
@@ -1,4 +1,4 @@
-import pandas as pd
+from woodwork import list_logical_types
 
 from featuretools.utils.gen_utils import find_descendents
 from featuretools.utils.plot_utils import (
@@ -37,13 +37,7 @@ def list_variable_types():
         variable_types (pd.DataFrame): a DataFrame with column headers of
             name, type_strings, and description.
     """
-    v_types = list(find_variable_types().values())
-    v_type_strings = list(find_variable_types().keys())
-    v_names = [x.__name__ for x in v_types]
-    descriptions = [v.__doc__ for v in v_types]
-    return pd.DataFrame({'name': v_names,
-                         'type_string': v_type_strings,
-                         'description': descriptions})
+    return list_logical_types()
 
 
 def graph_variable_types(to_file=None):


### PR DESCRIPTION
Closes #1258 by replacing `list_variable_types` with `list_logical_types`