### PR TITLE
Remove team reviewers for dependency checker

### DIFF
--- a/.github/workflows/latest_dependency_checker.yml
+++ b/.github/workflows/latest_dependency_checker.yml
@@ -31,4 +31,4 @@ jobs:
         branch: latest-dep-update
         branch-suffix: short-commit-hash
         base: main
-        team-reviewers: alteryx/ml-tools
+        reviewers: thehomebrewnerd, tamargrey, jeff-hernandez, tuethan1999, davesque, simha104 

--- a/.github/workflows/minimum_dependency_checker.yml
+++ b/.github/workflows/minimum_dependency_checker.yml
@@ -74,4 +74,4 @@ jobs:
           branch: min-dep-update
           branch-suffix: short-commit-hash
           base: main
-          team-reviewers: alteryx/ml-tools
+          reviewers: thehomebrewnerd, tamargrey, jeff-hernandez, tuethan1999, davesque, simha104 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -10,7 +10,7 @@ Future Release
     * Changes
     * Documentation Changes
     * Testing Changes
-        * Add additional reviewers to minimum and latest dependency checkers (:pr:`1558`, :pr:`1562`, :pr:`1564`)
+        * Add additional reviewers to minimum and latest dependency checkers (:pr:`1558`, :pr:`1562`, :pr:`1564`, :pr:`1567`)
     
     Thanks to the following people for contributing to this release:
     :user:`gsheni`


### PR DESCRIPTION
The team reviewers functionality is not working so reverting back to specifying individual people
