### PR TITLE
Specify conda channel and Windows exe in graphviz installation instructions

### DIFF
--- a/.github/workflows/unit_tests_with_latest_deps.yml
+++ b/.github/workflows/unit_tests_with_latest_deps.yml
@@ -102,7 +102,7 @@ jobs:
           . $env:USERPROFILE\Miniconda3\shell\condabin\conda-hook.ps1
           conda activate featuretools
           conda config --add channels conda-forge
-          conda install python-graphviz -q -y
+          conda install -q -y -c conda-forge python-graphviz
           python -m pip install --upgrade pip
           python -m pip install .
           python -m pip install -r test-requirements.txt

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -62,7 +62,7 @@ pip users::
     
 conda users::
 
-    conda install -c conda-forge graphviz
+    conda install -c conda-forge python-graphviz
 
 Ubuntu::
 
@@ -80,7 +80,7 @@ Windows:
 - Install according to your package manager::
 
     # conda
-    conda install -c conda-forge graphviz
+    conda install -c conda-forge python-graphviz
     # pip
     pip install graphviz
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -83,7 +83,7 @@ Windows:
     # pip
     pip install graphviz
 
-- If you installed graphviz with `pip`, install graphviz.exe from the `official source <https://graphviz.org/download/#windows>`_
+- If you installed graphviz with ``pip``, install graphviz.exe from the `official source <https://graphviz.org/download/#windows>`_
 
 
 Install from Source

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -66,7 +66,7 @@ conda users::
 
 Ubuntu::
 
-    sudo apt-get install graphviz
+    sudo apt install graphviz
     pip install graphviz
 
 Mac OS::

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -56,9 +56,13 @@ Installing Graphviz
 In order to use :meth:`EntitySet.plot <featuretools.entityset.EntitySet.plot>` or :func:`featuretools.graph_feature`
 you will need to install the graphviz library.
 
-Conda users::
+pip users::
 
-    conda install python-graphviz
+    pip install graphviz
+    
+conda users::
+
+    conda install -c conda-forge graphviz
 
 Ubuntu::
 
@@ -70,10 +74,15 @@ Mac OS::
     brew install graphviz
     pip install graphviz
 
-Windows::
+Windows:
 
-    conda install python-graphviz
+- Install the graphviz from the `official source <https://graphviz.org/download/#windows>`_
+- Install according to your package manager::
 
+    # conda
+    conda install -c conda-forge graphviz
+    # pip
+    pip install graphviz
 
 Install from Source
 -------------------

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -76,13 +76,15 @@ Mac OS::
 
 Windows:
 
-- Install the graphviz from the `official source <https://graphviz.org/download/#windows>`_
 - Install according to your package manager::
 
     # conda
     conda install -c conda-forge python-graphviz
     # pip
     pip install graphviz
+
+- If you installed graphviz with `pip`, install graphviz.exe from the `official source <https://graphviz.org/download/#windows>`_
+
 
 Install from Source
 -------------------

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -9,6 +9,7 @@ Future Release
     * Fixes
     * Changes
     * Documentation Changes
+        * Specify conda channel and Windows exe in graphviz installation instructions (:pr:`1611`)
     * Testing Changes
         * Add additional reviewers to minimum and latest dependency checkers (:pr:`1558`, :pr:`1562`, :pr:`1564`, :pr:`1567`)
     

--- a/featuretools/utils/plot_utils.py
+++ b/featuretools/utils/plot_utils.py
@@ -14,7 +14,7 @@ def check_graphviz():
             "To plot entity sets, a graphviz backend is required.\n" +
             "Install the backend using one of the following commands:\n" +
             "  Mac OS: brew install graphviz\n" +
-            "  Linux (Ubuntu): sudo apt-get install graphviz\n" +
+            "  Linux (Ubuntu): $ sudo apt install graphviz\n" +
             "  Windows: conda install -c conda-forge python-graphviz\n" +
             "  Windows: https://graphviz.org/download/#windows" +
             "  For more details visit: https://featuretools.alteryx.com/en/stable/install.html#installing-graphviz"

--- a/featuretools/utils/plot_utils.py
+++ b/featuretools/utils/plot_utils.py
@@ -15,8 +15,9 @@ def check_graphviz():
             "Install the backend using one of the following commands:\n" +
             "  Mac OS: brew install graphviz\n" +
             "  Linux (Ubuntu): $ sudo apt install graphviz\n" +
-            "  Windows: conda install -c conda-forge python-graphviz\n" +
-            "  Windows (download exe and install): https://graphviz.org/download/#windows" +
+            "  Windows (conda): conda install -c conda-forge python-graphviz\n" +
+            "  Windows (pip): pip install graphviz\n" +
+            "  Windows (EXE required if graphviz was installed via pip): https://graphviz.org/download/#windows" +
             "  For more details visit: https://featuretools.alteryx.com/en/stable/install.html#installing-graphviz"
         )
     return graphviz

--- a/featuretools/utils/plot_utils.py
+++ b/featuretools/utils/plot_utils.py
@@ -16,7 +16,7 @@ def check_graphviz():
             "  Mac OS: brew install graphviz\n" +
             "  Linux (Ubuntu): $ sudo apt install graphviz\n" +
             "  Windows: conda install -c conda-forge python-graphviz\n" +
-            "  Windows: https://graphviz.org/download/#windows" +
+            "  Windows (download exe and install): https://graphviz.org/download/#windows" +
             "  For more details visit: https://featuretools.alteryx.com/en/stable/install.html#installing-graphviz"
         )
     return graphviz

--- a/featuretools/utils/plot_utils.py
+++ b/featuretools/utils/plot_utils.py
@@ -16,6 +16,7 @@ def check_graphviz():
             "  Mac OS: brew install graphviz\n" +
             "  Linux (Ubuntu): sudo apt-get install graphviz\n" +
             "  Windows: conda install -c conda-forge python-graphviz\n" +
+            "  Windows: https://graphviz.org/download/#windows" +
             "  For more details visit: https://featuretools.alteryx.com/en/stable/install.html#installing-graphviz"
         )
     return graphviz

--- a/featuretools/utils/plot_utils.py
+++ b/featuretools/utils/plot_utils.py
@@ -15,7 +15,7 @@ def check_graphviz():
             "Install the backend using one of the following commands:\n" +
             "  Mac OS: brew install graphviz\n" +
             "  Linux (Ubuntu): sudo apt-get install graphviz\n" +
-            "  Windows: conda install python-graphviz\n" +
+            "  Windows: conda install -c conda-forge python-graphviz\n" +
             "  For more details visit: https://featuretools.alteryx.com/en/stable/install.html#installing-graphviz"
         )
     return graphviz


### PR DESCRIPTION
- Specify conda channel when graphviz installation instructions are given
- Tell users to download graphviz from the official source
- Move to `apt` install rather than the old `apt-get` (came out in 2016 with Ubuntu 16.04)