### PR TITLE
Remove tsfresh, nlp_primitives, sklearn_transformer add-on library and CI test

### DIFF
--- a/.github/workflows/install_test.yml
+++ b/.github/workflows/install_test.yml
@@ -30,9 +30,6 @@ jobs:
           python -m pip install -e unpacked_sdist/[complete]
       - name: Test by importing packages
         run: |
-          python -c "import featuretools_tsfresh_primitives"
           python -c "import alteryx_open_src_update_checker"
-          python -c "import nlp_primitives"
-          python -c "import featuretools_sklearn_transformer"
         env:
           ALTERYX_OPEN_SRC_UPDATE_CHECKER: False

--- a/README.md
+++ b/README.md
@@ -46,12 +46,6 @@ python -m pip install featuretools[complete]
 python -m pip install featuretools[update_checker]
 ```
 
-**TSFresh Primitives** - Use 60+ primitives from [tsfresh](https://tsfresh.readthedocs.io/en/latest/) within Featuretools
-
-```
-python -m pip install featuretools[tsfresh]
-```
-
 ## Example
 Below is an example of using Deep Feature Synthesis (DFS) to perform automated feature engineering. In this example, we apply DFS to a multi-table dataset consisting of timestamped customer transactions.
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -12,6 +12,4 @@ nbconvert==6.0.6
 nbsphinx==0.8.5
 Sphinx==3.2.1
 pydata_sphinx_theme==0.4.0
-# nlp_primitives>=1.0.0 - Uncomment and update after new version is released
-git+https://github.com/alteryx/nlp_primitives.git@ft-1.0.0-dev
 -r koalas-requirements.txt

--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -184,29 +184,6 @@ Location Transform Primitives
    Longitude
    Haversine
 
-.. currentmodule:: nlp_primitives
-
-.. autosummary::
-   :nosignatures:
-
-Natural Language Processing Primitives
---------------------------------------
-Natural Language Processing primitives create features for textual data. For more information on how to use and install these primitives, see `here <https://github.com/FeatureLabs/nlp_primitives>`__.
-
-.. autosummary::
-    :toctree: generated/
-
-    DiversityScore
-    LSA
-    MeanCharactersPerWord
-    PartOfSpeechCount
-    PolarityScore
-    PunctuationCount
-    StopwordCount
-    TitleWordCount
-    UniversalSentenceEncoder
-    UpperCaseCount
-
 
 Feature methods
 ---------------

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -23,21 +23,6 @@ Update checker:
 
         python -m pip install "featuretools[update_checker]"
 
-TSFresh Primitives:
-    Use 60+ primitives from `tsfresh <https://tsfresh.readthedocs.io/en/latest/>`__ in Featuretools::
-
-        python -m pip install "featuretools[tsfresh]"
-
-NLP Primitives:
-    Use Natural Language Processing Primitives for data with text in Featuretools::
-
-        python -m pip install "featuretools[nlp_primitives]"
-
-Featuretools Sklearn Transformer:
-    Deep Feature Synthesis as a scikit-learn pipelines transformer::
-
-        python -m pip install "featuretools[sklearn_transformer]"
-
 .. _graphviz:
 
 Installing Graphviz

--- a/setup.py
+++ b/setup.py
@@ -7,10 +7,7 @@ with open(path.join(dirname, 'README.md')) as f:
     long_description = f.read()
 
 extras_require = {
-    'tsfresh': ['featuretools-tsfresh-primitives >= 0.1.0'],
     'update_checker': ['alteryx-open-src-update-checker >= 2.0.0'],
-    'nlp_primitives': ['nlp-primitives[complete] >= 1.0.0'],
-    'sklearn_transformer': ['featuretools-sklearn-transformer >= 0.1.1'],
     'koalas': open('koalas-requirements.txt').readlines(),
 }
 extras_require['complete'] = sorted(set(sum(extras_require.values(), [])))


### PR DESCRIPTION
- For now we will not support Featuretools 1.0.0 with tsfresh, nlp_primitives, sklearn_transformer (it will be added back in the future)
