### PR TITLE
Remove more references to entity, entities, variable, var

### DIFF
--- a/featuretools/computational_backends/feature_set.py
+++ b/featuretools/computational_backends/feature_set.py
@@ -16,7 +16,7 @@ logger = logging.getLogger('featuretools.computational_backend')
 
 class FeatureSet(object):
     """
-    Represents an immutable set of features to be calculated for a single entity, and their
+    Represents an immutable set of features to be calculated for a single dataframe, and their
     dependencies.
     """
 
@@ -70,9 +70,9 @@ class FeatureSet(object):
         then used for all subsequent calls.
 
         The edges of the trie are RelationshipPaths and the values are tuples of
-        (bool, set[str], set[str]). The bool represents whether the full entity df is needed at
+        (bool, set[str], set[str]). The bool represents whether the full df is needed at
         that node, the first set contains the names of features which are needed on the full
-        entity, and the second set contains the names of the rest of the features
+        dataframe, and the second set contains the names of the rest of the features
 
         Returns:
             Trie[RelationshipPath, (bool, set[str], set[str])]
@@ -111,7 +111,7 @@ class FeatureSet(object):
         if name in approximate_feature_trie.value:
             return
 
-        # Add the feature to one of the sets, depending on whether it needs the full entity.
+        # Add the feature to one of the sets, depending on whether it needs the full dataframe.
         if needs_full_dataframe:
             full_features.add(name)
             if name in not_full_features:
@@ -168,7 +168,7 @@ class FeatureSet(object):
     def _get_feature_depths(self, features):
         """
         Generate and return a mapping of {feature name -> depth} in the
-        feature DAG for the given entity.
+        feature DAG for the given dataframe.
         """
         order = defaultdict(int)
         depths = {}
@@ -179,7 +179,7 @@ class FeatureSet(object):
 
             depths[f.unique_name()] = order[f.unique_name()]
 
-            # Only look at dependencies if they are on the same entity.
+            # Only look at dependencies if they are on the same dataframe.
             if not f.relationship_path:
                 dependencies = f.get_dependencies()
                 for dep in dependencies:

--- a/featuretools/computational_backends/feature_set.py
+++ b/featuretools/computational_backends/feature_set.py
@@ -70,7 +70,7 @@ class FeatureSet(object):
         then used for all subsequent calls.
 
         The edges of the trie are RelationshipPaths and the values are tuples of
-        (bool, set[str], set[str]). The bool represents whether the full df is needed at
+        (bool, set[str], set[str]). The bool represents whether the full dataframe is needed at
         that node, the first set contains the names of features which are needed on the full
         dataframe, and the second set contains the names of the rest of the features
 

--- a/featuretools/computational_backends/feature_set_calculator.py
+++ b/featuretools/computational_backends/feature_set_calculator.py
@@ -632,7 +632,7 @@ class FeatureSetCalculator(object):
             to_agg = {}
             agg_rename = {}
             to_apply = set()
-            # apply multivariable and time-dependent features as we find them, and
+            # apply multi-column and time-dependent features as we find them, and
             # save aggregable features for later
             for f in features:
                 if _can_agg(f):
@@ -746,7 +746,7 @@ class FeatureSetCalculator(object):
         return frame
 
     def _necessary_columns(self, dataframe_name, feature_names):
