### PR TITLE
Fix additional reviewers to min and latest dependency checker

### DIFF
--- a/.github/workflows/latest_dependency_checker.yml
+++ b/.github/workflows/latest_dependency_checker.yml
@@ -31,4 +31,4 @@ jobs:
         branch: latest-dep-update
         branch-suffix: short-commit-hash
         base: main
-        team-reviewers: @alteryx/ml-tools
+        team-reviewers: alteryx/ml-tools

--- a/.github/workflows/latest_dependency_checker.yml
+++ b/.github/workflows/latest_dependency_checker.yml
@@ -31,4 +31,4 @@ jobs:
         branch: latest-dep-update
         branch-suffix: short-commit-hash
         base: main
-        team-reviewers: alteryx/ml-tools
+        team-reviewers: ml-tools

--- a/.github/workflows/minimum_dependency_checker.yml
+++ b/.github/workflows/minimum_dependency_checker.yml
@@ -74,4 +74,4 @@ jobs:
           branch: min-dep-update
           branch-suffix: short-commit-hash
           base: main
-          team-reviewers: @alteryx/ml-tools
+          team-reviewers: alteryx/ml-tools

--- a/.github/workflows/minimum_dependency_checker.yml
+++ b/.github/workflows/minimum_dependency_checker.yml
@@ -74,4 +74,4 @@ jobs:
           branch: min-dep-update
           branch-suffix: short-commit-hash
           base: main
-          team-reviewers: alteryx/ml-tools
+          team-reviewers: ml-tools

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -10,7 +10,7 @@ Future Release
     * Changes
     * Documentation Changes
     * Testing Changes
-        * Add additional reviewers to minimum and latest dependency checkers (:pr:`1558`)
+        * Add additional reviewers to minimum and latest dependency checkers (:pr:`1558`, :pr:`1562`)
     
     Thanks to the following people for contributing to this release:
     :user:`gsheni`

--- a/featuretools/tests/requirement_files/latest_requirements.txt
+++ b/featuretools/tests/requirement_files/latest_requirements.txt
@@ -4,7 +4,7 @@ dask==2021.7.1
 distributed==2021.7.1
 koalas==1.8.1
 numpy==1.21.1
-pandas==1.3.1
+pandas==1.3.0
 psutil==5.8.0
 pyspark==3.1.2
 scipy==1.7.0


### PR DESCRIPTION
- Both workflows are failing on main due to a syntax error:
  - https://github.com/alteryx/featuretools/actions/runs/1068139279
  - https://github.com/alteryx/featuretools/actions/runs/1068139296
- This MR fixes it by referencing the correct team.
