### PR TITLE
Preserve EntitySet Woodwork schemas on pickling

### DIFF
--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -25,6 +25,7 @@ pd.options.mode.chained_assignment = None  # default='warn'
 logger = logging.getLogger('featuretools.entityset')
 
 LTI_COLUMN_NAME = '_ft_last_time'
+WW_SCHEMA_KEY = '_ww__getstate__schemas'
 
 
 class EntitySet(object):
@@ -1158,16 +1159,15 @@ class EntitySet(object):
     def __getstate__(self):
         return {
             **self.__dict__,
-            'schemas': {df_name: df.ww.schema for df_name, df in self.dataframe_dict.items()}
+            WW_SCHEMA_KEY: {df_name: df.ww.schema for df_name, df in self.dataframe_dict.items()}
         }
 
     def __setstate__(self, state):
-        schemas = state.pop('schemas')
+        ww_schemas = state.pop(WW_SCHEMA_KEY)
         for df_name, df in state.get('dataframe_dict', {}).items():
-            if schemas[df_name] is not None:
-                df.ww.init(schema=schemas[df_name])
-        for k, v in state.items():
-            object.__setattr__(self, k, v)
+            if ww_schemas[df_name] is not None:
+                df.ww.init(schema=ww_schemas[df_name], validate=False)
+        self.__dict__ = state
 
     # ###########################################################################
     # #  Other ###############################################

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -1167,7 +1167,7 @@ class EntitySet(object):
         for df_name, df in state.get('dataframe_dict', {}).items():
             if ww_schemas[df_name] is not None:
                 df.ww.init(schema=ww_schemas[df_name], validate=False)
-        self.__dict__ = state
+        self.__dict__.update(state)
 
     # ###########################################################################
     # #  Other ###############################################

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -7,7 +7,6 @@ import dask.dataframe as dd
 import numpy as np
 import pandas as pd
 from woodwork import init_series
-from woodwork.exceptions import WoodworkNotInitError
 from woodwork.logical_types import Datetime
 
 from featuretools.entityset import deserialize, serialize

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -1157,17 +1157,9 @@ class EntitySet(object):
     # #  Pickling ###############################################
     # ###########################################################################
     def __getstate__(self):
-        schemas = {}
-        for df_name, df in self.dataframe_dict.items():
-            try:
-                schema = df.ww.schema
-            except WoodworkNotInitError:
-                schema = None
-            schemas[df_name] = schema
-
         return {
             **self.__dict__,
-            'schemas': schemas
+            'schemas': {df_name: df.ww.schema for df_name, df in self.dataframe_dict.items()}
         }
 
     def __setstate__(self, state):

--- a/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
+++ b/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
@@ -1298,10 +1298,10 @@ def test_parallel_failure_raises_correct_error(pd_es):
                                  approximate='1 hour')
 
 
-def test_warning_not_enough_chunks(pd_es, capsys, cluster_scheduler_3):
+def test_warning_not_enough_chunks(pd_es, capsys, three_worker_scheduler):
     property_feature = IdentityFeature(pd_es, 'log', 'value') > 10
 
