### PR TITLE
Fix docs to avoid logging demos

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,6 +15,8 @@
 import os
 import subprocess
 import sys
+import shutil
+from pathlib import Path
 
 import featuretools
 
@@ -348,4 +350,9 @@ napoleon_use_param = True
 napoleon_use_rtype = True
 
 def setup(app):
+    home_dir = os.environ.get('HOME', '/')
+    ipython_p = Path(home_dir + "/.ipython/profile_default/startup")
+    ipython_p.mkdir(parents=True, exist_ok=True)
+    file_p = os.path.abspath(os.path.dirname(__file__))
+    shutil.copy(file_p + "/set-headers.py", home_dir + "/.ipython/profile_default/startup")
     app.add_css_file("style.css")

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -9,9 +9,11 @@ Release Notes
     * Fixes
     * Changes
     * Documentation Changes
+        * Prevent logging on build (:pr:`1498`)
     * Testing Changes
 
-.. Thanks to the following people for contributing to this release:
+    Thanks to the following people for contributing to this release:
+    :user:`frances-h`
 
 v0.25.0 Jun 11, 2021
 ====================

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,8 +3,8 @@
 Release Notes
 -------------
 
-.. Future Release
-  ==============
+Future Release
+==============
     * Enhancements
     * Fixes
     * Changes

--- a/docs/source/set-headers.py
+++ b/docs/source/set-headers.py
@@ -1,0 +1,5 @@
+import urllib.request
+
+opener = urllib.request.build_opener()
+opener.addheaders = [("Testing", "True")]
+urllib.request.install_opener(opener)

--- a/featuretools/demo/flight.py
+++ b/featuretools/demo/flight.py
@@ -59,7 +59,7 @@ def load_flight(month_filter=None,
     filename, csv_length = get_flight_filename(demo=demo)
 
     print('Downloading data ...')
-    url = "https://api.featurelabs.com/datasets/{}?version={}".format(filename, ft.__version__)
+    url = "https://api.featurelabs.com/datasets/{}?library=featuretools&version={}".format(filename, ft.__version__)
 
     chunksize = math.ceil(csv_length / 99)
     pd.options.display.max_columns = 200

--- a/featuretools/demo/retail.py
+++ b/featuretools/demo/retail.py
@@ -59,8 +59,8 @@ def load_retail(id='demo_retail_data', nrows=None, return_single_table=False):
 
 '''
     es = ft.EntitySet(id)
-    csv_s3_gz = "https://api.featurelabs.com/datasets/online-retail-logs-2018-08-28.csv.gz?version=" + ft.__version__
-    csv_s3 = "https://api.featurelabs.com/datasets/online-retail-logs-2018-08-28.csv?version=" + ft.__version__
+    csv_s3_gz = "https://api.featurelabs.com/datasets/online-retail-logs-2018-08-28.csv.gz?library=featuretools&version=" + ft.__version__
+    csv_s3 = "https://api.featurelabs.com/datasets/online-retail-logs-2018-08-28.csv?library=featuretools&version=" + ft.__version__
     # Try to read in gz compressed file
     try:
         df = pd.read_csv(csv_s3_gz,


### PR DESCRIPTION
Set the testing header when building the docs to prevent them from logging the demos.