### PR TITLE
Update Glossary with Woodwork terms

### DIFF
--- a/docs/source/resources/usage_tips/glossary.rst
+++ b/docs/source/resources/usage_tips/glossary.rst
@@ -41,4 +41,4 @@ Glossary
         Optional additional information on the column about the meaning or potential uses of data. Used to determine which primitives can be applied to a column to generate features.
 
     ColumnSchema
-        All of Woodwork's column type information including the logical type and any semantic tags.
+        All of a Woodwork column's type information including the logical type and any semantic tags.

--- a/docs/source/resources/usage_tips/glossary.rst
+++ b/docs/source/resources/usage_tips/glossary.rst
@@ -8,7 +8,7 @@ Glossary
     :sorted:
 
     feature
-        A transformation of data used for machine learning.  featuretools has a custom language for defining features as described :ref:`here <primitives>`. All features are represented by subclasses of :class:`FeatureBase`.
+        A transformation of data used for machine learning.  Featuretools has a custom language for defining features as described :ref:`here <primitives>`. All features are represented by subclasses of :class:`FeatureBase`.
 
     feature engineering
         The process of transforming data into representations that are better for machine learning.
@@ -32,13 +32,16 @@ Glossary
         A dataframe that references another dataframe via relationship. The "many" in a one-to-many relationship.
 
     relationship
-        A mapping between a parent dataframe and a child dataframe. The child dataframe must contain a column referencing the ID column on the parent dataframe. Represented by the :class:`.Relationship` class.
+        A mapping between a parent dataframe and a child dataframe. The child dataframe must contain a column referencing the index column on the parent dataframe. Represented by the :class:`.Relationship` class.
 
     logical type
-        Additional information about how data should be interpreted or parsed beyond how the data is stored on disk or in memory.
+        Additional information about how a column should be interpreted or parsed beyond how the data is stored on disk or in memory. Used to determine which primitives can be applied to a column to generate features.
 
     semantic tag
-        Optional additional information on the column about the meaning or potential uses of data.
+        Optional additional information on the column about the meaning or potential uses of data. Used to determine which primitives can be applied to a column to generate features.
+
+    ColumnSchema
+        All of Woodwork's column type information including the logical type and any semantic tags.
 
 .. todo
 .. label maker,

--- a/docs/source/resources/usage_tips/glossary.rst
+++ b/docs/source/resources/usage_tips/glossary.rst
@@ -34,6 +34,12 @@ Glossary
     relationship
         A mapping between a parent dataframe and a child dataframe. The child dataframe must contain a column referencing the ID column on the parent dataframe. Represented by the :class:`.Relationship` class.
 
+    logical type
+        Additional information about how data should be interpreted or parsed beyond how the data is stored on disk or in memory.
+
+    semantic tag
+        Optional additional information on the column about the meaning or potential uses of data.
+
 .. todo
 .. label maker,
 .. lag

--- a/docs/source/resources/usage_tips/glossary.rst
+++ b/docs/source/resources/usage_tips/glossary.rst
@@ -13,33 +13,26 @@ Glossary
     feature engineering
         The process of transforming data into representations that are better for machine learning.
 
-    variable
-        Equivalent to a column in a relational database. Represented by the :class:`.Variable` class.
-
-
     cutoff time
         The last point in time data is allowed to be used when calculating a feature
 
-    entity
-        Equivalent to a table in relational database. Represented by the :class:`.Entity` class.
-
     EntitySet
-        A collection of entities and the relationships between them. Represented by the :class:`.EntitySet` class.
+        A collection of dataframes and the relationships between them. Represented by the :class:`.EntitySet` class.
 
     instance
-        Equivalent to a row in a relational database. Each entity has many instances, and each instance has a value for each variable and feature defined on the entity.
+        Equivalent to a row in a relational database. Each dataframe has many instances, and each instance has a value for each column and feature defined on the dataframe.
 
     target dataframe
         The dataframe for which we will be making features
 
-    parent entity
-        An entity that is referenced by another entity via relationship. The "one" in a one-to-many relationship.
+    parent dataframe
+        A dataframe that is referenced by another dataframe via relationship. The "one" in a one-to-many relationship.
 
-    child entity
-        An entity that references another entity via relationship. The "many" in a one-to-many relationship.
+    child dataframe
+        A dataframe that references another dataframe via relationship. The "many" in a one-to-many relationship.
 
     relationship
-        A mapping between a parent entity and a child entity. The child entity must contain a variable referencing the ID variable on the parent entity. Represented by the :class:`.Relationship` class.
+        A mapping between a parent dataframe and a child dataframe. The child dataframe must contain a column referencing the ID column on the parent dataframe. Represented by the :class:`.Relationship` class.
 
 .. todo
 .. label maker,

--- a/docs/source/resources/usage_tips/glossary.rst
+++ b/docs/source/resources/usage_tips/glossary.rst
@@ -42,8 +42,3 @@ Glossary
 
     ColumnSchema
         All of Woodwork's column type information including the logical type and any semantic tags.
-
-.. todo
-.. label maker,
-.. lag
-..     The amount of time before the prediction time that data is used to make a prediction. This is the time between the beginning and end of a learning window.


### PR DESCRIPTION
Updates the glossary to remove references to "entity" and "variables" to match the updated woodwork integration. Also adds "logical type", "semantic tags", and "ColumnSchema" to the glossary.

Closes #1579