### PR TITLE
Add replace_inf_values util function

### DIFF
--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -251,6 +251,26 @@ Feature encoding
 
     encode_features
 
+Feature Selection
+~~~~~~~~~~~~~~~~~
+.. currentmodule:: featuretools.selection
+.. autosummary::
+    :toctree: generated/
+
+    remove_low_information_features
+    remove_highly_correlated_features
+    remove_highly_null_features
+    remove_single_value_features
+
+Feature utils
+~~~~~~~~~~~~~
+.. currentmodule:: featuretools.computational_backends
+.. autosummary::
+    :toctree: generated/
+
+    replace_inf_values
+    
+
 Saving and Loading Features
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. currentmodule:: featuretools
@@ -376,14 +396,3 @@ Variable Utils Methods
     find_variable_types
     list_variable_types
     graph_variable_types
-
-Feature Selection
-------------------
-.. currentmodule:: featuretools.selection
-.. autosummary::
-    :toctree: generated/
-
-    remove_low_information_features
-    remove_highly_correlated_features
-    remove_highly_null_features
-    remove_single_value_features

--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -262,8 +262,8 @@ Feature Selection
     remove_highly_null_features
     remove_single_value_features
 
-Feature utils
-~~~~~~~~~~~~~
+Feature Matrix utils
+~~~~~~~~~~~~~~~~~~~~
 .. currentmodule:: featuretools.computational_backends
 .. autosummary::
     :toctree: generated/

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -6,6 +6,7 @@ Release Notes
 Future Release
 ==============
     * Enhancements
+        * Add ``replace_inf_values`` utility function for replacing ``inf`` values in a feature matrix (pr:`1505`)
     * Fixes
     * Changes
     * Documentation Changes
@@ -13,7 +14,7 @@ Future Release
     * Testing Changes
 
     Thanks to the following people for contributing to this release:
-    :user:`frances-h`
+    :user:`frances-h`, :user:`thehomebrewnerd`
 
 v0.25.0 Jun 11, 2021
 ====================

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -6,7 +6,7 @@ Release Notes
 Future Release
 ==============
     * Enhancements
-        * Add ``replace_inf_values`` utility function for replacing ``inf`` values in a feature matrix (pr:`1505`)
+        * Add ``replace_inf_values`` utility function for replacing ``inf`` values in a feature matrix (:pr:`1505`)
     * Fixes
     * Changes
     * Documentation Changes

--- a/featuretools/computational_backends/api.py
+++ b/featuretools/computational_backends/api.py
@@ -3,4 +3,8 @@ from .calculate_feature_matrix import (
     approximate_features,
     calculate_feature_matrix
 )
-from .utils import bin_cutoff_times, create_client_and_cluster
+from .utils import (
+    bin_cutoff_times,
+    create_client_and_cluster,
+    replace_inf_values
+)

--- a/featuretools/computational_backends/utils.py
+++ b/featuretools/computational_backends/utils.py
@@ -278,11 +278,11 @@ def _check_cutoff_time_type(cutoff_time, es_time_type):
 
 
 def replace_inf_values(feature_matrix, replacement_value=np.nan):
-    """Replace all `np.inf` values in a feature matrix with the specified replacement value.
+    """Replace all ``np.inf`` values in a feature matrix with the specified replacement value.
 
         Args:
             feature_matrix (DataFrame): DataFrame whose columns are feature names and rows are instances
-            replacement_value (int, float, str, optional): Value with which `np.inf` values will be replaced
+            replacement_value (int, float, str, optional): Value with which ``np.inf`` values will be replaced
 
         Returns:
             feature_matrix

--- a/featuretools/computational_backends/utils.py
+++ b/featuretools/computational_backends/utils.py
@@ -4,6 +4,7 @@ import warnings
 from functools import wraps
 
 import dask.dataframe as dd
+import numpy as np
 import pandas as pd
 import psutil
 
