### PR TITLE
Synthesis test fixes

### DIFF
--- a/featuretools/computational_backends/calculate_feature_matrix.py
+++ b/featuretools/computational_backends/calculate_feature_matrix.py
@@ -341,7 +341,7 @@ def calculate_chunk(cutoff_time, chunk_size, feature_set, entityset, approximate
 
     feature_matrix = []
     if no_unapproximated_aggs and approximate is not None:
-        if entityset.time_type == 'numeric_time_index':
+        if entityset.time_type == 'numeric':
             group_time = np.inf
         else:
             group_time = datetime.now()

--- a/featuretools/synthesis/encode_features.py
+++ b/featuretools/synthesis/encode_features.py
@@ -105,7 +105,7 @@ def encode_features(feature_matrix, features, top_n=DEFAULT_TOP_N, include_unkno
     for f in iterator:
         # TODO: features with multiple columns are not encoded by this method,
         # which can cause an "encoded" matrix with non-numeric vlaues
-        is_discrete = 'category' in f.column_schema.semantic_tags
+        is_discrete = {'category', 'foreign_key'}.intersection(f.column_schema.semantic_tags)
         if (f.number_output_features > 1 or not is_discrete):
             if f.number_output_features > 1:
                 logger.warning("Feature %s has multiple columns and will not "
@@ -120,7 +120,9 @@ def encode_features(feature_matrix, features, top_n=DEFAULT_TOP_N, include_unkno
             new_columns.extend(f.get_feature_names())
             continue
 
-        val_counts = X[f.get_name()].value_counts().to_frame()
+        val_counts = X[f.get_name()].value_counts()
+        # Remove 0 count category values
+        val_counts = val_counts[val_counts > 0].to_frame()
         index_name = val_counts.index.name
         if index_name is None:
             if 'index' in val_counts.columns:


### PR DESCRIPTION
Fixes #1546

* Fix outdated time type check
* Encode foreign key features 

Still two failing tests in the synthesis folder but they are both typing mismatches in the output feature matrix, which should be resolved by #1393 