-    dkwargs = {'cluster': cluster_scheduler_3['address']}
+    dkwargs = {'cluster': three_worker_scheduler['address']}
     calculate_feature_matrix([property_feature],
                              entityset=pd_es,
                              chunk_size=.5,
@@ -1673,7 +1673,6 @@ def test_calls_progress_callback_cluster(pd_mock_customer, cluster_scheduler):
     trans_per_customer = ft.Feature(ft.Feature(pd_mock_customer, "transactions", "transaction_id"), parent_dataframe_name="customers", primitive=Count)
     features = [trans_per_session, ft.Feature(trans_per_customer, "sessions")]
 
-    # with cluster() as (scheduler, [a, b]):
     dkwargs = {'cluster': cluster_scheduler['address']}
     calculate_feature_matrix(features,
                              entityset=pd_mock_customer,

--- a/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
+++ b/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
@@ -1,6 +1,6 @@
 import logging
 import os
-# import re
+import re
 import shutil
 from datetime import datetime
 from itertools import combinations
@@ -11,7 +11,7 @@ import pandas as pd
 import psutil
 import pytest
 from dask import dataframe as dd
-# from distributed.utils_test import cluster
+from distributed.utils_test import cluster
 from tqdm import tqdm
 from woodwork.column_schema import ColumnSchema
 
@@ -1161,61 +1161,61 @@ def test_cfm_returns_original_time_indexes_approximate(pd_es):
     assert (time_level_vals == cutoff_df['time'].values).all()
 
 
-# def test_dask_kwargs(pd_es):
-#     times = list([datetime(2011, 4, 9, 10, 30, i * 6) for i in range(5)] +
-#                  [datetime(2011, 4, 9, 10, 31, i * 9) for i in range(4)] +
-#                  [datetime(2011, 4, 9, 10, 40, 0)] +
-#                  [datetime(2011, 4, 10, 10, 40, i) for i in range(2)] +
-#                  [datetime(2011, 4, 10, 10, 41, i * 3) for i in range(3)] +
-#                  [datetime(2011, 4, 10, 11, 10, i * 3) for i in range(2)])
-#     labels = [False] * 3 + [True] * 2 + [False] * 9 + [True] + [False] * 2
-#     cutoff_time = pd.DataFrame({'time': times, 'instance_id': range(17)})
-#     property_feature = IdentityFeature(pd_es, 'log', 'value') > 10
+def test_dask_kwargs(pd_es):
+    times = list([datetime(2011, 4, 9, 10, 30, i * 6) for i in range(5)] +
+                 [datetime(2011, 4, 9, 10, 31, i * 9) for i in range(4)] +
+                 [datetime(2011, 4, 9, 10, 40, 0)] +
+                 [datetime(2011, 4, 10, 10, 40, i) for i in range(2)] +
+                 [datetime(2011, 4, 10, 10, 41, i * 3) for i in range(3)] +
+                 [datetime(2011, 4, 10, 11, 10, i * 3) for i in range(2)])
+    labels = [False] * 3 + [True] * 2 + [False] * 9 + [True] + [False] * 2
+    cutoff_time = pd.DataFrame({'time': times, 'instance_id': range(17)})
+    property_feature = IdentityFeature(pd_es, 'log', 'value') > 10
 
-#     with cluster() as (scheduler, [a, b]):
-#         dkwargs = {'cluster': scheduler['address']}
-#         feature_matrix = calculate_feature_matrix([property_feature],
-#                                                   entityset=pd_es,
-#                                                   cutoff_time=cutoff_time,
-#                                                   verbose=True,
-#                                                   chunk_size=.13,
-#                                                   dask_kwargs=dkwargs,
-#                                                   approximate='1 hour')
+    with cluster() as (scheduler, [a, b]):
+        dkwargs = {'cluster': scheduler['address']}
+        feature_matrix = calculate_feature_matrix([property_feature],
+                                                  entityset=pd_es,
+                                                  cutoff_time=cutoff_time,
+                                                  verbose=True,
+                                                  chunk_size=.13,
+                                                  dask_kwargs=dkwargs,
+                                                  approximate='1 hour')
 
-#     assert (feature_matrix[property_feature.get_name()] == labels).values.all()
+    assert (feature_matrix[property_feature.get_name()] == labels).values.all()
 
 
-# def test_dask_persisted_es(pd_es, capsys):
-#     times = list([datetime(2011, 4, 9, 10, 30, i * 6) for i in range(5)] +
-#                  [datetime(2011, 4, 9, 10, 31, i * 9) for i in range(4)] +
-#                  [datetime(2011, 4, 9, 10, 40, 0)] +
-#                  [datetime(2011, 4, 10, 10, 40, i) for i in range(2)] +
-#                  [datetime(2011, 4, 10, 10, 41, i * 3) for i in range(3)] +
-#                  [datetime(2011, 4, 10, 11, 10, i * 3) for i in range(2)])
-#     labels = [False] * 3 + [True] * 2 + [False] * 9 + [True] + [False] * 2
-#     cutoff_time = pd.DataFrame({'time': times, 'instance_id': range(17)})
-#     property_feature = IdentityFeature(pd_es, 'log', 'value') > 10
+def test_dask_persisted_es(pd_es, capsys):
+    times = list([datetime(2011, 4, 9, 10, 30, i * 6) for i in range(5)] +
+                 [datetime(2011, 4, 9, 10, 31, i * 9) for i in range(4)] +
+                 [datetime(2011, 4, 9, 10, 40, 0)] +
+                 [datetime(2011, 4, 10, 10, 40, i) for i in range(2)] +
+                 [datetime(2011, 4, 10, 10, 41, i * 3) for i in range(3)] +
+                 [datetime(2011, 4, 10, 11, 10, i * 3) for i in range(2)])
+    labels = [False] * 3 + [True] * 2 + [False] * 9 + [True] + [False] * 2
+    cutoff_time = pd.DataFrame({'time': times, 'instance_id': range(17)})
+    property_feature = IdentityFeature(pd_es, 'log', 'value') > 10
 
-#     with cluster() as (scheduler, [a, b]):
-#         dkwargs = {'cluster': scheduler['address']}
-#         feature_matrix = calculate_feature_matrix([property_feature],
-#                                                   entityset=pd_es,
-#                                                   cutoff_time=cutoff_time,
-#                                                   verbose=True,
-#                                                   chunk_size=.13,
-#                                                   dask_kwargs=dkwargs,
-#                                                   approximate='1 hour')
-#         assert (feature_matrix[property_feature.get_name()] == labels).values.all()
-#         feature_matrix = calculate_feature_matrix([property_feature],
-#                                                   entityset=pd_es,
-#                                                   cutoff_time=cutoff_time,
-#                                                   verbose=True,
-#                                                   chunk_size=.13,
-#                                                   dask_kwargs=dkwargs,
-#                                                   approximate='1 hour')
-#         captured = capsys.readouterr()
-#         assert "Using EntitySet persisted on the cluster as dataset " in captured[0]
-#         assert (feature_matrix[property_feature.get_name()] == labels).values.all()
+    with cluster() as (scheduler, [a, b]):
+        dkwargs = {'cluster': scheduler['address']}
+        feature_matrix = calculate_feature_matrix([property_feature],
+                                                  entityset=pd_es,
+                                                  cutoff_time=cutoff_time,
+                                                  verbose=True,
+                                                  chunk_size=.13,
+                                                  dask_kwargs=dkwargs,
+                                                  approximate='1 hour')
+        assert (feature_matrix[property_feature.get_name()] == labels).values.all()
+        feature_matrix = calculate_feature_matrix([property_feature],
+                                                  entityset=pd_es,
+                                                  cutoff_time=cutoff_time,
+                                                  verbose=True,
+                                                  chunk_size=.13,
+                                                  dask_kwargs=dkwargs,
+                                                  approximate='1 hour')
+        captured = capsys.readouterr()
+        assert "Using EntitySet persisted on the cluster as dataset " in captured[0]
+        assert (feature_matrix[property_feature.get_name()] == labels).values.all()
 
 
 class TestCreateClientAndCluster(object):
@@ -1301,20 +1301,20 @@ def test_parallel_failure_raises_correct_error(pd_es):
                                  approximate='1 hour')
 
 
-# def test_warning_not_enough_chunks(pd_es, capsys):
-#     property_feature = IdentityFeature(pd_es, 'log', 'value') > 10
+def test_warning_not_enough_chunks(pd_es, capsys):
+    property_feature = IdentityFeature(pd_es, 'log', 'value') > 10
 
-#     with cluster(nworkers=3) as (scheduler, [a, b, c]):
-#         dkwargs = {'cluster': scheduler['address']}
-#         calculate_feature_matrix([property_feature],
-#                                  entityset=pd_es,
-#                                  chunk_size=.5,
-#                                  verbose=True,
-#                                  dask_kwargs=dkwargs)
+    with cluster(nworkers=3) as (scheduler, [a, b, c]):
+        dkwargs = {'cluster': scheduler['address']}
+        calculate_feature_matrix([property_feature],
+                                 entityset=pd_es,
+                                 chunk_size=.5,
+                                 verbose=True,
+                                 dask_kwargs=dkwargs)
 
-#     captured = capsys.readouterr()
-#     pattern = r'Fewer chunks \([0-9]+\), than workers \([0-9]+\) consider reducing the chunk size'
-#     assert re.search(pattern, captured.out) is not None
+    captured = capsys.readouterr()
+    pattern = r'Fewer chunks \([0-9]+\), than workers \([0-9]+\) consider reducing the chunk size'
+    assert re.search(pattern, captured.out) is not None
 
 
 def test_n_jobs():
@@ -1659,33 +1659,33 @@ def test_calls_progress_callback(mock_customer):
     assert np.isclose(mock_progress_callback.total_progress_percent, 100.0)
 
 
-# def test_calls_progress_callback_cluster(pd_mock_customer):
-#     class MockProgressCallback:
-#         def __init__(self):
-#             self.progress_history = []
-#             self.total_update = 0
-#             self.total_progress_percent = 0
+def test_calls_progress_callback_cluster(pd_mock_customer):
+    class MockProgressCallback:
+        def __init__(self):
+            self.progress_history = []
+            self.total_update = 0
+            self.total_progress_percent = 0
 
-#         def __call__(self, update, progress_percent, time_elapsed):
-#             self.total_update += update
-#             self.total_progress_percent = progress_percent
-#             self.progress_history.append(progress_percent)
+        def __call__(self, update, progress_percent, time_elapsed):
+            self.total_update += update
+            self.total_progress_percent = progress_percent
+            self.progress_history.append(progress_percent)
 
-#     mock_progress_callback = MockProgressCallback()
+    mock_progress_callback = MockProgressCallback()
 
-#     trans_per_session = ft.Feature(ft.Feature(pd_mock_customer, "transactions", "transaction_id"), parent_dataframe_name="sessions", primitive=Count)
-#     trans_per_customer = ft.Feature(ft.Feature(pd_mock_customer, "transactions", "transaction_id"), parent_dataframe_name="customers", primitive=Count)
-#     features = [trans_per_session, ft.Feature(trans_per_customer, "sessions")]
+    trans_per_session = ft.Feature(ft.Feature(pd_mock_customer, "transactions", "transaction_id"), parent_dataframe_name="sessions", primitive=Count)
+    trans_per_customer = ft.Feature(ft.Feature(pd_mock_customer, "transactions", "transaction_id"), parent_dataframe_name="customers", primitive=Count)
+    features = [trans_per_session, ft.Feature(trans_per_customer, "sessions")]
 
-#     with cluster() as (scheduler, [a, b]):
-#         dkwargs = {'cluster': scheduler['address']}
-#         calculate_feature_matrix(features,
-#                                  entityset=pd_mock_customer,
-#                                  progress_callback=mock_progress_callback,
-#                                  dask_kwargs=dkwargs)
+    with cluster() as (scheduler, [a, b]):
+        dkwargs = {'cluster': scheduler['address']}
+        calculate_feature_matrix(features,
+                                 entityset=pd_mock_customer,
+                                 progress_callback=mock_progress_callback,
+                                 dask_kwargs=dkwargs)
 
-#     assert np.isclose(mock_progress_callback.total_update, 100.0)
-#     assert np.isclose(mock_progress_callback.total_progress_percent, 100.0)
+    assert np.isclose(mock_progress_callback.total_update, 100.0)
+    assert np.isclose(mock_progress_callback.total_progress_percent, 100.0)
 
 
 def test_closes_tqdm(es):

--- a/featuretools/tests/conftest.py
+++ b/featuretools/tests/conftest.py
@@ -4,6 +4,7 @@ import composeml as cp
 import dask.dataframe as dd
 import pandas as pd
 import pytest
+from distributed.utils_test import cluster
 from woodwork.logical_types import Boolean, Integer
 
 import featuretools as ft
@@ -13,6 +14,18 @@ from featuretools.tests.testing_utils import (
 )
 from featuretools.utils.gen_utils import import_or_none
 from featuretools.utils.koalas_utils import pd_to_ks_clean
+
+
+@pytest.fixture()
+def cluster_scheduler():
+    with cluster() as (scheduler, [a, b]):
+        yield scheduler
+
+
+@pytest.fixture()
+def cluster_scheduler_3():
+    with cluster(nworkers=3) as (scheduler, [a, b, c]):
+        yield scheduler
 
 
 @pytest.fixture(scope='session', autouse=True)

--- a/featuretools/tests/conftest.py
+++ b/featuretools/tests/conftest.py
@@ -23,7 +23,7 @@ def cluster_scheduler():
 
 
 @pytest.fixture()
-def cluster_scheduler_3():
+def three_worker_scheduler():
     with cluster(nworkers=3) as (scheduler, [a, b, c]):
         yield scheduler
 

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -1,5 +1,6 @@
 import copy
 import logging
+import pickle
 import re
 from datetime import datetime
 
@@ -2016,3 +2017,19 @@ def test_dataframe_type_empty_es():
 
 def test_dataframe_type_pandas_es(pd_es):
     assert pd_es.dataframe_type == Library.PANDAS.value
+
+
+def test_pd_es_pickling(pd_es):
+    pkl = pickle.dumps(pd_es)
+    unpickled = pickle.loads(pkl)
+
+    assert pd_es.__eq__(unpickled, deep=True)
+    assert not hasattr(unpickled, 'schemas')
+
+
+def test_empty_es_pickling():
+    es = ft.EntitySet(id="empty")
+    pkl = pickle.dumps(es)
+    unpickled = pickle.loads(pkl)
+
+    assert es.__eq__(unpickled, deep=True)

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -26,7 +26,7 @@ from woodwork.logical_types import (
 
 import featuretools as ft
 from featuretools.entityset import EntitySet
-from featuretools.entityset.entityset import LTI_COLUMN_NAME
+from featuretools.entityset.entityset import LTI_COLUMN_NAME, WW_SCHEMA_KEY
 from featuretools.tests.testing_utils import get_df_tags, to_pandas
 from featuretools.utils.gen_utils import Library, import_or_none
 from featuretools.utils.koalas_utils import pd_to_ks_clean
@@ -2019,12 +2019,16 @@ def test_dataframe_type_pandas_es(pd_es):
     assert pd_es.dataframe_type == Library.PANDAS.value
 
 
+def test_es__getstate__key_unique(es):
+    assert not hasattr(es, WW_SCHEMA_KEY)
+
+
 def test_pd_es_pickling(pd_es):
     pkl = pickle.dumps(pd_es)
     unpickled = pickle.loads(pkl)
 
     assert pd_es.__eq__(unpickled, deep=True)
-    assert not hasattr(unpickled, 'schemas')
+    assert not hasattr(unpickled, WW_SCHEMA_KEY)
 
 
 def test_empty_es_pickling():

--- a/featuretools/tests/synthesis/test_dfs_method.py
+++ b/featuretools/tests/synthesis/test_dfs_method.py
@@ -3,7 +3,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from dask import dataframe as dd
-# from distributed.utils_test import cluster
+from distributed.utils_test import cluster
 from woodwork.column_schema import ColumnSchema
 from woodwork.logical_types import NaturalLanguage
 
@@ -467,49 +467,49 @@ def test_calls_progress_callback(dataframes, relationships):
     assert np.isclose(mock_progress_callback.total_progress_percent, 100.0)
 
 
-# def test_calls_progress_callback_cluster(pd_dataframes, relationships):
-#     class MockProgressCallback:
-#         def __init__(self):
-#             self.progress_history = []
-#             self.total_update = 0
-#             self.total_progress_percent = 0
+def test_calls_progress_callback_cluster(pd_dataframes, relationships):
+    class MockProgressCallback:
+        def __init__(self):
+            self.progress_history = []
+            self.total_update = 0
+            self.total_progress_percent = 0
 
-#         def __call__(self, update, progress_percent, time_elapsed):
-#             self.total_update += update
-#             self.total_progress_percent = progress_percent
-#             self.progress_history.append(progress_percent)
+        def __call__(self, update, progress_percent, time_elapsed):
+            self.total_update += update
+            self.total_progress_percent = progress_percent
+            self.progress_history.append(progress_percent)
 
-#     mock_progress_callback = MockProgressCallback()
+    mock_progress_callback = MockProgressCallback()
 
-#     with cluster() as (scheduler, [a, b]):
-#         dkwargs = {'cluster': scheduler['address']}
-#         dfs(dataframes=pd_dataframes,
-#             relationships=relationships,
-#             target_dataframe_name="transactions",
-#             progress_callback=mock_progress_callback,
-#             dask_kwargs=dkwargs)
+    with cluster() as (scheduler, [a, b]):
+        dkwargs = {'cluster': scheduler['address']}
+        dfs(dataframes=pd_dataframes,
+            relationships=relationships,
+            target_dataframe_name="transactions",
+            progress_callback=mock_progress_callback,
+            dask_kwargs=dkwargs)
 
-#     assert np.isclose(mock_progress_callback.total_update, 100.0)
-#     assert np.isclose(mock_progress_callback.total_progress_percent, 100.0)
+    assert np.isclose(mock_progress_callback.total_update, 100.0)
+    assert np.isclose(mock_progress_callback.total_progress_percent, 100.0)
 
 
-# def test_dask_kwargs(pd_dataframes, relationships):
-#     cutoff_times_df = pd.DataFrame({"instance_id": [1, 2, 3],
-#                                     "time": [10, 12, 15]})
-#     feature_matrix, features = dfs(dataframes=pd_dataframes,
-#                                    relationships=relationships,
-#                                    target_dataframe_name="transactions",
-#                                    cutoff_time=cutoff_times_df)
+def test_dask_kwargs(pd_dataframes, relationships):
+    cutoff_times_df = pd.DataFrame({"instance_id": [1, 2, 3],
+                                    "time": [10, 12, 15]})
+    feature_matrix, features = dfs(dataframes=pd_dataframes,
+                                   relationships=relationships,
+                                   target_dataframe_name="transactions",
+                                   cutoff_time=cutoff_times_df)
 
-#     with cluster() as (scheduler, [a, b]):
-#         dask_kwargs = {'cluster': scheduler['address']}
-#         feature_matrix_2, features_2 = dfs(dataframes=pd_dataframes,
-#                                            relationships=relationships,
-#                                            target_dataframe_name="transactions",
-#                                            cutoff_time=cutoff_times_df,
-#                                            dask_kwargs=dask_kwargs)
+    with cluster() as (scheduler, [a, b]):
+        dask_kwargs = {'cluster': scheduler['address']}
+        feature_matrix_2, features_2 = dfs(dataframes=pd_dataframes,
+                                           relationships=relationships,
+                                           target_dataframe_name="transactions",
+                                           cutoff_time=cutoff_times_df,
+                                           dask_kwargs=dask_kwargs)
 
-#     assert all(f1.unique_name() == f2.unique_name() for f1, f2 in zip(features, features_2))
-#     for column in feature_matrix:
-#         for x, y in zip(feature_matrix[column], feature_matrix_2[column]):
-#             assert ((pd.isnull(x) and pd.isnull(y)) or (x == y))
+    assert all(f1.unique_name() == f2.unique_name() for f1, f2 in zip(features, features_2))
+    for column in feature_matrix:
+        for x, y in zip(feature_matrix[column], feature_matrix_2[column]):
+            assert ((pd.isnull(x) and pd.isnull(y)) or (x == y))

--- a/featuretools/tests/synthesis/test_dfs_method.py
+++ b/featuretools/tests/synthesis/test_dfs_method.py
@@ -3,7 +3,6 @@ import numpy as np
 import pandas as pd
 import pytest
 from dask import dataframe as dd
-from distributed.utils_test import cluster
 from woodwork.column_schema import ColumnSchema
 from woodwork.logical_types import NaturalLanguage
 
@@ -467,7 +466,7 @@ def test_calls_progress_callback(dataframes, relationships):
     assert np.isclose(mock_progress_callback.total_progress_percent, 100.0)
 
 
-def test_calls_progress_callback_cluster(pd_dataframes, relationships):
+def test_calls_progress_callback_cluster(pd_dataframes, relationships, cluster_scheduler):
     class MockProgressCallback:
         def __init__(self):
             self.progress_history = []
@@ -481,19 +480,18 @@ def test_calls_progress_callback_cluster(pd_dataframes, relationships):
 
     mock_progress_callback = MockProgressCallback()
 
-    with cluster() as (scheduler, [a, b]):
-        dkwargs = {'cluster': scheduler['address']}
-        dfs(dataframes=pd_dataframes,
-            relationships=relationships,
-            target_dataframe_name="transactions",
-            progress_callback=mock_progress_callback,
-            dask_kwargs=dkwargs)
+    dkwargs = {'cluster': cluster_scheduler['address']}
+    dfs(dataframes=pd_dataframes,
+        relationships=relationships,
+        target_dataframe_name="transactions",
+        progress_callback=mock_progress_callback,
+        dask_kwargs=dkwargs)
 
     assert np.isclose(mock_progress_callback.total_update, 100.0)
     assert np.isclose(mock_progress_callback.total_progress_percent, 100.0)
 
 
-def test_dask_kwargs(pd_dataframes, relationships):
+def test_dask_kwargs(pd_dataframes, relationships, cluster_scheduler):
     cutoff_times_df = pd.DataFrame({"instance_id": [1, 2, 3],
                                     "time": [10, 12, 15]})
     feature_matrix, features = dfs(dataframes=pd_dataframes,
@@ -501,13 +499,12 @@ def test_dask_kwargs(pd_dataframes, relationships):
                                    target_dataframe_name="transactions",
                                    cutoff_time=cutoff_times_df)
 
-    with cluster() as (scheduler, [a, b]):
-        dask_kwargs = {'cluster': scheduler['address']}
-        feature_matrix_2, features_2 = dfs(dataframes=pd_dataframes,
-                                           relationships=relationships,
-                                           target_dataframe_name="transactions",
-                                           cutoff_time=cutoff_times_df,
-                                           dask_kwargs=dask_kwargs)
+    dask_kwargs = {'cluster': cluster_scheduler['address']}
+    feature_matrix_2, features_2 = dfs(dataframes=pd_dataframes,
+                                       relationships=relationships,
+                                       target_dataframe_name="transactions",
+                                       cutoff_time=cutoff_times_df,
+                                       dask_kwargs=dask_kwargs)
 
     assert all(f1.unique_name() == f2.unique_name() for f1, f2 in zip(features, features_2))
     for column in feature_matrix:


### PR DESCRIPTION
Add `__getstate__` and `__setstate__` methods to EntitySet to preserve and restore Woodwork schema when an entityset is pickled.

Closes #1541