@@ -274,3 +275,17 @@ def _check_cutoff_time_type(cutoff_time, es_time_type):
     if es_time_type == DatetimeTimeIndex and not is_datetime:
         raise TypeError("cutoff_time times must be datetime type: try casting "
                         "via pd.to_datetime()")
+
+
+def replace_inf_values(feature_matrix, replacement_value=np.nan):
+    """Replace all `np.inf` values in a feature matrix with the specified replacement value.
+
+        Args:
+            feature_matrix (DataFrame): DataFrame whose columns are feature names and rows are instances
+            replacement_value (int, float, str, optional): Value with which `np.inf` values will be replaced
+
+        Returns:
+            feature_matrix
+
+    """
+    return feature_matrix.replace([np.inf, -np.inf], replacement_value)

--- a/featuretools/computational_backends/utils.py
+++ b/featuretools/computational_backends/utils.py
@@ -277,15 +277,21 @@ def _check_cutoff_time_type(cutoff_time, es_time_type):
                         "via pd.to_datetime()")
 
 
-def replace_inf_values(feature_matrix, replacement_value=np.nan):
+def replace_inf_values(feature_matrix, replacement_value=np.nan, columns=None):
     """Replace all ``np.inf`` values in a feature matrix with the specified replacement value.
 
         Args:
             feature_matrix (DataFrame): DataFrame whose columns are feature names and rows are instances
             replacement_value (int, float, str, optional): Value with which ``np.inf`` values will be replaced
+            columns (list[str], optional): A list specifying which columns should have values replaced. If None,
+                values will be replaced for all columns.
 
         Returns:
             feature_matrix
 
     """
-    return feature_matrix.replace([np.inf, -np.inf], replacement_value)
+    if columns is None:
+        feature_matrix = feature_matrix.replace([np.inf, -np.inf], replacement_value)
+    else:
+        feature_matrix[columns] = feature_matrix[columns].replace([np.inf, -np.inf], replacement_value)
+    return feature_matrix

--- a/featuretools/tests/computational_backend/test_utils.py
+++ b/featuretools/tests/computational_backend/test_utils.py
@@ -25,3 +25,16 @@ def test_replace_inf_values(divide_by_zero_es):
         assert np.inf not in custom_value_fm.values
         assert -np.inf not in replaced_fm.values
         assert 'custom_val' in custom_value_fm.values
+
+
+def test_replace_inf_values_specify_cols(divide_by_zero_es):
+    div_by_scalar = DivideNumericScalar(value=0)
+    fm, _ = ft.dfs(entityset=divide_by_zero_es,
+                    target_entity='zero',
+                    trans_primitives=[div_by_scalar])
+
+    assert np.inf in to_pandas(fm['col1 / 0']).values
+    replaced_fm = replace_inf_values(fm, columns=['col1 / 0'])
+    replaced_fm = to_pandas(replaced_fm)
+    assert np.inf not in replaced_fm['col1 / 0'].values
+    assert np.inf in replaced_fm['col2 / 0'].values

--- a/featuretools/tests/computational_backend/test_utils.py
+++ b/featuretools/tests/computational_backend/test_utils.py
@@ -1,0 +1,27 @@
+import numpy as np
+
+import featuretools as ft
+from featuretools.computational_backends import replace_inf_values
+from featuretools.primitives import DivideByFeature, DivideNumericScalar
+from featuretools.tests.testing_utils import to_pandas
+
+
+def test_replace_inf_values(divide_by_zero_es):
+    div_by_scalar = DivideNumericScalar(value=0)
+    div_by_feature = DivideByFeature(value=1)
+    div_by_feature_neg = DivideByFeature(value=-1)
+    for primitive in ['divide_numeric', div_by_scalar, div_by_feature, div_by_feature_neg]:
+        fm, _ = ft.dfs(entityset=divide_by_zero_es,
+                       target_entity='zero',
+                       trans_primitives=[primitive])
+        assert np.inf in to_pandas(fm).values or -np.inf in to_pandas(fm).values
+        replaced_fm = replace_inf_values(fm)
+        replaced_fm = to_pandas(replaced_fm)
+        assert np.inf not in replaced_fm.values
+        assert -np.inf not in replaced_fm.values
+
+        custom_value_fm = replace_inf_values(fm, replacement_value='custom_val')
+        custom_value_fm = to_pandas(custom_value_fm)
+        assert np.inf not in custom_value_fm.values
+        assert -np.inf not in replaced_fm.values
+        assert 'custom_val' in custom_value_fm.values

