### PR TITLE
Update nlp-primitives requirement

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -12,6 +12,7 @@ nbconvert==6.0.6
 nbsphinx==0.8.5
 Sphinx==3.2.1
 pydata_sphinx_theme==0.4.0
-nlp_primitives>=1.0.0
+# nlp_primitives>=1.0.0 - Uncomment and update after new version is released
+git+https://github.com/alteryx/nlp_primitives.git@ft-1.0.0-dev
 autonormalize >= 1.0.1
 -r koalas-requirements.txt


### PR DESCRIPTION
### Update nlp-primitives requirement

Updates NLP primitives requirement in `dev-requirements.txt` to install updated version that is compatible with Featuretools 1.0.0, allowing for NLP Primitives section of docs to build successfully