### PR TITLE
Use make index to re-create index on new DataFrame in EntitySet.replace_dataframe

### DIFF
--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -307,7 +307,7 @@ EntitySet load and prepare data
     EntitySet.concat
     EntitySet.normalize_dataframe
     EntitySet.set_secondary_time_index
-    EntitySet.update_dataframe
+    EntitySet.replace_dataframe
 
 EntitySet serialization
 -------------------------------

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -45,7 +45,7 @@ Breaking Changes
 * ``EntitySet.add_relationship`` has been updated to accept dataframe and column name values or a
   ``Relationship`` object. Adding a relationship from a ``Relationship`` object now requires passing
   the relationship as a keyword argument.
-* ``Entity.update_data`` has been removed. To update the dataframe, call ``EntitySet.update_dataframe`` and use the ``dataframe_name`` paramter.
+* ``Entity.update_data`` has been removed. To update the dataframe, call ``EntitySet.replace_dataframe`` and use the ``dataframe_name`` paramter.
 * The data in an ``EntitySet`` is no longer stored in ``Entity`` objects. Instead, dataframes
   with Woodwork typing information are used. Accordingly, most language referring to “entities”
   will now refer to “dataframes”, references to “variables” will now refer to “columns”, and
@@ -134,11 +134,11 @@ this approach the ``relationship`` parameter name must be included.
 
 **Update DataFrame**
 
-To update a dataframe in an EntitySet, call ``EntitySet.update_dataframe`` and pass in the name of the dataframe to update along with the new data.
+To update a dataframe in an EntitySet, call ``EntitySet.replace_dataframe`` and pass in the name of the dataframe to update along with the new data.
 
 .. code-block:: python
 
-    >>> es.update_dataframe(dataframe_name='log', df=df)
+    >>> es.replace_dataframe(dataframe_name='log', df=df)
 
 **List Logical Types and Semantic Tags**
 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -7,7 +7,7 @@ Future Release
 ==============
     * Enhancements
         * Add support for creating EntitySets from Woodwork DataTables (:pr:`1277`)