--- a/featuretools/tests/computational_backend/test_utils.py
+++ b/featuretools/tests/computational_backend/test_utils.py
@@ -30,8 +30,8 @@ def test_replace_inf_values(divide_by_zero_es):
 def test_replace_inf_values_specify_cols(divide_by_zero_es):
     div_by_scalar = DivideNumericScalar(value=0)
     fm, _ = ft.dfs(entityset=divide_by_zero_es,
-                    target_entity='zero',
-                    trans_primitives=[div_by_scalar])
+                   target_entity='zero',
+                   trans_primitives=[div_by_scalar])
 
     assert np.inf in to_pandas(fm['col1 / 0']).values
     replaced_fm = replace_inf_values(fm, columns=['col1 / 0'])

--- a/featuretools/tests/conftest.py
+++ b/featuretools/tests/conftest.py
@@ -484,9 +484,9 @@ def divide_by_zero_es(request):
 @pytest.fixture
 def divide_by_zero_es_pd():
     df = pd.DataFrame({
-        'id': [0, 1, 2],
-        'col1': [1, 0, -3],
-        'col2': [0, 0, 0],
+        'id': [0, 1, 2, 3],
+        'col1': [1, 0, -3, 4],
+        'col2': [0, 0, 0, 4],
     })
     return ft.EntitySet("data", {'zero': (df, 'id', None)})
 

--- a/featuretools/tests/conftest.py
+++ b/featuretools/tests/conftest.py
@@ -474,3 +474,41 @@ def koalas_transform_es(pd_transform_es):
                                  index=entity.index,
                                  variable_types=entity.variable_types)
     return es
+
+
+@pytest.fixture(params=['divide_by_zero_es_pd', 'divide_by_zero_es_dask', 'divide_by_zero_es_koalas'])
+def divide_by_zero_es(request):
+    return request.getfixturevalue(request.param)
+
+
+@pytest.fixture
+def divide_by_zero_es_pd():
+    df = pd.DataFrame({
+        'id': [0, 1, 2],
+        'col1': [1, 0, -3],
+        'col2': [0, 0, 0],
+    })
+    return ft.EntitySet("data", {'zero': (df, 'id', None)})
+
+
+@pytest.fixture
+def divide_by_zero_es_dask(divide_by_zero_es_pd):
+    es = ft.EntitySet(id=divide_by_zero_es_pd.id)
+    for entity in divide_by_zero_es_pd.entities:
+        es.entity_from_dataframe(entity_id=entity.id,
+                                 dataframe=dd.from_pandas(entity.df, npartitions=2),
+                                 index=entity.index,
+                                 variable_types=entity.variable_types)
+    return es
+
+
+@pytest.fixture
+def divide_by_zero_es_koalas(divide_by_zero_es_pd):
+    ks = pytest.importorskip('databricks.koalas', reason="Koalas not installed, skipping")
+    es = ft.EntitySet(id=divide_by_zero_es_pd.id)
+    for entity in divide_by_zero_es_pd.entities:
+        es.entity_from_dataframe(entity_id=entity.id,
+                                 dataframe=ks.from_pandas(entity.df),
+                                 index=entity.index,
+                                 variable_types=entity.variable_types)
+    return es


### PR DESCRIPTION
### Add replace_inf_values util function
Closes #1496 

Adds a new utility function, `replace_inf_values`, that can be used to replace `np.inf` values in a feature matrix with `np.NaN` values (default) or with a value of the user's choosing (optional).

Also relocates Feature Selection section in API Reference, which was previously includes under the `EntitSet, Entity, Relationship, Variable Types` section instead of with the other feature related methods.