-        # We have to keep all Id columns because we don't know what forward
+        # We have to keep all index and foreign columns because we don't know what forward
         # relationships will come from this node.
         df = self.entityset[dataframe_name]
         index_columns = {col for col in df.columns

--- a/featuretools/demo/flight.py
+++ b/featuretools/demo/flight.py
@@ -45,7 +45,7 @@ def load_flight(month_filter=None,
             In [3]: es
             Out[3]:
             Entityset: Flight Data
-              Entities:
+              DataFrames:
                 airports [Rows: 55, Columns: 3]
                 flights [Rows: 613, Columns: 9]
                 trip_logs [Rows: 9456, Columns: 22]

--- a/featuretools/demo/retail.py
+++ b/featuretools/demo/retail.py
@@ -35,7 +35,7 @@ def load_retail(id='demo_retail_data', nrows=None, return_single_table=False):
             In [3]: es
             Out[3]:
             Entityset: demo_retail_data
-              Entities:
+              DataFrames:
                 orders (shape = [22190, 3])
                 products (shape = [3684, 3])
                 customers (shape = [4372, 2])
@@ -51,7 +51,7 @@ def load_retail(id='demo_retail_data', nrows=None, return_single_table=False):
             In [5]: es
             Out[5]:
             Entityset: demo_retail_data
-              Entities:
+              DataFrames:
                 orders (shape = [67, 5])
                 products (shape = [606, 3])
                 customers (shape = [50, 2])

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -179,7 +179,7 @@ class EntitySet(object):
 
     @property
     def dataframe_type(self):
-        '''String specifying the library used for the entity dataframes. Null if no dataframes'''
+        '''String specifying the library used for the dataframes. Null if no dataframes'''
         df_type = None
 
         if self.dataframes:
@@ -342,7 +342,7 @@ class EntitySet(object):
 
         if parent_df.ww.index != parent_column:
             parent_df.ww.set_index(parent_column)
-        # Empty dataframes (as a result of accessing Entity.metadata)
+        # Empty dataframes (as a result of accessing metadata)
         # default to object dtypes for categorical columns, but
         # indexes/foreign keys default to ints. In this case, we convert
         # the empty column's type to int
@@ -1281,7 +1281,7 @@ class EntitySet(object):
                 column_typing_info.append(col_string)
 
             columns_string = '\l'.join(column_typing_info)  # noqa: W605
-            if isinstance(df, dd.DataFrame):  # entity is a dask entity
+            if isinstance(df, dd.DataFrame):  # dataframe is a dask dataframe
                 label = '{%s |%s\l}' % (df.ww.name, columns_string)  # noqa: W605
             else:
                 nrows = df.shape[0]
@@ -1368,7 +1368,7 @@ class EntitySet(object):
             column_name (str) : Column to query on. If None, query on index.
             columns (list[str]) : Columns to return. Return all columns if None.
             time_last (pd.TimeStamp) : Query data up to and including this
-                time. Only applies if entity has a time index.
+                time. Only applies if dataframe has a time index.
             training_window (Timedelta, optional):
                 Window defining how much time before the cutoff time data
                 can be used when calculating features. If None, all data before cutoff time is used.

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -342,11 +342,7 @@ class EntitySet(object):
 
         if parent_df.ww.index != parent_column:
             parent_df.ww.set_index(parent_column)
-        # Empty dataframes (as a result of accessing metadata)
-        # default to object dtypes for categorical columns, but
-        # indexes/foreign keys default to ints. In this case, we convert
-        # the empty column's type to int
-        # --> Implementation: is this still relevant?
+
         if isinstance(child_df, pd.DataFrame) and \
                 (child_df.empty and child_df[child_column].dtype == object and
                  parent_df.ww.columns[parent_column].is_numeric):
@@ -819,10 +815,6 @@ class EntitySet(object):
 
         base_dataframe_index = index
 
-        # --> Implementation: not sure that this is the same as using ltype Categorical because we can't just set a standard tag
-        # why did we set it to Categorical???
-        # and why does it get reset when we did it above??
-        # transfer_types[index] = ('Categorical', set())
         if make_secondary_time_index:
             old_ti_name = list(make_secondary_time_index.keys())[0]
             ti_cols = list(make_secondary_time_index.values())[0]

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -343,6 +343,10 @@ class EntitySet(object):
         if parent_df.ww.index != parent_column:
             parent_df.ww.set_index(parent_column)
 
+        # Empty dataframes (as a result of accessing metadata)
+        # default to object dtypes for categorical columns, but
+        # indexes/foreign keys default to ints. In this case, we convert
+        # the empty column's type to int
         if isinstance(child_df, pd.DataFrame) and \
                 (child_df.empty and child_df[child_column].dtype == object and
                  parent_df.ww.columns[parent_column].is_numeric):

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -820,7 +820,7 @@ class EntitySet(object):
         base_dataframe_index = index
 
         # --> Implementation: not sure that this is the same as using ltype Categorical because we can't just set a standard tag
-        # why did we set it to variable Categorical???
+        # why did we set it to Categorical???
         # and why does it get reset when we did it above??
         # transfer_types[index] = ('Categorical', set())
         if make_secondary_time_index:
@@ -1522,7 +1522,7 @@ class EntitySet(object):
         return time_type
 
 
-def _vals_to_series(instance_vals, variable_id):
+def _vals_to_series(instance_vals, column_id):
     """
     instance_vals may be a pd.Dataframe, a pd.Series, a list, a single
     value, or None. This function always returns a Series or None.
@@ -1536,9 +1536,9 @@ def _vals_to_series(instance_vals, variable_id):
 
     # convert iterable to pd.Series
     if isinstance(instance_vals, pd.DataFrame):
-        out_vals = instance_vals[variable_id]
+        out_vals = instance_vals[column_id]
     elif is_instance(instance_vals, (pd, dd, ks), 'Series'):
-        out_vals = instance_vals.rename(variable_id)
+        out_vals = instance_vals.rename(column_id)
     else:
         out_vals = pd.Series(instance_vals)
 

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -64,14 +64,14 @@ class EntitySet(object):
 
                 .. code-block:: python
 
-                    entities = {
+                    dataframes = {
                         "cards" : (card_df, "id"),
                         "transactions" : (transactions_df, "id", "transaction_time")
                     }
 
                     relationships = [("cards", "id", "transactions", "card_id")]
 
-                    ft.EntitySet("my-entity-set", entities, relationships)
+                    ft.EntitySet("my-entity-set", dataframes, relationships)
         """
         self.id = id
         self.dataframe_dict = {}
@@ -179,7 +179,7 @@ class EntitySet(object):
 
     @property
     def dataframe_type(self):
-        '''String specifying the library used for the entity dataframes. Null if no entities'''
+        '''String specifying the library used for the entity dataframes. Null if no dataframes'''
         df_type = None
 
         if self.dataframes:
@@ -343,7 +343,7 @@ class EntitySet(object):
         if parent_df.ww.index != parent_column:
             parent_df.ww.set_index(parent_column)
         # Empty dataframes (as a result of accessing Entity.metadata)
-        # default to object dtypes for discrete variables, but
+        # default to object dtypes for categorical columns, but
         # indexes/foreign keys default to ints. In this case, we convert
         # the empty column's type to int
         # --> Implementation: is this still relevant?
@@ -819,7 +819,7 @@ class EntitySet(object):
 
         base_dataframe_index = index
 
-        # --> Implementation: not sure that this is the same as using vtype Categorical because we can't just set a standard tag
+        # --> Implementation: not sure that this is the same as using ltype Categorical because we can't just set a standard tag
         # why did we set it to variable Categorical???
         # and why does it get reset when we did it above??
         # transfer_types[index] = ('Categorical', set())
@@ -1268,7 +1268,7 @@ class EntitySet(object):
         graph = graphviz.Digraph(self.id, format=format_,
                                  graph_attr={'splines': 'ortho'})
 
-        # Draw entities
+        # Draw dataframes
         for df in self.dataframes:
             column_typing_info = []
             for col_name, col_schema in df.ww.columns.items():
@@ -1290,7 +1290,7 @@ class EntitySet(object):
 
         # Draw relationships
         for rel in self.relationships:
-            # Display the key only once if is the same for both related entities
+            # Display the key only once if is the same for both related dataframes
             if rel._parent_column_name == rel._child_column_name:
                 label = rel._parent_column_name
             else:

--- a/featuretools/entityset/relationship.py
+++ b/featuretools/entityset/relationship.py
@@ -2,7 +2,7 @@ class Relationship(object):
     """Class to represent a relationship between dataframes
 
     See Also:
-        :class:`.EntitySet`, :class:`.Entity`
+        :class:`.EntitySet`
     """
 
     def __init__(self, entityset, parent_dataframe_name, parent_column_name,

--- a/featuretools/entityset/relationship.py
+++ b/featuretools/entityset/relationship.py
@@ -1,5 +1,5 @@
 class Relationship(object):
-    """Class to represent an relationship between entities
+    """Class to represent a relationship between dataframes
 
     See Also:
         :class:`.EntitySet`, :class:`.Entity`
@@ -103,7 +103,7 @@ class Relationship(object):
         }
 
     def _is_unique(self):
-        """Is there any other relationship with same parent and child entities?"""
+        """Is there any other relationship with same parent and child dataframes?"""
         es = self.entityset
         relationships = es.get_forward_relationships(self._child_dataframe_name)
         n = len([r for r in relationships

--- a/featuretools/feature_base/feature_base.py
+++ b/featuretools/feature_base/feature_base.py
@@ -191,8 +191,7 @@ class FeatureBase(object):
                 if column_schema.is_categorical:
                     column_schema.semantic_tags.add('category')
 
-            # direct features should keep the Id return type, but all other features should get
-            # converted to Categorical
+            # direct features should keep the foreign key tag, but all other features should get converted
             if not isinstance(feature, DirectFeature) and 'foreign_key' in column_schema.semantic_tags:
                 column_schema = ColumnSchema(logical_type=column_schema.logical_type,
                                              semantic_tags=column_schema.semantic_tags - {"foreign_key"})

--- a/featuretools/feature_base/feature_base.py
+++ b/featuretools/feature_base/feature_base.py
@@ -519,7 +519,7 @@ class AggregationFeature(FeatureBase):
             time_index = base_features[0].dataframe.ww.time_index
             time_col = base_features[0].dataframe.ww[time_index]
             assert time_index is not None, ("Use previous can only be defined "
-                                            "on entities with a time index")
+                                            "on dataframes with a time index")
             assert _check_time_against_column(self.use_previous, time_col)
 
         super(AggregationFeature, self).__init__(entityset=entityset,

--- a/featuretools/feature_base/feature_base.py
+++ b/featuretools/feature_base/feature_base.py
@@ -24,8 +24,8 @@ class FeatureBase(object):
             entityset (EntitySet): entityset this feature is being calculated for
             dataframe_name (str): name of dataframe this feature is being calculated for
             base_features (list[FeatureBase]): list of base features for primitive
-            relationship_path (RelationshipPath): path from this entity to the
-                entity of the base features.
+            relationship_path (RelationshipPath): path from this dataframe to the
+                dataframe of the base features.
             primitive (:class:`.PrimitiveBase`): primitive to calculate. if not initialized when passed, gets initialized with no arguments
         """
         assert all(isinstance(f, FeatureBase) for f in base_features), \

--- a/featuretools/feature_base/feature_visualizer.py
+++ b/featuretools/feature_base/feature_visualizer.py
@@ -228,13 +228,13 @@ def get_dataframe_table(dataframe_name, dataframe_dict):
     else:
         rows = []
 
-    for var in list(columns) + list(feats) + list(targets):
+    for col in list(columns) + list(feats) + list(targets):
         template = COL_TEMPLATE
-        if var in targets:
+        if col in targets:
             template = TARGET_TEMPLATE
 
-        var = html.escape(var)
-        rows.append(template.format(var, var))
+        col = html.escape(col)
+        rows.append(template.format(col, col))
 
     table = TABLE_TEMPLATE.format(dataframe_name=dataframe_name,
                                   table_cols="\n".join(rows))

--- a/featuretools/primitives/base/aggregation_primitive_base.py
+++ b/featuretools/primitives/base/aggregation_primitive_base.py
@@ -80,7 +80,7 @@ def make_agg_primitive(function, input_types, return_type, name=None,
             calculated at will be passed to the function as the keyword
             argument 'time'.
 
-        default_value (Variable): Default value when creating the primitive to
+        default_value (int, float): Default value when creating the primitive to
             avoid the inference step. If no default value if provided, the
             inference happen.
 

--- a/featuretools/primitives/base/primitive_base.py
+++ b/featuretools/primitives/base/primitive_base.py
@@ -13,9 +13,9 @@ class PrimitiveBase(object):
     """Base class for all primitives."""
     #: (str): Name of the primitive
     name = None
-    #: (list): Variable types of inputs
+    #: (list): woodwork.ColumnSchema types of inputs
     input_types = None
-    #: (:class:`.Variable`): variable type of return
+    #: (woodwork.ColumnSchema): ColumnSchema type of return
     return_type = None
     #: Default value this feature returns if no data found. Defaults to np.nan
     default_value = np.nan

--- a/featuretools/primitives/base/transform_primitive_base.py
+++ b/featuretools/primitives/base/transform_primitive_base.py
@@ -7,9 +7,9 @@ from featuretools.primitives.base.utils import inspect_function_args
 
 
 class TransformPrimitive(PrimitiveBase):
-    """Feature for entity that is a based off one or more other features
-        in that entity."""
-    # (bool) If True, feature function depends on all values of entity
+    """Feature for dataframe that is a based off one or more other features
+        in that dataframe."""
+    # (bool) If True, feature function depends on all values of dataframe
     #   (and will receive these values as input, regardless of specified instance ids)
     uses_full_dataframe = False
 

--- a/featuretools/primitives/standard/aggregation_primitives.py
+++ b/featuretools/primitives/standard/aggregation_primitives.py
@@ -695,7 +695,7 @@ class TimeSinceFirst(AggregationPrimitive):
 
 
 class Trend(AggregationPrimitive):
-    """Calculates the trend of a variable over time.
+    """Calculates the trend of a column over time.
 
     Description:
         Given a list of values and a corresponding list of
@@ -777,11 +777,11 @@ def find_dividend_by_unit(time):
 
 
 class Entropy(AggregationPrimitive):
-    """Calculates the entropy for a categorical variable
+    """Calculates the entropy for a categorical column
 
     Description:
         Given a list of observations from a categorical
-        variable return the entropy of the distribution.
+        column return the entropy of the distribution.
         NaN values can be treated as a category or
         dropped.
 

--- a/featuretools/primitives/standard/transform_primitive.py
+++ b/featuretools/primitives/standard/transform_primitive.py
@@ -550,7 +550,7 @@ class Percentile(TransformPrimitive):
 
 class Latitude(TransformPrimitive):
     """Returns the first tuple value in a list of LatLong tuples.
-       For use with the LatLong variable type.
+       For use with the LatLong logical type.
 
     Examples:
         >>> latitude = Latitude()
@@ -572,7 +572,7 @@ class Latitude(TransformPrimitive):
 
 class Longitude(TransformPrimitive):
     """Returns the second tuple value in a list of LatLong tuples.
-       For use with the LatLong variable type.
+       For use with the LatLong logical type.
 
     Examples:
         >>> longitude = Longitude()
@@ -593,8 +593,7 @@ class Longitude(TransformPrimitive):
 
 
 class Haversine(TransformPrimitive):
-    """Calculates the approximate haversine distance between two LatLong
-        variable types.
+    """Calculates the approximate haversine distance between two LatLong columns.
 
         Args:
             unit (str): Determines the unit value to output. Could

--- a/featuretools/synthesis/dfs.py
+++ b/featuretools/synthesis/dfs.py
@@ -63,7 +63,7 @@ def dfs(dataframes=None,
         entityset (EntitySet): An already initialized entityset. Required if
             dataframes and relationships are not defined.
 
-        target_dataframe (str): Entity id of entity on which to make predictions.
+        target_dataframe_name (str): Name of dataframe on which to make predictions.
 
         cutoff_time (pd.DataFrame or Datetime): Specifies times at which to calculate
             the features for each instance. The resulting feature matrix will use data
@@ -92,7 +92,7 @@ def dfs(dataframes=None,
         groupby_trans_primitives (list[str or :class:`.primitives.TransformPrimitive`], optional):
             list of Transform primitives to make GroupByTransformFeatures with
 
-        allowed_paths (list[list[str]]): Allowed entity paths on which to make
+        allowed_paths (list[list[str]]): Allowed dataframe paths on which to make
             features.
 
         max_depth (int) : Maximum allowed depth of features.
@@ -101,7 +101,7 @@ def dfs(dataframes=None,
             blacklist when creating features.
 
         ignore_columns (dict[str -> list[str]], optional): List of specific
-            columns within each entity to blacklist when creating features.
+            columns within each dataframe to blacklist when creating features.
 
         primitive_options (list[dict[str or tuple[str] -> dict] or dict[str or tuple[str] -> dict, optional]):
             Specify options for a single primitive or a group of primitives.
@@ -116,9 +116,9 @@ def dfs(dataframes=None,
                 List of dataframes to be blacklisted when creating features
                 for the primitive(s) (list[str]).
             ``"include_columns"``
-                List of specific columns within each entity to include when
+                List of specific columns within each dataframe to include when
                 creating features for the primitive(s). All other columns
-                in a given entity will be ignored (dict[str -> list[str]]).
+                in a given dataframe will be ignored (dict[str -> list[str]]).
             ``"ignore_columns"``
                 List of specific columns within each dataframe to blacklist
                 when creating features for the primitive(s) (dict[str ->
@@ -130,11 +130,11 @@ def dfs(dataframes=None,
                 List of dataframes to blacklist when finding groupbys
                 (list[str]).
             ``"include_groupby_columns"``
-                List of specific columns within each entity to include as
+                List of specific columns within each dataframe to include as
                 groupbys, if applicable. All other columns in each
-                entity will be ignored (dict[str -> list[str]]).
+                dataframe will be ignored (dict[str -> list[str]]).
             ``"ignore_groupby_columns"``
-                List of specific columns within each entity to blacklist
+                List of specific columns within each dataframe to blacklist
                 as groupbys (dict[str -> list[str]]).
 
         seed_features (list[:class:`.FeatureBase`]): List of manually defined

--- a/featuretools/tests/computational_backend/test_feature_set_calculator.py
+++ b/featuretools/tests/computational_backend/test_feature_set_calculator.py
@@ -503,7 +503,7 @@ def test_make_dfeat_of_agg_feat_on_self(es):
 
         R       R = Regions, a parent of customers
         |
-        C       C = Customers, the entity we're trying to predict on
+        C       C = Customers, the dataframe we're trying to predict on
         |
        etc.
 
@@ -527,7 +527,7 @@ def test_make_dfeat_of_agg_feat_through_parent(es):
     """
     The graph looks like this:
 
-        R       C = Customers, the entity we're trying to predict on
+        R       C = Customers, the dataframe we're trying to predict on
        / \\     R = Regions, a parent of customers
       S   C     S = Stores, a child of regions
           |
@@ -555,7 +555,7 @@ def test_make_deep_agg_feat_of_dfeat_of_agg_feat(es):
     """
     The graph looks like this (higher implies parent):
 
-          C     C = Customers, the entity we're trying to predict on
+          C     C = Customers, the dataframe we're trying to predict on
           |     S = Sessions, a child of Customers
       P   S     L = Log, a child of both Sessions and Log
        \\ /     P = Products, a parent of Log which is not a descendent of customers

--- a/featuretools/tests/computational_backend/test_feature_set_calculator.py
+++ b/featuretools/tests/computational_backend/test_feature_set_calculator.py
@@ -69,7 +69,7 @@ def test_make_dfeat(es):
     assert (v == 33)
 
 
-def test_make_agg_feat_of_identity_variable(es):
+def test_make_agg_feat_of_identity_column(es):
     agg_feat = ft.Feature(ft.Feature(es, 'log', 'value'), parent_dataframe_name='sessions', primitive=Sum)
 
     feature_set = FeatureSet([agg_feat])
@@ -113,7 +113,7 @@ def test_full_dataframe_error_dask(dask_es):
         calculator.run(np.array([1]))
 
 
-def test_make_agg_feat_of_identity_index_variable(es):
+def test_make_agg_feat_of_identity_index_column(es):
     agg_feat = ft.Feature(ft.Feature(es, 'log', 'id'), parent_dataframe_name='sessions', primitive=Count)
 
     feature_set = FeatureSet([agg_feat])
@@ -889,7 +889,7 @@ def test_handles_primitive_function_name_uniqueness(es):
     double_value_sum = pd.Series([112, 52, 0])
     assert all(fm[f2.get_name()].sort_index() == double_value_sum)
 
-    # same primitive, same variable, different args
+    # same primitive, same column, different args
     fm = ft.calculate_feature_matrix(features=[f1, f2], entityset=es)
 
     assert all(fm[f1.get_name()].sort_index() == value_sum)

--- a/featuretools/tests/computational_backend/test_feature_set_calculator.py
+++ b/featuretools/tests/computational_backend/test_feature_set_calculator.py
@@ -452,7 +452,7 @@ def test_make_3_stacked_agg_feats(df):
     """
     Tests stacking 3 agg features.
 
-    The test specifically uses non numeric indices to test how ancestor variables are handled
+    The test specifically uses non numeric indices to test how ancestor columns are handled
     as dataframes are merged together
 
     """

--- a/featuretools/tests/demo_tests/test_demo_data.py
+++ b/featuretools/tests/demo_tests/test_demo_data.py
@@ -41,7 +41,7 @@ def test_load_flight():
     es = load_flight(month_filter=[1],
                      categorical_filter={'origin_city': ['Charlotte, NC']},
                      return_single_table=False, nrows=1000)
-    entity_names = ['airports', 'flights', 'trip_logs', 'airlines']
+    dataframe_names = ['airports', 'flights', 'trip_logs', 'airlines']
     realvals = [(11, 3), (13, 9), (103, 21), (1, 1)]
-    for i, name in enumerate(entity_names):
+    for i, name in enumerate(dataframe_names):
         assert es[name].shape == realvals[i]

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -355,7 +355,7 @@ def test_query_by_id_with_time(es):
     assert list(df['id'].values) == [0, 1, 2]
 
 
-def test_query_by_variable_with_time(es):
+def test_query_by_column_with_time(es):
     df = es.query_by_values(
         dataframe_name='log',
         instance_vals=[0, 1, 2], column_name='session_id',
@@ -372,7 +372,7 @@ def test_query_by_variable_with_time(es):
     assert list(df['value'].values) == true_values
 
 
-def test_query_by_variable_with_no_lti_and_training_window(es):
+def test_query_by_column_with_no_lti_and_training_window(es):
     match = "Using training_window but last_time_index is not set for dataframe customers"
     with pytest.warns(UserWarning, match=match):
         df = es.query_by_values(
@@ -386,7 +386,7 @@ def test_query_by_variable_with_no_lti_and_training_window(es):
     assert list(df['age'].values) == [25]
 
 
-def test_query_by_variable_with_lti_and_training_window(es):
+def test_query_by_column_with_lti_and_training_window(es):
     es.add_last_time_indexes()
     df = es.query_by_values(
         dataframe_name='customers',
@@ -399,7 +399,7 @@ def test_query_by_variable_with_lti_and_training_window(es):
     assert list(df['age'].values) == [33, 25, 56]
 
 
-def test_query_by_indexed_variable(es):
+def test_query_by_indexed_column(es):
     df = es.query_by_values(
         dataframe_name='log',
         instance_vals=['taco clock'],

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -626,9 +626,9 @@ def test_converts_dtype_on_init(df4):
     df4.ww.init(name='test_dataframe', index='id', logical_types=logical_types)
     es.add_dataframe(dataframe=df4)
 
-    entity_df = es['test_dataframe']
-    assert entity_df['ints'].dtype.name == 'int64'
-    assert entity_df['floats'].dtype.name == 'float64'
+    df = es['test_dataframe']
+    assert df['ints'].dtype.name == 'int64'
+    assert df['floats'].dtype.name == 'float64'
 
     # this is infer from pandas dtype
     df = es["test_dataframe"]
@@ -1051,7 +1051,7 @@ def test_concat_with_make_index(es):
     assert es.__eq__(es_1, deep=True)
     assert es.__eq__(es_2, deep=True)
 
-    # map of what rows to take from es_1 and es_2 for each entity
+    # map of what rows to take from es_1 and es_2 for each dataframe
     emap = {
         'log': [list(range(10)) + [14, 15, 16], list(range(10, 14)) + [15, 16]],
         'sessions': [[0, 1, 2], [1, 3, 4, 5]],
@@ -1105,7 +1105,7 @@ def transactions_df(request):
 
 
 def test_set_time_type_on_init(transactions_df):
-    # create cards entity
+    # create cards dataframe
     cards_df = pd.DataFrame({"id": [1, 2, 3, 4, 5]})
     if isinstance(transactions_df, dd.DataFrame):
         cards_df = dd.from_pandas(cards_df, npartitions=3)
@@ -1162,7 +1162,7 @@ def test_sets_time_when_adding_dataframe(transactions_df):
     es = EntitySet("fraud")
     # assert it's not set
     assert getattr(es, "time_type", None) is None
-    # add entity
+    # add dataframe
     es.add_dataframe(transactions_df,
                      dataframe_name="transactions",
                      index="id",
@@ -1170,14 +1170,14 @@ def test_sets_time_when_adding_dataframe(transactions_df):
                      logical_types=transactions_logical_types)
     # assert time_type is set
     assert es.time_type == 'numeric'
-    # add another entity
+    # add another dataframe
     es.normalize_dataframe("transactions",
                            "cards",
                            "card_id",
                            make_time_index=True)
     # assert time_type unchanged
     assert es.time_type == 'numeric'
-    # add wrong time type entity
+    # add wrong time type dataframe
     error_text = "accounts time index is Datetime type which differs from other entityset time indexes"
     with pytest.raises(TypeError, match=error_text):
         es.add_dataframe(accounts_df,
@@ -1677,13 +1677,13 @@ def test_use_time_index(index_df):
 
     error_text = re.escape("Cannot add 'time_index' tag directly for column transaction_time. To set a column as the time index, use DataFrame.ww.set_time_index() instead.")
     with pytest.raises(ValueError, match=error_text):
-        es.add_dataframe(dataframe_name="entity",
+        es.add_dataframe(dataframe_name="dataframe",
                          index="id",
                          logical_types=bad_ltypes,
                          semantic_tags=bad_semantic_tags,
                          dataframe=index_df)
 
-    es.add_dataframe(dataframe_name="entity",
+    es.add_dataframe(dataframe_name="dataframe",
                      index="id",
                      time_index="transaction_time",
                      logical_types=logical_types,

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -1123,12 +1123,12 @@ def test_set_time_type_on_init(transactions_df):
         cards_logical_types = None
         transactions_logical_types = None
 
-    entities = {
+    dataframes = {
         "cards": (cards_df, "id", None, cards_logical_types),
         "transactions": (transactions_df, "id", "transaction_time", transactions_logical_types)
     }
     relationships = [("cards", "id", "transactions", "card_id")]
-    es = EntitySet("fraud", entities, relationships)
+    es = EntitySet("fraud", dataframes, relationships)
     # assert time_type is set
     assert es.time_type == 'numeric'
 
@@ -1252,12 +1252,12 @@ def test_checks_time_type_setting_secondary_time_index(es):
         "transaction_date": [datetime(1989, 2, i) for i in range(1, 7)],
         "fraud": [True, False, False, False, True, True]
     })
-    entities = {
+    dataframes = {
         "cards": (cards_df, "id"),
         "transactions": (transactions_df, "id", "transaction_time")
     }
     relationships = [("cards", "id", "transactions", "card_id")]
-    card_es = EntitySet("fraud", entities, relationships)
+    card_es = EntitySet("fraud", dataframes, relationships)
     assert card_es.time_type == 'numeric'
     # add secondary index that is numeric time type
     new_2nd_ti = {'fraud_decision_time': ['fraud_decision_time', 'fraud']}

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -486,7 +486,7 @@ def test_extra_column_type(df):
                          logical_types=logical_types, dataframe=df)
 
 
-def test_add_parent_not_index_varible(es):
+def test_add_parent_not_index_column(es):
     error_text = "Parent column 'language' is not the index of dataframe régions"
     with pytest.raises(AttributeError, match=error_text):
         es.add_relationship(u'régions', 'language', 'customers', u'région_id')

--- a/featuretools/tests/entityset_tests/test_es_metadata.py
+++ b/featuretools/tests/entityset_tests/test_es_metadata.py
@@ -236,7 +236,7 @@ def test_raise_key_error_missing_dataframe(es):
         es_without_id["testing"]
 
 
-def test_add_parent_not_index_variable(es):
+def test_add_parent_not_index_column(es):
     error_text = "Parent column 'language' is not the index of dataframe régions"
     with pytest.raises(AttributeError, match=error_text):
         es.add_relationship(u'régions', 'language', 'customers', u'région_id')

--- a/featuretools/tests/entityset_tests/test_koalas_es.py
+++ b/featuretools/tests/entityset_tests/test_koalas_es.py
@@ -57,14 +57,14 @@ def test_create_entityset_with_mixed_dataframe_types(pd_es, ks_es):
               "Cannot add dataframe of type {} to an entityset with existing dataframes " \
               "of type {}"
 
-    # Test error is raised when trying to add Koalas dataframe to entitset with existing pandas entities
+    # Test error is raised when trying to add Koalas dataframe to entitset with existing pandas dataframes
     with pytest.raises(ValueError, match=err_msg.format(type(ks_df), type(pd_es.dataframes[0]))):
         pd_es.add_dataframe(
             dataframe_name="new_dataframe",
             dataframe=ks_df,
             index="id")
 
-    # Test error is raised when trying to add pandas dataframe to entitset with existing ks entities
+    # Test error is raised when trying to add pandas dataframe to entitset with existing ks dataframes
     with pytest.raises(ValueError, match=err_msg.format(type(df), type(ks_es.dataframes[0]))):
         ks_es.add_dataframe(
             dataframe_name="new_dataframe",

--- a/featuretools/tests/entityset_tests/test_ww_es.py
+++ b/featuretools/tests/entityset_tests/test_ww_es.py
@@ -463,7 +463,7 @@ def test_update_dataframe_errors(es):
 
 
 def test_update_dataframe_already_sorted(es):
-    # test already_sorted on entity without time index
+    # test already_sorted on dataframe without time index
     df = es["sessions"].copy()
     updated_id = to_pandas(df['id'])
     updated_id.iloc[1] = 2
@@ -487,7 +487,7 @@ def test_update_dataframe_already_sorted(es):
     sessions_df = to_pandas(es['sessions'])
     assert sessions_df["id"].iloc[1] == 2
 
-    # test already_sorted on entity with time index
+    # test already_sorted on dataframe with time index
     df = es["customers"].copy()
     updated_signup = to_pandas(df['signup_date'])
     updated_signup.iloc[0] = datetime(2011, 4, 11)

--- a/featuretools/tests/primitive_tests/test_dask_primitives.py
+++ b/featuretools/tests/primitive_tests/test_dask_primitives.py
@@ -22,7 +22,7 @@ def test_transform(pd_es, dask_es):
 
     assert pd_es == dask_es
 
-    # Run DFS using each entity as a target and confirm results match
+    # Run DFS using each dataframe as a target and confirm results match
     for df in pd_es.dataframes:
         features = ft.dfs(entityset=pd_es,
                           target_dataframe_name=df.ww.name,
@@ -60,7 +60,7 @@ def test_aggregation(pd_es, dask_es):
 
     assert pd_es == dask_es
 
-    # Run DFS using each entity as a target and confirm results match
+    # Run DFS using each dataframe as a target and confirm results match
     for df in pd_es.dataframes:
         fm, _ = ft.dfs(entityset=pd_es,
                        target_dataframe_name=df.ww.name,

--- a/featuretools/tests/primitive_tests/test_direct_features.py
+++ b/featuretools/tests/primitive_tests/test_direct_features.py
@@ -43,7 +43,7 @@ def test_direct_from_identity(es):
     assert v == expected
 
 
-def test_direct_from_variable(es):
+def test_direct_from_column(es):
     # should be same behavior as test_direct_from_identity
     device = Feature(es, 'sessions', 'device_type')
     d = DirectFeature(base_feature=device,

--- a/featuretools/tests/primitive_tests/test_feature_base.py
+++ b/featuretools/tests/primitive_tests/test_feature_base.py
@@ -106,11 +106,11 @@ def test_return_type_inference_numeric_time_index(int_es):
 
 
 def test_return_type_inference_id(es):
-    # direct features should keep Id variable type
+    # direct features should keep foreign key tag
     direct_id_feature = ft.Feature(es, "sessions", "customer_id", "log")
     assert "foreign_key" in direct_id_feature.column_schema.semantic_tags
 
-    # aggregations of Id variable types should get converted
+    # aggregations of foreign key types should get converted
     last_feat = ft.Feature(es, "log", "session_id", parent_dataframe_name="customers", primitive=Last)
     assert "foreign_key" not in last_feat.column_schema.semantic_tags
     assert isinstance(last_feat.column_schema.logical_type, Integer)

--- a/featuretools/tests/primitive_tests/test_feature_descriptions.py
+++ b/featuretools/tests/primitive_tests/test_feature_descriptions.py
@@ -194,11 +194,11 @@ def test_generic_description(es):
     assert describe_feature(custom_trans) == custom_trans_description
 
 
-def test_variable_description(es):
-    variable_description = 'the name of the device used for each session'
-    es['sessions'].ww.columns['device_name'].description = variable_description
+def test_column_description(es):
+    column_description = 'the name of the device used for each session'
+    es['sessions'].ww.columns['device_name'].description = column_description
     identity_feat = IdentityFeature(es, 'sessions', 'device_name')
-    assert describe_feature(identity_feat) == variable_description[0].upper() + variable_description[1:] + '.'
+    assert describe_feature(identity_feat) == column_description[0].upper() + column_description[1:] + '.'
 
 
 def test_metadata(es, tmpdir):

--- a/featuretools/tests/primitive_tests/test_feature_visualizer.py
+++ b/featuretools/tests/primitive_tests/test_feature_visualizer.py
@@ -57,11 +57,11 @@ def test_transform(es, trans_feat):
 
     feat_name = feat.get_name()
     prim_node = '0_{}_year'.format(feat_name)
-    entity_table = '\u2605 customers (target)'
+    dataframe_table = '\u2605 customers (target)'
     prim_edge = 'customers:cancel_date -> "{}"'.format(prim_node)
     feat_edge = '"{}" -> customers:"{}"'.format(prim_node, feat_name)
 
-    graph_components = [feat_name, entity_table, prim_node, prim_edge, feat_edge]
+    graph_components = [feat_name, dataframe_table, prim_node, prim_edge, feat_edge]
     for component in graph_components:
         assert component in graph
 
@@ -96,14 +96,14 @@ def test_groupby_transform(es):
     feat_name = feat.get_name()
     prim_node = "0_{}_cum_max".format(feat_name)
     groupby_node = '{}_groupby_customers--cohort'.format(feat_name)
-    entity_table = '\u2605 customers (target)'
+    dataframe_table = '\u2605 customers (target)'
 
     groupby_edge = 'customers:cohort -> "{}"'.format(groupby_node)
     groupby_input = 'customers:age -> "{}"'.format(groupby_node)
     prim_input = '"{}" -> "{}"'.format(groupby_node, prim_node)
     feat_edge = '"{}" -> customers:"{}"'.format(prim_node, feat_name)
 
-    graph_components = [feat_name, prim_node, groupby_node, entity_table,
+    graph_components = [feat_name, prim_node, groupby_node, dataframe_table,
                         groupby_edge, groupby_input, prim_input, feat_edge]
     for component in graph_components:
         assert component in graph
@@ -112,7 +112,7 @@ def test_groupby_transform(es):
     assert len(matches) == 1
     rows = re.findall(r"<TR.*?</TR>", matches[0], re.DOTALL)
     assert len(rows) == 4
-    assert entity_table in rows[0]
+    assert dataframe_table in rows[0]
     assert feat_name in rows[-1]
     assert ('age' in rows[1] and 'cohort' in rows[2]) or \
            ('age' in rows[2] and 'cohort' in rows[1])
@@ -145,22 +145,22 @@ def test_groupby_transform_direct_groupby(es):
     for component in graph_components:
         assert component in graph
 
-    entities = {'cohorts': [cohorts_table, 'cohort_name'],
+    dataframes = {'cohorts': [cohorts_table, 'cohort_name'],
                 'customers': [customers_table, 'cohort', 'age', groupby_name, feat_name]}
-    for entity in entities:
-        regex = r"{} \[label=<\n<TABLE.*?</TABLE>>".format(entity)
+    for dataframe in dataframes:
+        regex = r"{} \[label=<\n<TABLE.*?</TABLE>>".format(dataframe)
         matches = re.findall(regex, graph, re.DOTALL)
         assert len(matches) == 1
 
         rows = re.findall(r"<TR.*?</TR>", matches[0], re.DOTALL)
-        assert len(rows) == len(entities[entity])
+        assert len(rows) == len(dataframes[dataframe])
 
         for row in rows:
             matched = False
-            for i in entities[entity]:
+            for i in dataframes[dataframe]:
                 if i in row:
                     matched = True
-                    entities[entity].remove(i)
+                    dataframes[dataframe].remove(i)
                     break
             assert matched
 
@@ -187,21 +187,21 @@ def test_aggregation(es):
     for component in graph_components:
         assert component in graph
 
-    entities = {'log': [log_table, 'id', 'session_id'],
+    dataframes = {'log': [log_table, 'id', 'session_id'],
                 'sessions': [sessions_table, feat_name]}
-    for entity in entities:
-        regex = r"{} \[label=<\n<TABLE.*?</TABLE>>".format(entity)
+    for dataframe in dataframes:
+        regex = r"{} \[label=<\n<TABLE.*?</TABLE>>".format(dataframe)
         matches = re.findall(regex, graph, re.DOTALL)
         assert len(matches) == 1
 
         rows = re.findall(r"<TR.*?</TR>", matches[0], re.DOTALL)
-        assert len(rows) == len(entities[entity])
+        assert len(rows) == len(dataframes[dataframe])
         for row in rows:
             matched = False
-            for i in entities[entity]:
+            for i in dataframes[dataframe]:
                 if i in row:
                     matched = True
-                    entities[entity].remove(i)
+                    dataframes[dataframe].remove(i)
                     break
             assert matched
 
@@ -229,21 +229,21 @@ def test_multioutput(es):
     for component in graph_components:
         assert component in graph
 
-    entities = {'log': [log_table, 'zipcode', 'session_id'],
+    dataframes = {'log': [log_table, 'zipcode', 'session_id'],
                 'sessions': [sessions_table, feat_name]}
-    for entity in entities:
-        regex = r"{} \[label=<\n<TABLE.*?</TABLE>>".format(entity)
+    for dataframe in dataframes:
+        regex = r"{} \[label=<\n<TABLE.*?</TABLE>>".format(dataframe)
         matches = re.findall(regex, graph, re.DOTALL)
         assert len(matches) == 1
 
         rows = re.findall(r"<TR.*?</TR>", matches[0], re.DOTALL)
-        assert len(rows) == len(entities[entity])
+        assert len(rows) == len(dataframes[dataframe])
         for row in rows:
             matched = False
-            for i in entities[entity]:
+            for i in dataframes[dataframe]:
                 if i in row:
                     matched = True
-                    entities[entity].remove(i)
+                    dataframes[dataframe].remove(i)
                     break
             assert matched
 
@@ -275,23 +275,23 @@ def test_direct(es):
     for component in graph_components:
         assert component in graph
 
-    entities = {'customers': [customers_table, 'engagement_level'],
+    dataframes = {'customers': [customers_table, 'engagement_level'],
                 'sessions': [sessions_table, 'customer_id', d1_name],
                 'log': [log_table, 'session_id', d2_name]}
 
-    for entity in entities:
-        regex = r"{} \[label=<\n<TABLE.*?</TABLE>>".format(entity)
+    for dataframe in dataframes:
+        regex = r"{} \[label=<\n<TABLE.*?</TABLE>>".format(dataframe)
         matches = re.findall(regex, graph, re.DOTALL)
         assert len(matches) == 1
 
         rows = re.findall(r"<TR.*?</TR>", matches[0], re.DOTALL)
-        assert len(rows) == len(entities[entity])
+        assert len(rows) == len(dataframes[dataframe])
         for row in rows:
             matched = False
-            for i in entities[entity]:
+            for i in dataframes[dataframe]:
                 if i in row:
                     matched = True
-                    entities[entity].remove(i)
+                    dataframes[dataframe].remove(i)
                     break
             assert matched
 

--- a/featuretools/tests/primitive_tests/test_feature_visualizer.py
+++ b/featuretools/tests/primitive_tests/test_feature_visualizer.py
@@ -146,7 +146,7 @@ def test_groupby_transform_direct_groupby(es):
         assert component in graph
 
     dataframes = {'cohorts': [cohorts_table, 'cohort_name'],
-                'customers': [customers_table, 'cohort', 'age', groupby_name, feat_name]}
+                  'customers': [customers_table, 'cohort', 'age', groupby_name, feat_name]}
     for dataframe in dataframes:
         regex = r"{} \[label=<\n<TABLE.*?</TABLE>>".format(dataframe)
         matches = re.findall(regex, graph, re.DOTALL)
@@ -188,7 +188,7 @@ def test_aggregation(es):
         assert component in graph
 
     dataframes = {'log': [log_table, 'id', 'session_id'],
-                'sessions': [sessions_table, feat_name]}
+                  'sessions': [sessions_table, feat_name]}
     for dataframe in dataframes:
         regex = r"{} \[label=<\n<TABLE.*?</TABLE>>".format(dataframe)
         matches = re.findall(regex, graph, re.DOTALL)
@@ -230,7 +230,7 @@ def test_multioutput(es):
         assert component in graph
 
     dataframes = {'log': [log_table, 'zipcode', 'session_id'],
-                'sessions': [sessions_table, feat_name]}
+                  'sessions': [sessions_table, feat_name]}
     for dataframe in dataframes:
         regex = r"{} \[label=<\n<TABLE.*?</TABLE>>".format(dataframe)
         matches = re.findall(regex, graph, re.DOTALL)
@@ -276,8 +276,8 @@ def test_direct(es):
         assert component in graph
 
     dataframes = {'customers': [customers_table, 'engagement_level'],
-                'sessions': [sessions_table, 'customer_id', d1_name],
-                'log': [log_table, 'session_id', d2_name]}
+                  'sessions': [sessions_table, 'customer_id', d1_name],
+                  'log': [log_table, 'session_id', d2_name]}
 
     for dataframe in dataframes:
         regex = r"{} \[label=<\n<TABLE.*?</TABLE>>".format(dataframe)

--- a/featuretools/tests/primitive_tests/test_features_serializer.py
+++ b/featuretools/tests/primitive_tests/test_features_serializer.py
@@ -182,7 +182,7 @@ def test_feature_use_previous_pd_dateoffset(es):
 
 
 def _compare_feature_dicts(a_dict, b_dict):
-    # We can't compare entityset dictionaries because variable lists are not
+    # We can't compare entityset dictionaries because column lists are not
     # guaranteed to be in the same order.
     es_a = description_to_entityset(a_dict.pop('entityset'))
     es_b = description_to_entityset(b_dict.pop('entityset'))

--- a/featuretools/tests/primitive_tests/test_overrides.py
+++ b/featuretools/tests/primitive_tests/test_overrides.py
@@ -152,7 +152,7 @@ def test_scalar_overrides(es):
         assert o.unique_name() == f.unique_name()
 
 
-def test_override_cmp_from_variable(es):
+def test_override_cmp_from_columns(es):
     count_lo = ft.Feature(es, 'log', 'value') > 1
 
     to_test = [False, True, True]

--- a/featuretools/tests/selection/test_selection.py
+++ b/featuretools/tests/selection/test_selection.py
@@ -184,13 +184,13 @@ def test_multi_output_selection():
     df2 = pd.DataFrame({'first_id': [0, 1, 1, 3],
                         "all_nulls": [None, None, None, None], 'quarter': ['a', 'b', None, 'c']})
 
-    entities = {
+    dataframes = {
         "first": (df1, 'id'),
         "second": (df2, 'index'),
     }
 
     relationships = [("first", 'id', 'second', 'first_id')]
-    es = ft.EntitySet("data", entities, relationships=relationships)
+    es = ft.EntitySet("data", dataframes, relationships=relationships)
     es['second'].ww.set_types(logical_types={'all_nulls': 'categorical', 'quarter': 'categorical'})
 
     fm, features = ft.dfs(entityset=es,

--- a/featuretools/tests/synthesis/test_deep_feature_synthesis.py
+++ b/featuretools/tests/synthesis/test_deep_feature_synthesis.py
@@ -927,9 +927,9 @@ def test_makes_direct_features_through_multiple_relationships(games_es):
     teams = ['home', 'away']
     for forward in teams:
         for backward in teams:
-            for var in teams:
+            for col in teams:
                 f = 'teams[%s_team_id].MEAN(games[%s_team_id].%s_team_score)' \
-                    % (forward, backward, var)
+                    % (forward, backward, col)
                 assert feature_with_name(features, f)
 
 

--- a/featuretools/tests/variables/test_variables_utils.py
+++ b/featuretools/tests/variables/test_variables_utils.py
@@ -1,9 +1,7 @@
 from pytest import warns
 from woodwork import list_logical_types
 
-from featuretools.variable_types import (  # graph_variable_types,
-    list_variable_types
-)
+from featuretools.variable_types import list_variable_types
 
 
 def test_list_variables():
@@ -12,35 +10,3 @@ def test_list_variables():
         vtypes = list_variable_types()
     ltypes = list_logical_types()
     assert vtypes.equals(ltypes)
-
-
-# def test_returns_digraph_object():
-#     graph = graph_variable_types()
-#     assert isinstance(graph, graphviz.Digraph)
-
-
-# def test_saving_png_file(tmpdir):
-#     output_path = str(tmpdir.join("test1.png"))
-
-#     graph_variable_types(to_file=output_path)
-
-#     assert os.path.isfile(output_path)
-#     os.remove(output_path)
-
-
-# def test_missing_file_extension():
-#     output_path = "test1"
-
-#     with pytest.raises(ValueError) as excinfo:
-#         graph_variable_types(to_file=output_path)
-
-#     assert str(excinfo.value).startswith("Please use a file extension")
-
-
-# def test_invalid_format():
-#     output_path = "test1.xzy"
-
-#     with pytest.raises(ValueError) as excinfo:
-#         graph_variable_types(to_file=output_path)
-
-#     assert str(excinfo.value).startswith("Unknown format")

--- a/featuretools/utils/wrangle.py
+++ b/featuretools/utils/wrangle.py
@@ -77,8 +77,8 @@ def _check_time_against_column(time, time_column):
     '''
     Check to make sure that time is compatible with time_column,
     where time could be a timestamp, or a Timedelta, number, or None,
-    and time_column is a Variable. Compatibility means that
-    arithmetic can be performed between time and elements of time_columnj
+    and time_column is a Woodwork initialized column. Compatibility means that
+    arithmetic can be performed between time and elements of time_column
 
     If time is None, then we don't care if arithmetic can be performed
     (presumably it won't ever be performed)

--- a/featuretools/variable_types/utils.py
+++ b/featuretools/variable_types/utils.py
@@ -16,37 +16,3 @@ def list_variable_types():
     message = 'list_variable_types has been deprecated. Please use featuretools.list_logical_types instead.'
     warn(message=message, category=FutureWarning)
     return list_logical_types()
-
-
-# TODO: decide if this should be adapted for woodwork
-# def graph_variable_types(to_file=None):
-#     """
-#     Create a UML diagram-ish graph of all the Variables.
-
-#     Args:
-#         to_file (str, optional) : Path to where the plot should be saved.
-#             If set to None (as by default), the plot will not be saved.
-
-#     Returns:
-#         graphviz.Digraph : Graph object that can directly be displayed in
-#             Jupyter notebooks.
-#     """
-#     graphviz = check_graphviz()
-#     format_ = get_graphviz_format(graphviz=graphviz,
-#                                   to_file=to_file)
-
-#     # Initialize a new directed graph
-#     graph = graphviz.Digraph('variables', format=format_)
-#     graph.attr(rankdir="LR")
-#     graph.node(Variable.__name__, shape='Mdiamond')
-
-#     all_variables_types = list(find_variable_types().values())
-#     all_variables_types.sort(key=lambda x: x.__name__)
-
-#     for node in all_variables_types:
-#         for parent in node.__bases__:
-#             graph.edge(parent.__name__, node.__name__)
-
-#     if to_file:
-#         save_graph(graph, to_file, format_)
-#     return graph

--- a/featuretools/variable_types/utils.py
+++ b/featuretools/variable_types/utils.py
@@ -5,15 +5,13 @@ from woodwork import list_logical_types
 
 def list_variable_types():
     """
-    Retrieves all Variable types as a dataframe, with the column headers
-        of name, type_string, and description.
+    Retrieves all logical types as a dataframe
 
     Args:
         None
 
     Returns:
-        variable_types (pd.DataFrame): a DataFrame with column headers of
-            name, type_strings, and description.
+        logical_types (pd.DataFrame): a DataFrame with all logical types
     """
     message = 'list_variable_types has been deprecated. Please use featuretools.list_logical_types instead.'
     warn(message=message, category=FutureWarning)


### PR DESCRIPTION
### Remove more references to entity, entities, variable, var

Closes #1270 

Removes code references to entity, entities, variable and var and replaces them with dataframe, dataframes, column and col. 

Note, this update was only done on the python files. Documentation was not updated as those references should be fixed as part of other PRs.