### PR TITLE
Fix broken EntitySet tests

### DIFF
--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -180,7 +180,9 @@ def test_add_relationship_different_logical_types_same_dtype(es):
         'value_many_nans': Double,
         'priority_level': Ordinal(order=[0, 1, 2]),
         'purchased': Boolean,
-        'comments': NaturalLanguage
+        'comments': NaturalLanguage,
+        'url': URL,
+        'email_address': EmailAddress,
     }
     log_semantic_tags = {
         'session_id': 'foreign_key',
@@ -222,7 +224,9 @@ def test_add_relationship_different_compatible_dtypes(es):
         'value_many_nans': Double,
         'priority_level': Ordinal(order=[0, 1, 2]),
         'purchased': Boolean,
-        'comments': NaturalLanguage
+        'comments': NaturalLanguage,
+        'url': URL,
+        'email_address': EmailAddress,
     }
     log_semantic_tags = {
         'session_id': 'foreign_key',


### PR DESCRIPTION
### Fix broken EntitySet tests

Closes #1529 

With this update (and the associated updated serialized data in S3) all the test in `test/entityset_tests` should now pass.