### PR TITLE
Validate schema after dataframe update

### DIFF
--- a/featuretools/tests/entityset_tests/test_ww_es.py
+++ b/featuretools/tests/entityset_tests/test_ww_es.py
@@ -849,5 +849,5 @@ def test_update_dataframe_schema():
 
     assert not after.dtypes.equals(before.dtypes)
     es.update_dataframe(dataframe_name='data', df=after)
-    assert after.ww.schema == before.ww.schema
-    assert after.dtypes.equals(before.dtypes)
+    assert es['data'].ww.schema == before.ww.schema
+    assert es['data'].dtypes.equals(before.dtypes)

--- a/featuretools/tests/entityset_tests/test_ww_es.py
+++ b/featuretools/tests/entityset_tests/test_ww_es.py
@@ -847,7 +847,7 @@ def test_update_dataframe_schema():
         'latlong': [[5, 6], '7, 8', [np.nan, np.nan]],
     }).astype({'boolean': int, 'latlong': str})
 
-    assert not after.dtypes.equals(before.dtypes)
+    assert not after.dtypes.equals(es['data'].dtypes)
     es.update_dataframe(dataframe_name='data', df=after)
     assert es['data'].ww.schema == before.ww.schema
     assert es['data'].dtypes.equals(before.dtypes)

--- a/featuretools/tests/entityset_tests/test_ww_es.py
+++ b/featuretools/tests/entityset_tests/test_ww_es.py
@@ -824,3 +824,28 @@ def test_normalize_ww_init():
 
     assert es['new_df'].ww.name == 'new_df'
     assert es['new_df'].ww.schema.name == 'new_df'
+
+
+def test_update_dataframe_schema():
+    before = pd.DataFrame({
+        'index': [0, 1, 2],
+        'boolean': [True, False, True],
+        'latlong': [(1.0, 2.0), (3.0, 4.0), np.nan],
+    })
+
+    before.ww.init(index='index', logical_types={
+        'boolean': ww.logical_types.Boolean,
+        'latlong': ww.logical_types.LatLong,
+    })
+
+    es = EntitySet()
+    es.add_dataframe(dataframe_name='data', df=before)
+
+    after = pd.DataFrame({
+        'index': [0, 1, 2],
+        'boolean': [0, 1, 0],
+        'latlong': [[5, 6], '7, 8', [np.nan, np.nan]],
+    })
+
+    es.update_dataframe(dataframe_name='data', df=after)
+    assert after.ww.schema == before.ww.schema

--- a/featuretools/tests/entityset_tests/test_ww_es.py
+++ b/featuretools/tests/entityset_tests/test_ww_es.py
@@ -845,7 +845,9 @@ def test_update_dataframe_schema():
         'index': [0, 1, 2],
         'boolean': [0, 1, 0],
         'latlong': [[5, 6], '7, 8', [np.nan, np.nan]],
-    })
+    }).astype({'boolean': int, 'latlong': str})
 
+    assert not after.dtypes.equals(before.dtypes)
     es.update_dataframe(dataframe_name='data', df=after)
     assert after.ww.schema == before.ww.schema
+    assert after.dtypes.equals(before.dtypes)


### PR DESCRIPTION
Adds test case to check if new data conforms to original schema after the update.