-        * Add ``EntitySet.__deepcopy__` that retains Woodwork typing information (:pr:`1465`)
+        * Add ``EntitySet.__deepcopy__`` that retains Woodwork typing information (:pr:`1465`)
     * Fixes
     * Changes
         * Remove ``add_interesting_values`` from ``Entity`` (:pr:`1269`)
@@ -45,7 +45,7 @@ Breaking Changes
 * ``EntitySet.add_relationship`` has been updated to accept dataframe and column name values or a
   ``Relationship`` object. Adding a relationship from a ``Relationship`` object now requires passing
   the relationship as a keyword argument.
-* ``Entity.update_data`` has been removed. To update the dataframe, call ``EntitySet.replace_dataframe`` and use the ``dataframe_name`` paramter.
+* ``Entity.update_data`` has been removed. To update the dataframe, call ``EntitySet.replace_dataframe`` and use the ``dataframe_name`` parameter.
 * The data in an ``EntitySet`` is no longer stored in ``Entity`` objects. Instead, dataframes
   with Woodwork typing information are used. Accordingly, most language referring to “entities”
   will now refer to “dataframes”, references to “variables” will now refer to “columns”, and

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -132,9 +132,9 @@ this approach the ``relationship`` parameter name must be included.
 
     >>> es.add_relationship(relationship=new_relationship)
 
-**Update DataFrame**
+**Replace DataFrame**
 
-To update a dataframe in an EntitySet, call ``EntitySet.replace_dataframe`` and pass in the name of the dataframe to update along with the new data.
+To replace a dataframe in an EntitySet with a new dataframe, call ``EntitySet.replace_dataframe`` and pass in the name of the dataframe to replace along with the new data.
 
 .. code-block:: python
 

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -1422,7 +1422,8 @@ class EntitySet(object):
         '''Replace the internal dataframe of an EntitySet table, keeping Woodwork typing information the same.
         Optionally makes sure that data is sorted, that reference indexes to other dataframes are consistent,
         and that last_time_indexes are updated to reflect the new data. If an index was created for the original
-        dataframe, an index column of the same name will be added to the new dataframe.
+        dataframe and is not present on the new dataframe, an index column of the same name will be added to the
+        new dataframe.
         '''
         if not isinstance(df, type(self[dataframe_name])):
             raise TypeError('Incorrect DataFrame type used')

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -900,7 +900,7 @@ class EntitySet(object):
                     other_lti_col is not None):
                 has_last_time_index.append(df.ww.name)
 
-            combined_es.update_dataframe(
+            combined_es.replace_dataframe(
                 dataframe_name=df.ww.name,
                 df=combined_df,
                 recalculate_last_time_indexes=False,
@@ -1418,7 +1418,7 @@ class EntitySet(object):
 
         return df
 
-    def update_dataframe(self, dataframe_name, df, already_sorted=False, recalculate_last_time_indexes=True):
+    def replace_dataframe(self, dataframe_name, df, already_sorted=False, recalculate_last_time_indexes=True):
         '''Update the internal dataframe of an EntitySet table, keeping Woodwork typing information the same.
         Optionally makes sure that data is sorted, that reference indexes to other dataframes are consistent,
         and that last_time_indexes are updated to reflect the new data.

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -1435,13 +1435,11 @@ class EntitySet(object):
             self[dataframe_name].ww.pop(last_time_index_column)
             del self[dataframe_name].ww.metadata['last_time_index']
 
-        # If the original DataFrame had an index created via make_index, we may need to remake the index
+        # If the original DataFrame had an index created via make_index,
+        # we may need to remake the index if it's not in the new DataFrame
         created_index = self[dataframe_name].ww.metadata.get('created_index')
-        if created_index is not None:
-            if created_index not in df.columns:
-                df = _create_index(df, created_index)
-            else:
-                warnings.warn(f'New DataFrame, {dataframe_name}, already has the created index column, {created_index}. ')
+        if created_index is not None and created_index not in df.columns:
+            df = _create_index(df, created_index)
 
         old_column_names = list(self[dataframe_name].columns)
         if len(df.columns) != len(old_column_names):

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -1419,9 +1419,10 @@ class EntitySet(object):
         return df
 
     def replace_dataframe(self, dataframe_name, df, already_sorted=False, recalculate_last_time_indexes=True):
-        '''Update the internal dataframe of an EntitySet table, keeping Woodwork typing information the same.
+        '''Replace the internal dataframe of an EntitySet table, keeping Woodwork typing information the same.
         Optionally makes sure that data is sorted, that reference indexes to other dataframes are consistent,
-        and that last_time_indexes are updated to reflect the new data.
+        and that last_time_indexes are updated to reflect the new data. If an index was created for the original
+        dataframe, an index column of the same name will be added to the new dataframe.
         '''
         if not isinstance(df, type(self[dataframe_name])):
             raise TypeError('Incorrect DataFrame type used')

--- a/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
+++ b/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
@@ -659,7 +659,7 @@ def test_training_window_recent_time_index(pd_es):
     df.index = df.index.astype("category")
     df["id"] = df["id"].astype("category")
 
-    pd_es.update_dataframe(dataframe_name='customers', df=df, recalculate_last_time_indexes=False)
+    pd_es.replace_dataframe(dataframe_name='customers', df=df, recalculate_last_time_indexes=False)
     pd_es.add_last_time_indexes()
 
     property_feature = ft.Feature(ft.Feature(pd_es, 'log', 'id'), parent_dataframe_name='customers', primitive=Count)

--- a/featuretools/tests/computational_backend/test_dask_features.py
+++ b/featuretools/tests/computational_backend/test_dask_features.py
@@ -26,5 +26,5 @@ def test_tokenize_entityset(pd_es, int_es):
                            columns=['cohort', 'cohort_name', 'cohort_end'],
                            index=[2])
     more_cohorts = cohorts_df.append(new_row, ignore_index=True, sort=True)
-    dupe.update_dataframe(dataframe_name='cohorts', df=more_cohorts)
+    dupe.replace_dataframe(dataframe_name='cohorts', df=more_cohorts)
     assert tokenize(pd_es) == tokenize(dupe)

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -459,7 +459,7 @@ def test_make_index_any_location(df):
     assert es.dataframe_dict['test_dataframe'].ww.index == 'id1'
 
 
-def test_replace_dataframe_with_make_index(es):
+def test_replace_dataframe_and_create_index(es):
     df = pd.DataFrame({'ints': [3, 4, 5], 'category': ['a', 'b', 'a']})
     if es.dataframe_type == Library.DASK.value:
         df = dd.from_pandas(df, npartitions=2)
@@ -486,6 +486,22 @@ def test_replace_dataframe_with_make_index(es):
     assert es['test_df'].ww.index == 'id'
     assert all(expected_idx_col == to_pandas(es['test_df']['id']))
 
+
+def test_replace_dataframe_created_index_present(es):
+    df = pd.DataFrame({'ints': [3, 4, 5], 'category': ['a', 'b', 'a']})
+    if es.dataframe_type == Library.DASK.value:
+        df = dd.from_pandas(df, npartitions=2)
+    elif es.dataframe_type == Library.KOALAS.value:
+        df = ks.from_pandas(df)
+
+    logical_types = {'ints': Integer,
+                     'category': Categorical}
+    es.add_dataframe(dataframe=df,
+                     dataframe_name='test_df',
+                     index='id',
+                     make_index=True,
+                     logical_types=logical_types)
+
     # DataFrame that already has the index column
     has_idx_df = es['test_df'].replace({0: 100})
     if es.dataframe_type == Library.PANDAS.value:
@@ -495,9 +511,7 @@ def test_replace_dataframe_with_make_index(es):
 
     original_idx_col = [100, 1, 2]
 
-    warning = "New DataFrame, test_df, already has the created index column, id."
-    with pytest.warns(UserWarning, match=warning):
-        es.replace_dataframe('test_df', has_idx_df)
+    es.replace_dataframe('test_df', has_idx_df)
     assert es['test_df'].ww.index == 'id'
     assert all(original_idx_col == to_pandas(es['test_df']['id']))
 

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -459,7 +459,7 @@ def test_make_index_any_location(df):
     assert es.dataframe_dict['test_dataframe'].ww.index == 'id1'
 
 
-def test_update_dataframe_with_make_index(es):
+def test_replace_dataframe_with_make_index(es):
     df = pd.DataFrame({'ints': [3, 4, 5], 'category': ['a', 'b', 'a']})
     if es.dataframe_type == Library.DASK.value:
         df = dd.from_pandas(df, npartitions=2)
@@ -481,7 +481,7 @@ def test_update_dataframe_with_make_index(es):
     # DataFrame that needs the index column added
     assert 'id' not in needs_idx_df.columns
     expected_idx_col = [0, 1, 2]
-    es.update_dataframe('test_df', needs_idx_df)
+    es.replace_dataframe('test_df', needs_idx_df)
 
     assert es['test_df'].ww.index == 'id'
     assert all(expected_idx_col == to_pandas(es['test_df']['id']))
@@ -497,7 +497,7 @@ def test_update_dataframe_with_make_index(es):
 
     warning = "New DataFrame, test_df, already has the created index column, id."
     with pytest.warns(UserWarning, match=warning):
-        es.update_dataframe('test_df', has_idx_df)
+        es.replace_dataframe('test_df', has_idx_df)
     assert es['test_df'].ww.index == 'id'
     assert all(original_idx_col == to_pandas(es['test_df']['id']))
 
@@ -947,7 +947,7 @@ def test_concat_not_inplace(es):
     first_es = copy.deepcopy(es)
     for df in first_es.dataframes:
         new_df = df.loc[[], :]
-        first_es.update_dataframe(df.ww.name, new_df)
+        first_es.replace_dataframe(df.ww.name, new_df)
 
     second_es = copy.deepcopy(es)
 
@@ -966,7 +966,7 @@ def test_concat_inplace(es):
     second_es = copy.deepcopy(es)
     for df in first_es.dataframes:
         new_df = df.loc[[], :]
-        first_es.update_dataframe(df.ww.name, new_df)
+        first_es.replace_dataframe(df.ww.name, new_df)
 
     # set the data description
     es.metadata
@@ -987,7 +987,7 @@ def test_concat_with_lti(es):
             new_df = df.head(1)
         else:
             new_df = df.loc[[], :]
-        first_es.update_dataframe(df.ww.name, new_df)
+        first_es.replace_dataframe(df.ww.name, new_df)
 
     second_es = copy.deepcopy(es)
 
@@ -1030,9 +1030,9 @@ def test_concat_errors(es):
 def test_concat_sort_index_with_time_index(pd_es):
     # only pandas dataframes sort on the index and time index
     es1 = copy.deepcopy(pd_es)
-    es1.update_dataframe(dataframe_name='customers', df=pd_es['customers'].loc[[0, 1], :], already_sorted=True)
+    es1.replace_dataframe(dataframe_name='customers', df=pd_es['customers'].loc[[0, 1], :], already_sorted=True)
     es2 = copy.deepcopy(pd_es)
-    es2.update_dataframe(dataframe_name='customers', df=pd_es['customers'].loc[[2], :], already_sorted=True)
+    es2.replace_dataframe(dataframe_name='customers', df=pd_es['customers'].loc[[2], :], already_sorted=True)
 
     combined_es_order_1 = es1.concat(es2)
     combined_es_order_2 = es2.concat(es1)
@@ -1047,9 +1047,9 @@ def test_concat_sort_index_with_time_index(pd_es):
 def test_concat_sort_index_without_time_index(pd_es):
     # Sorting is only performed on DataFrames with time indices
     es1 = copy.deepcopy(pd_es)
-    es1.update_dataframe(dataframe_name='products', df=pd_es['products'].iloc[[0, 1, 2], :], already_sorted=True)
+    es1.replace_dataframe(dataframe_name='products', df=pd_es['products'].iloc[[0, 1, 2], :], already_sorted=True)
     es2 = copy.deepcopy(pd_es)
-    es2.update_dataframe(dataframe_name='products', df=pd_es['products'].iloc[[3, 4, 5], :], already_sorted=True)
+    es2.replace_dataframe(dataframe_name='products', df=pd_es['products'].iloc[[3, 4, 5], :], already_sorted=True)
 
     combined_es_order_1 = es1.concat(es2)
     combined_es_order_2 = es2.concat(es1)
@@ -1105,7 +1105,7 @@ def test_concat_with_make_index(es):
     for i, _es in enumerate([es_1, es_2]):
         for df_name, rows in emap.items():
             df = _es[df_name]
-            _es.update_dataframe(dataframe_name=df_name, df=df.loc[rows[i]])
+            _es.replace_dataframe(dataframe_name=df_name, df=df.loc[rows[i]])
 
     assert es.__eq__(es_1, deep=False)
     assert es.__eq__(es_2, deep=False)
@@ -1984,7 +1984,7 @@ def test_entityset_deep_equality(es):
     assert first_es.__eq__(second_es, deep=True)
 
     updated_df = first_es['customers'].loc[[2, 0], :]
-    first_es.update_dataframe('customers', updated_df)
+    first_es.replace_dataframe('customers', updated_df)
 
     assert first_es.__eq__(second_es, deep=False)
     # Uses woodwork equality which only looks at df content for pandas

--- a/featuretools/tests/entityset_tests/test_last_time_index.py
+++ b/featuretools/tests/entityset_tests/test_last_time_index.py
@@ -138,7 +138,7 @@ class TestLastTimeIndex(object):
         df = df[['value', 'value_time']].sort_values(by='value')
         df.index.name = None
 
-        values_es.update_dataframe(dataframe_name='values', df=df)
+        values_es.replace_dataframe(dataframe_name='values', df=df)
         values_es.add_last_time_indexes()
         # lti value should default to instance's time index
         true_values_lti[10] = pd.Timestamp("2011-04-10 11:10:02")
@@ -166,7 +166,7 @@ class TestLastTimeIndex(object):
         # test dataframe without time index and not all instance have children
 
         # add session instance with no associated log instances
-        es.update_dataframe(dataframe_name='sessions', df=extra_session_df)
+        es.replace_dataframe(dataframe_name='sessions', df=extra_session_df)
         es.add_last_time_indexes()
         # since sessions has no time index, default value is NaT
         true_sessions_lti[6] = pd.NaT
@@ -245,7 +245,7 @@ class TestLastTimeIndex(object):
             pytest.xfail('Cannot make index on a Koalas DataFrame')
 
         # add row to sessions so not all session instances are in log
-        es.update_dataframe(dataframe_name='sessions', df=extra_session_df)
+        es.replace_dataframe(dataframe_name='sessions', df=extra_session_df)
 
         # add row to wishlist df so new session instance in in wishlist_log
         row_values = {'session_id': 6,
@@ -287,7 +287,7 @@ class TestLastTimeIndex(object):
             pytest.xfail('Cannot make index on a Koalas DataFrame')
 
         # add row to sessions so not all session instances are in log
-        es.update_dataframe(dataframe_name='sessions', df=extra_session_df)
+        es.replace_dataframe(dataframe_name='sessions', df=extra_session_df)
 
         # add row to wishlist_log so extra session has child instance
         row_values = {'session_id': 6,
@@ -339,7 +339,7 @@ class TestLastTimeIndex(object):
                          'datetime': Datetime,
                          'product_id': Categorical}
         # add row to sessions to create session with no events
-        es.update_dataframe(dataframe_name='sessions', df=extra_session_df)
+        es.replace_dataframe(dataframe_name='sessions', df=extra_session_df)
 
         es.add_dataframe(dataframe_name="wishlist_log",
                          dataframe=wishlist_df,
@@ -378,7 +378,7 @@ class TestLastTimeIndex(object):
             df = dd.from_pandas(df, npartitions=2)
         if es.dataframe_type == Library.KOALAS.value:
             df = ks.from_pandas(df)
-        es.update_dataframe(dataframe_name='log', df=df)
+        es.replace_dataframe(dataframe_name='log', df=df)
         es.add_last_time_indexes()
         customers = es["customers"]
 

--- a/featuretools/tests/entityset_tests/test_ww_es.py
+++ b/featuretools/tests/entityset_tests/test_ww_es.py
@@ -264,7 +264,7 @@ def test_normalize_dataframe():
     assert 'foreign_key' in es['first_table'].ww.semantic_tags['age']
 
 
-def test_update_dataframe():
+def test_replace_dataframe():
     df = pd.DataFrame({
         'id': range(4),
         'full_name': ['Mr. John Doe', 'Doe, Mrs. Jane', 'James Brown', 'Ms. Paige Turner'],
@@ -281,7 +281,7 @@ def test_update_dataframe():
     original_schema = es['table'].ww.schema
 
     new_df = df.iloc[2:]
-    es.update_dataframe('table', new_df)
+    es.replace_dataframe('table', new_df)
 
     assert len(es['table']) == 2
     assert es['table'].ww.schema == original_schema
@@ -446,7 +446,7 @@ def test_extra_woodwork_params(es):
     assert 'new_tag' not in sessions_df.ww.semantic_tags
 
 
-def test_update_dataframe_errors(es):
+def test_replace_dataframe_errors(es):
     df = es['customers'].copy()
     if ks and isinstance(df, ks.DataFrame):
         df['new'] = [1, 2, 3]
@@ -455,14 +455,14 @@ def test_update_dataframe_errors(es):
 
     error_text = 'Updated dataframe is missing new cohort column'
     with pytest.raises(ValueError, match=error_text):
-        es.update_dataframe(dataframe_name='customers', df=df.drop(columns=['cohort']))
+        es.replace_dataframe(dataframe_name='customers', df=df.drop(columns=['cohort']))
 
     error_text = 'Updated dataframe contains 16 columns, expecting 15'
     with pytest.raises(ValueError, match=error_text):
-        es.update_dataframe(dataframe_name='customers', df=df)
+        es.replace_dataframe(dataframe_name='customers', df=df)
 
 
-def test_update_dataframe_already_sorted(es):
+def test_replace_dataframe_already_sorted(es):
     # test already_sorted on dataframe without time index
     df = es["sessions"].copy()
     updated_id = to_pandas(df['id'])
@@ -480,10 +480,10 @@ def test_update_dataframe_already_sorted(es):
     elif isinstance(df, dd.DataFrame):
         df["id"] = updated_id
 
-    es.update_dataframe(dataframe_name='sessions', df=df.copy(), already_sorted=False)
+    es.replace_dataframe(dataframe_name='sessions', df=df.copy(), already_sorted=False)
     sessions_df = to_pandas(es['sessions'])
     assert sessions_df["id"].iloc[1] == 2  # no sorting since time index not defined
-    es.update_dataframe(dataframe_name='sessions', df=df.copy(), already_sorted=True)
+    es.replace_dataframe(dataframe_name='sessions', df=df.copy(), already_sorted=True)
     sessions_df = to_pandas(es['sessions'])
     assert sessions_df["id"].iloc[1] == 2
 
@@ -500,12 +500,12 @@ def test_update_dataframe_already_sorted(es):
     else:
         df['signup_date'] = updated_signup
 
-    es.update_dataframe(dataframe_name='customers', df=df.copy(), already_sorted=True)
+    es.replace_dataframe(dataframe_name='customers', df=df.copy(), already_sorted=True)
     customers_df = to_pandas(es['customers'])
     assert customers_df["id"].iloc[0] == 2
 
     # only pandas allows for sorting:
-    es.update_dataframe(dataframe_name='customers', df=df.copy(), already_sorted=False)
+    es.replace_dataframe(dataframe_name='customers', df=df.copy(), already_sorted=False)
     updated_customers = to_pandas(es['customers'])
     if isinstance(df, pd.DataFrame):
         assert updated_customers["id"].iloc[0] == 0
@@ -513,7 +513,7 @@ def test_update_dataframe_already_sorted(es):
         assert updated_customers["id"].iloc[0] == 2
 
 
-def test_update_dataframe_invalid_schema(es):
+def test_replace_dataframe_invalid_schema(es):
     if not isinstance(es['customers'], pd.DataFrame):
         pytest.xfail('Invalid schema checks able to be caught by Woodwork only relevant for Pandas')
     df = es['customers'].copy()
@@ -521,14 +521,14 @@ def test_update_dataframe_invalid_schema(es):
 
     error_text = 'Woodwork typing information is not valid for this DataFrame: Index mismatch between DataFrame and typing information'
     with pytest.raises(ValueError, match=error_text):
-        es.update_dataframe(dataframe_name='customers', df=df)
+        es.replace_dataframe(dataframe_name='customers', df=df)
 
 
-def test_update_dataframe_different_dtypes(es):
+def test_replace_dataframe_different_dtypes(es):
     float_dtype_df = es['customers'].copy()
     float_dtype_df = float_dtype_df.astype({'age': 'float64'})
 
-    es.update_dataframe(dataframe_name='customers', df=float_dtype_df)
+    es.replace_dataframe(dataframe_name='customers', df=float_dtype_df)
 
     assert es['customers']['age'].dtype == 'int64'
     assert isinstance(es['customers'].ww.logical_types['age'], Integer)
@@ -544,7 +544,7 @@ def test_update_dataframe_different_dtypes(es):
         # Dask and Koalas do not error on invalid type conversion until compute
         error_msg = 'Error converting datatype for age from type object to type int64. Please confirm the underlying data is consistent with logical type Integer.'
         with pytest.raises(TypeConversionError, match=error_msg):
-            es.update_dataframe(dataframe_name='customers', df=incompatible_dtype_df)
+            es.replace_dataframe(dataframe_name='customers', df=incompatible_dtype_df)
 
 
 @pytest.fixture()
@@ -578,7 +578,7 @@ def latlong_df(request):
     return request.getfixturevalue(request.param)
 
 
-def test_update_dataframe_data_transformation(latlong_df):
+def test_replace_dataframe_data_transformation(latlong_df):
     initial_df = latlong_df.copy()
     initial_df.ww.init(name='latlongs', index='string_tuple',
                        logical_types={col_name: 'LatLong' for col_name in initial_df.columns})
@@ -593,7 +593,7 @@ def test_update_dataframe_data_transformation(latlong_df):
         series = df[col]
         assert series.iloc[0] == expected_val
 
-    es.update_dataframe('latlongs', latlong_df)
+    es.replace_dataframe('latlongs', latlong_df)
     df = to_pandas(es['latlongs'])
     expected_val = (3, 4)
     if ks and isinstance(es['latlongs'], ks.DataFrame):
@@ -603,7 +603,7 @@ def test_update_dataframe_data_transformation(latlong_df):
         assert series.iloc[-1] == expected_val
 
 
-def test_update_dataframe_column_order(es):
+def test_replace_dataframe_column_order(es):
     original_column_order = es['customers'].columns.copy()
 
     df = es['customers'].copy()
@@ -613,12 +613,12 @@ def test_update_dataframe_column_order(es):
     assert not df.columns.equals(original_column_order)
     assert set(df.columns) == set(original_column_order)
 
-    es.update_dataframe(dataframe_name='customers', df=df)
+    es.replace_dataframe(dataframe_name='customers', df=df)
 
     assert es['customers'].columns.equals(original_column_order)
 
 
-def test_update_dataframe_different_woodwork_initialized(es):
+def test_replace_dataframe_different_woodwork_initialized(es):
     df = es['customers'].copy()
     if ks and isinstance(df, ks.DataFrame):
         df['age'] = [1, 2, 3]
@@ -638,7 +638,7 @@ def test_update_dataframe_different_woodwork_initialized(es):
 
     warning = 'Woodwork typing information on new dataframe will be replaced with existing typing information from customers'
     with pytest.warns(UserWarning, match=warning):
-        es.update_dataframe('customers', df, already_sorted=True)
+        es.replace_dataframe('customers', df, already_sorted=True)
 
     if isinstance(df, dd.DataFrame):
         assert all(to_pandas(es['customers']['age']) == [1, 2, 3])
@@ -650,7 +650,7 @@ def test_update_dataframe_different_woodwork_initialized(es):
     assert es['customers']['cancel_date'].dtype == 'datetime64[ns]'
 
 
-def test_update_dataframe_different_dataframe_types():
+def test_replace_dataframe_different_dataframe_types():
     dask_es = EntitySet(id="dask_es")
 
     sessions = pd.DataFrame({"id": [0, 1, 2, 3],
@@ -676,10 +676,10 @@ def test_update_dataframe_different_dataframe_types():
                           logical_types=sessions_logical_types, semantic_tags=sessions_semantic_tags)
 
     with pytest.raises(TypeError, match='Incorrect DataFrame type used'):
-        dask_es.update_dataframe('sessions', sessions)
+        dask_es.replace_dataframe('sessions', sessions)
 
 
-def test_update_dataframe_and_min_last_time_index(es):
+def test_replace_dataframe_and_min_last_time_index(es):
     es.add_last_time_indexes(['products'])
 
     original_time_index = es['log']['datetime'].copy()
@@ -696,14 +696,14 @@ def test_update_dataframe_and_min_last_time_index(es):
     new_dataframe['datetime'] = new_time_index
     new_dataframe.pop(LTI_COLUMN_NAME)
 
-    es.update_dataframe('log', new_dataframe, recalculate_last_time_indexes=True)
+    es.replace_dataframe('log', new_dataframe, recalculate_last_time_indexes=True)
 
     # Koalas reorders indices during last time index, so we sort to confirm individual values are the same
     pd.testing.assert_series_equal(to_pandas(es['products'][LTI_COLUMN_NAME]).sort_index(), to_pandas(expected_last_time_index).sort_index())
     pd.testing.assert_series_equal(to_pandas(es['log'][LTI_COLUMN_NAME]).sort_index(), to_pandas(new_time_index).sort_index(), check_names=False)
 
 
-def test_update_dataframe_dont_recalculate_last_time_index_present(es):
+def test_replace_dataframe_dont_recalculate_last_time_index_present(es):
     es.add_last_time_indexes()
 
     original_time_index = es['customers']['signup_date'].copy()
@@ -717,11 +717,11 @@ def test_update_dataframe_dont_recalculate_last_time_index_present(es):
     new_dataframe = es['customers'].copy()
     new_dataframe['signup_date'] = new_time_index
 
-    es.update_dataframe('customers', new_dataframe, recalculate_last_time_indexes=False)
+    es.replace_dataframe('customers', new_dataframe, recalculate_last_time_indexes=False)
     pd.testing.assert_series_equal(to_pandas(es['customers'][LTI_COLUMN_NAME], sort_index=True), to_pandas(original_last_time_index, sort_index=True))
 
 
-def test_update_dataframe_dont_recalculate_last_time_index_not_present(es):
+def test_replace_dataframe_dont_recalculate_last_time_index_not_present(es):
     es.add_last_time_indexes()
     original_lti_name = es['customers'].ww.metadata.get('last_time_index')
     assert original_lti_name is not None
@@ -737,12 +737,12 @@ def test_update_dataframe_dont_recalculate_last_time_index_not_present(es):
     new_dataframe['signup_date'] = new_time_index
     new_dataframe.pop(LTI_COLUMN_NAME)
 
-    es.update_dataframe('customers', new_dataframe, recalculate_last_time_indexes=False)
+    es.replace_dataframe('customers', new_dataframe, recalculate_last_time_indexes=False)
     assert 'last_time_index' not in es['customers'].ww.metadata
     assert original_lti_name not in es['customers'].columns
 
 
-def test_update_dataframe_recalculate_last_time_index_not_present(es):
+def test_replace_dataframe_recalculate_last_time_index_not_present(es):
     es.add_last_time_indexes()
 
     original_time_index = es['log']['datetime'].copy()
@@ -756,12 +756,12 @@ def test_update_dataframe_recalculate_last_time_index_not_present(es):
     new_dataframe['datetime'] = new_time_index
     new_dataframe.pop(LTI_COLUMN_NAME)
 
-    es.update_dataframe('log', new_dataframe, recalculate_last_time_indexes=True)
+    es.replace_dataframe('log', new_dataframe, recalculate_last_time_indexes=True)
     pd.testing.assert_series_equal(to_pandas(es['log']['datetime']).sort_index(), to_pandas(new_time_index).sort_index(), check_names=False)
     pd.testing.assert_series_equal(to_pandas(es['log'][LTI_COLUMN_NAME]).sort_index(), to_pandas(new_time_index).sort_index(), check_names=False)
 
 
-def test_update_dataframe_recalculate_last_time_index_present(es):
+def test_replace_dataframe_recalculate_last_time_index_present(es):
     es.add_last_time_indexes()
 
     original_time_index = es['log']['datetime'].copy()
@@ -775,7 +775,7 @@ def test_update_dataframe_recalculate_last_time_index_present(es):
     new_dataframe['datetime'] = new_time_index
     assert LTI_COLUMN_NAME in new_dataframe.columns
 
-    es.update_dataframe('log', new_dataframe, recalculate_last_time_indexes=True)
+    es.replace_dataframe('log', new_dataframe, recalculate_last_time_indexes=True)
     pd.testing.assert_series_equal(to_pandas(es['log']['datetime']).sort_index(), to_pandas(new_time_index).sort_index(), check_names=False)
     pd.testing.assert_series_equal(to_pandas(es['log'][LTI_COLUMN_NAME]).sort_index(), to_pandas(new_time_index).sort_index(), check_names=False)
 

--- a/featuretools/tests/primitive_tests/test_transform_features.py
+++ b/featuretools/tests/primitive_tests/test_transform_features.py
@@ -655,7 +655,7 @@ def test_latlong_with_nan(pd_es):
     df['latlong'][1] = (10, np.nan)
     df['latlong'][2] = (np.nan, 4)
     df['latlong'][3] = (np.nan, np.nan)
-    pd_es.update_dataframe(dataframe_name='log', df=df)
+    pd_es.replace_dataframe(dataframe_name='log', df=df)
     log_latlong_feat = ft.Feature(pd_es, 'log', 'latlong')
     latitude = ft.Feature(log_latlong_feat, primitive=Latitude)
     longitude = ft.Feature(log_latlong_feat, primitive=Longitude)
@@ -708,7 +708,7 @@ def test_haversine_with_nan(pd_es):
     df = pd_es['log']
     df['latlong'][0] = np.nan
     df['latlong'][1] = (10, np.nan)
-    pd_es.update_dataframe(dataframe_name='log', df=df)
+    pd_es.replace_dataframe(dataframe_name='log', df=df)
     log_latlong_feat = ft.Feature(pd_es, 'log', 'latlong')
     log_latlong_feat2 = ft.Feature(pd_es, 'log', 'latlong2')
     haversine = ft.Feature([log_latlong_feat, log_latlong_feat2],
@@ -726,7 +726,7 @@ def test_haversine_with_nan(pd_es):
     # Check all `nan` values
     df = pd_es['log']
     df['latlong2'] = np.nan
-    pd_es.update_dataframe(dataframe_name='log', df=df)
+    pd_es.replace_dataframe(dataframe_name='log', df=df)
     log_latlong_feat = ft.Feature(pd_es, 'log', 'latlong')
     log_latlong_feat2 = ft.Feature(pd_es, 'log', 'latlong2')
     haversine = ft.Feature([log_latlong_feat, log_latlong_feat2],


### PR DESCRIPTION
This PR does two things:
1. renames `EntitySet.update_dataframe` to `EntitySet.replace_dataframe`
2. Accesses the `created_index` key in the DataFrame's Woodwork metadata to recreate the index column on the new DataFrame (if it's not present) at `replace_dataframe`

closes #1484 