### PR TITLE
Bump min Woodwork version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ distributed>=2.12.0
 dask[dataframe]>=2.12.0
 psutil>=5.4.8
 click>=7.0.0
-woodwork>=0.4.0
+woodwork>=0.4.1


### PR DESCRIPTION
### Bump min Woodwork version

Closes #1474 

Woodwork version 0.4.1 fixes a couple bugs that needed to be fixed to complete the integration into Featuretools. Bumping the min Woodwork version in `requirements.txt` as a result.
