### PR TITLE
Allow deep equality check on EntitySet

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -19,6 +19,7 @@ Future Release
         * Refactor ``EntitySet.plot`` to work with Woodwork dataframes (:pr:`1468`)
         * Move ``last_time_index`` to be a column on the DataFrame (:pr:`1456`)
         * Replace ``list_variable_types`` with ``list_logical_types`` (:pr:`1477`)
+        * Allow deep EntitySet equality check (:pr:`1480`)
     * Documentation Changes
         * Improve formatting of release notes (:pr:`1396`)
     * Testing Changes

--- a/featuretools/demo/flight.py
+++ b/featuretools/demo/flight.py
@@ -95,7 +95,7 @@ def make_es(data):
                         'taxi_in', 'taxi_out', 'air_time', 'dep_time']
 
     logical_types = {'flight_num': ww.logical_types.Categorical,
-                     'distance_group': ww.logical_types.Ordinal(order=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+                     'distance_group': ww.logical_types.Ordinal(order=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),
                      'canceled': ww.logical_types.Boolean,
                      'diverted': ww.logical_types.Boolean}
 

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -20,6 +20,8 @@ from featuretools.utils.plot_utils import (
 # import pandas.api.types as pdtypes
 
 
+# from featuretools.utils.wrangle import _check_timedelta
+
 ks = import_or_none('databricks.koalas')
 
 pd.options.mode.chained_assignment = None  # default='warn'

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -142,31 +142,6 @@ class EntitySet(object):
                 return False
         return True
 
-# --> remove maybe!
-    def _eq_df(self, other, deep=False):
-        if self.id != other.id:
-            return False
-        if self.time_type != other.time_type:
-            return False
-        if len(self.dataframe_dict) != len(other.dataframe_dict):
-            return False
-        for df_name, df in self.dataframe_dict.items():
-            if df_name not in other.dataframe_dict:
-                return False
-            if df.ww.make_index != df.ww.make_index:
-                return False
-            if not df.ww._schema.__eq__(other[df_name].ww._schema, deep=deep):
-                return False
-            if deep and not _dataframes_equal(df, other[df_name]):
-                return False
-
-        if not len(self.relationships) == len(other.relationships):
-            return False
-        for r in self.relationships:
-            if r not in other.relationships:
-                return False
-        return True
-
     def __ne__(self, other, deep=False):
         return not self.__eq__(other, deep=deep)
 

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -20,7 +20,7 @@ from featuretools.utils.plot_utils import (
 # import pandas.api.types as pdtypes
 
 
-# from featuretools.utils.wrangle import _check_timedelta
+from featuretools.utils.wrangle import _dataframes_equal
 
 ks = import_or_none('databricks.koalas')
 
@@ -133,9 +133,33 @@ class EntitySet(object):
         for df_name, df in self.dataframe_dict.items():
             if df_name not in other.dataframe_dict:
                 return False
-            # --> WW bug: Waiting on deep behavior for WW equality
-            if not df.ww.__eq__(other[df_name].ww):
+            if not df.ww.__eq__(other[df_name].ww, deep=deep):
                 return False
+        if not len(self.relationships) == len(other.relationships):
+            return False
+        for r in self.relationships:
+            if r not in other.relationships:
+                return False
+        return True
+
+# --> remove maybe!
+    def _eq_df(self, other, deep=False):
+        if self.id != other.id:
+            return False
+        if self.time_type != other.time_type:
+            return False
+        if len(self.dataframe_dict) != len(other.dataframe_dict):
+            return False
+        for df_name, df in self.dataframe_dict.items():
+            if df_name not in other.dataframe_dict:
+                return False
+            if df.ww.make_index != df.ww.make_index:
+                return False
+            if not df.ww._schema.__eq__(other[df_name].ww._schema, deep=deep):
+                return False
+            if deep and not _dataframes_equal(df, other[df_name]):
+                return False
+
         if not len(self.relationships) == len(other.relationships):
             return False
         for r in self.relationships:

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -20,8 +20,6 @@ from featuretools.utils.plot_utils import (
 # import pandas.api.types as pdtypes
 
 
-from featuretools.utils.wrangle import _dataframes_equal
-
 ks = import_or_none('databricks.koalas')
 
 pd.options.mode.chained_assignment = None  # default='warn'

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -1820,65 +1820,15 @@ def test_entityset_deep_equality(es):
     assert first_es.__eq__(second_es, deep=False)
     assert first_es.__eq__(second_es, deep=True)
 
-    updated_df = first_es['customers'].loc[[], :]
+    updated_df = first_es['customers'].loc[[2, 0], :]
     first_es.update_dataframe('customers', updated_df)
 
     assert first_es.__eq__(second_es, deep=False)
-    # --> currently only looking at df content for pandas
+    # Uses woodwork equality which only looks at df content for pandas
     if isinstance(updated_df, pd.DataFrame):
         assert not first_es.__eq__(second_es, deep=True)
     else:
         assert first_es.__eq__(second_es, deep=True)
-
-
-def test_entityset_deep_equality_df(es):
-    first_es = EntitySet()
-    second_es = EntitySet()
-
-    first_es.add_dataframe(dataframe_name='customers',
-                           dataframe=es['customers'].copy(),
-                           index='id',
-                           time_index='signup_date',
-                           logical_types=es['customers'].ww.logical_types,
-                           semantic_tags=get_df_tags(es['customers']))
-
-    second_es.add_dataframe(dataframe_name='sessions',
-                            dataframe=es['sessions'].copy(),
-                            index='id',
-                            logical_types=es['sessions'].ww.logical_types,
-                            semantic_tags=get_df_tags(es['sessions']))
-
-    first_es.add_dataframe(dataframe_name='sessions',
-                           dataframe=es['sessions'].copy(),
-                           index='id',
-                           logical_types=es['sessions'].ww.logical_types,
-                           semantic_tags=get_df_tags(es['sessions']))
-    second_es.add_dataframe(dataframe_name='customers',
-                            dataframe=es['customers'].copy(),
-                            index='id',
-                            time_index='signup_date',
-                            logical_types=es['customers'].ww.logical_types,
-                            semantic_tags=get_df_tags(es['customers']))
-
-    assert first_es._eq_df(second_es, deep=False)
-    assert first_es._eq_df(second_es, deep=True)
-
-    # Woodwork metadata only gets included in deep equality check
-    first_es['sessions'].ww.metadata['created_by'] = 'user0'
-
-    assert first_es._eq_df(second_es, deep=False)
-    assert not first_es._eq_df(second_es, deep=True)
-
-    second_es['sessions'].ww.metadata['created_by'] = 'user0'
-
-    assert first_es._eq_df(second_es, deep=False)
-    assert first_es._eq_df(second_es, deep=True)
-
-    updated_df = first_es['customers'].loc[[], :]
-    first_es.update_dataframe('customers', updated_df)
-
-    assert first_es._eq_df(second_es, deep=False)
-    assert not first_es._eq_df(second_es, deep=True)
 
 
 @pytest.fixture(params=['make_es', 'dask_es_to_copy'])

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -1787,18 +1787,17 @@ def test_entityset_deep_equality(es):
                            time_index='signup_date',
                            logical_types=es['customers'].ww.logical_types,
                            semantic_tags=get_df_tags(es['customers']))
+    first_es.add_dataframe(dataframe_name='sessions',
+                           dataframe=es['sessions'].copy(),
+                           index='id',
+                           logical_types=es['sessions'].ww.logical_types,
+                           semantic_tags=get_df_tags(es['sessions']))
 
     second_es.add_dataframe(dataframe_name='sessions',
                             dataframe=es['sessions'].copy(),
                             index='id',
                             logical_types=es['sessions'].ww.logical_types,
                             semantic_tags=get_df_tags(es['sessions']))
-
-    first_es.add_dataframe(dataframe_name='sessions',
-                           dataframe=es['sessions'].copy(),
-                           index='id',
-                           logical_types=es['sessions'].ww.logical_types,
-                           semantic_tags=get_df_tags(es['sessions']))
     second_es.add_dataframe(dataframe_name='customers',
                             dataframe=es['customers'].copy(),
                             index='id',

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -1753,7 +1753,7 @@ def test_entityset_equality(es):
     assert first_es == second_es
 
 
-def test_entityset_id_equality(es):
+def test_entityset_id_equality():
     first_es = EntitySet(id='first')
     first_es_copy = EntitySet(id='first')
     second_es = EntitySet(id='second')
@@ -1762,7 +1762,7 @@ def test_entityset_id_equality(es):
     assert first_es == first_es_copy
 
 
-def test_entityset_time_type_equality(es):
+def test_entityset_time_type_equality():
     first_es = EntitySet()
     second_es = EntitySet()
     assert first_es == second_es
@@ -1775,6 +1775,110 @@ def test_entityset_time_type_equality(es):
 
     second_es.time_type = 'numeric'
     assert first_es == second_es
+
+
+def test_entityset_deep_equality(es):
+    first_es = EntitySet()
+    second_es = EntitySet()
+
+    first_es.add_dataframe(dataframe_name='customers',
+                           dataframe=es['customers'].copy(),
+                           index='id',
+                           time_index='signup_date',
+                           logical_types=es['customers'].ww.logical_types,
+                           semantic_tags=get_df_tags(es['customers']))
+
+    second_es.add_dataframe(dataframe_name='sessions',
+                            dataframe=es['sessions'].copy(),
+                            index='id',
+                            logical_types=es['sessions'].ww.logical_types,
+                            semantic_tags=get_df_tags(es['sessions']))
+
+    first_es.add_dataframe(dataframe_name='sessions',
+                           dataframe=es['sessions'].copy(),
+                           index='id',
+                           logical_types=es['sessions'].ww.logical_types,
+                           semantic_tags=get_df_tags(es['sessions']))
+    second_es.add_dataframe(dataframe_name='customers',
+                            dataframe=es['customers'].copy(),
+                            index='id',
+                            time_index='signup_date',
+                            logical_types=es['customers'].ww.logical_types,
+                            semantic_tags=get_df_tags(es['customers']))
+
+    assert first_es.__eq__(second_es, deep=False)
+    assert first_es.__eq__(second_es, deep=True)
+
+    # Woodwork metadata only gets included in deep equality check
+    first_es['sessions'].ww.metadata['created_by'] = 'user0'
+
+    assert first_es.__eq__(second_es, deep=False)
+    assert not first_es.__eq__(second_es, deep=True)
+
+    second_es['sessions'].ww.metadata['created_by'] = 'user0'
+
+    assert first_es.__eq__(second_es, deep=False)
+    assert first_es.__eq__(second_es, deep=True)
+
+    updated_df = first_es['customers'].loc[[], :]
+    first_es.update_dataframe('customers', updated_df)
+
+    assert first_es.__eq__(second_es, deep=False)
+    # --> currently only looking at df content for pandas
+    if isinstance(updated_df, pd.DataFrame):
+        assert not first_es.__eq__(second_es, deep=True)
+    else:
+        assert first_es.__eq__(second_es, deep=True)
+
+
+def test_entityset_deep_equality_df(es):
+    first_es = EntitySet()
+    second_es = EntitySet()
+
+    first_es.add_dataframe(dataframe_name='customers',
+                           dataframe=es['customers'].copy(),
+                           index='id',
+                           time_index='signup_date',
+                           logical_types=es['customers'].ww.logical_types,
+                           semantic_tags=get_df_tags(es['customers']))
+
+    second_es.add_dataframe(dataframe_name='sessions',
+                            dataframe=es['sessions'].copy(),
+                            index='id',
+                            logical_types=es['sessions'].ww.logical_types,
+                            semantic_tags=get_df_tags(es['sessions']))
+
+    first_es.add_dataframe(dataframe_name='sessions',
+                           dataframe=es['sessions'].copy(),
+                           index='id',
+                           logical_types=es['sessions'].ww.logical_types,
+                           semantic_tags=get_df_tags(es['sessions']))
+    second_es.add_dataframe(dataframe_name='customers',
+                            dataframe=es['customers'].copy(),
+                            index='id',
+                            time_index='signup_date',
+                            logical_types=es['customers'].ww.logical_types,
+                            semantic_tags=get_df_tags(es['customers']))
+
+    assert first_es._eq_df(second_es, deep=False)
+    assert first_es._eq_df(second_es, deep=True)
+
+    # Woodwork metadata only gets included in deep equality check
+    first_es['sessions'].ww.metadata['created_by'] = 'user0'
+
+    assert first_es._eq_df(second_es, deep=False)
+    assert not first_es._eq_df(second_es, deep=True)
+
+    second_es['sessions'].ww.metadata['created_by'] = 'user0'
+
+    assert first_es._eq_df(second_es, deep=False)
+    assert first_es._eq_df(second_es, deep=True)
+
+    updated_df = first_es['customers'].loc[[], :]
+    first_es.update_dataframe('customers', updated_df)
+
+    assert first_es._eq_df(second_es, deep=False)
+    assert not first_es._eq_df(second_es, deep=True)
 
 
 @pytest.fixture(params=['make_es', 'dask_es_to_copy'])


### PR DESCRIPTION
Passes the `deep` parameter for `EntitySet.__eq__` down to the Woodwork dataframe. 

#1424 
