### PR TITLE
Remove add on libraries from install docs, setup.py and CI tests

### DIFF
--- a/.github/workflows/install_test.yml
+++ b/.github/workflows/install_test.yml
@@ -30,11 +30,6 @@ jobs:
           python -m pip install -e unpacked_sdist/[complete]
       - name: Test by importing packages
         run: |
-          python -c "import featuretools_tsfresh_primitives"
           python -c "import alteryx_open_src_update_checker"
-          python -c "import categorical_encoding"
-          python -c "import nlp_primitives"
-          python -c "import autonormalize"
-          python -c "import featuretools_sklearn_transformer"
         env:
           ALTERYX_OPEN_SRC_UPDATE_CHECKER: False

--- a/README.md
+++ b/README.md
@@ -46,12 +46,6 @@ python -m pip install featuretools[complete]
 python -m pip install featuretools[update_checker]
 ```
 
-**TSFresh Primitives** - Use 60+ primitives from [tsfresh](https://tsfresh.readthedocs.io/en/latest/) within Featuretools
-
-```
-python -m pip install featuretools[tsfresh]
-```
-
 ## Example
 Below is an example of using Deep Feature Synthesis (DFS) to perform automated feature engineering. In this example, we apply DFS to a multi-table dataset consisting of timestamped customer transactions.
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -11,6 +11,4 @@ nbconvert==6.0.6
 nbsphinx==0.8.5
 Sphinx==3.2.1
 pydata_sphinx_theme==0.4.0
-nlp_primitives>=1.0.0
-autonormalize >= 1.0.1
 -r koalas-requirements.txt

--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -32,14 +32,6 @@ Wrappers
 ~~~~~~~~
 .. currentmodule:: featuretools
 
-Scikit-learn (BETA)
--------------------
-.. autosummary::
-    :toctree: generated/
-
-    wrappers.DFSTransformer
-
-
 
 .. DeepFeatureSynthesis
 
@@ -183,29 +175,6 @@ Location Transform Primitives
    Latitude
    Longitude
    Haversine
-
-.. currentmodule:: nlp_primitives
-
-.. autosummary::
-   :nosignatures:
-
-Natural Language Processing Primitives
---------------------------------------
-Natural Language Processing primitives create features for textual data. For more information on how to use and install these primitives, see `here <https://github.com/FeatureLabs/nlp_primitives>`__.
-
-.. autosummary::
-    :toctree: generated/
-
-    DiversityScore
-    LSA
-    MeanCharactersPerWord
-    PartOfSpeechCount
-    PolarityScore
-    PunctuationCount
-    StopwordCount
-    TitleWordCount
-    UniversalSentenceEncoder
-    UpperCaseCount
 
 
 Feature methods

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -23,31 +23,6 @@ Update checker:
 
         python -m pip install "featuretools[update_checker]"
 
-TSFresh Primitives:
-    Use 60+ primitives from `tsfresh <https://tsfresh.readthedocs.io/en/latest/>`__ in Featuretools::
-
-        python -m pip install "featuretools[tsfresh]"
-
-Categorical Encoding:
-    Encode categorical data for integration into Featuretools/machine learning workflows::
-
-        python -m pip install "featuretools[categorical_encoding]"
-
-NLP Primitives:
-    Use Natural Language Processing Primitives for data with text in Featuretools::
-
-        python -m pip install "featuretools[nlp_primitives]"
-
-AutoNormalize:
-    Automated creation of normalized ``EntitySet`` from denormalized data::
-
-        python -m pip install "featuretools[autonormalize]"
-
-Featuretools Sklearn Transformer:
-    Deep Feature Synthesis as a scikit-learn pipelines transformer::
-
-        python -m pip install "featuretools[sklearn_transformer]"
-
 .. _graphviz:
 
 Installing Graphviz

--- a/docs/source/resources/frequently_asked_questions.ipynb
+++ b/docs/source/resources/frequently_asked_questions.ipynb
@@ -830,51 +830,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Can I automatically normalize a single table?\n",
-    "\n",
-    "Yes, another open source library [AutoNormalize](https://github.com/FeatureLabs/autonormalize), also produced by Feature Labs, automates table normalization and integrates with Featuretools. To install run:\n",
-    "\n",
-    "```shell\n",
-    "python -m pip install featuretools[autonormalize]\n",
-    "```\n",
-    "\n",
-    "A normalized `EntitySet` will help Featuretools to generate more features. For example:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from featuretools.autonormalize import autonormalize as an\n",
-    "es = an.normalize_entity(es)\n",
-    "es.plot()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "As you can see, AutoNormalize creates a relational `EntitySet`. Below, we run dfs on the `EntitySet`, and you can see all the features created; take note of the aggregated features."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "feature_matrix, feature_defs = ft.dfs(entityset=es, \n",
-    "                                      target_entity=\"transaction_id\", \n",
-    "                                      trans_primitives=[])\n",
-    "feature_matrix.head()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "### How do I prevent label leakage with DFS?\n",
     "\n",
     "One concern you might have with using DFS is about label leakage. You want to make sure that labels in your data aren't used incorrectly to create features and the feature matrix.\n",
@@ -2067,7 +2022,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.7.9"
   },
   "mimetype": "text/x-python",
   "name": "python",

--- a/setup.py
+++ b/setup.py
@@ -7,12 +7,7 @@ with open(path.join(dirname, 'README.md')) as f:
     long_description = f.read()
 
 extras_require = {
-    'tsfresh': ['featuretools-tsfresh-primitives >= 0.1.0'],
     'update_checker': ['alteryx-open-src-update-checker >= 2.0.0'],
-    'categorical_encoding': ['categorical-encoding >= 0.2.0'],
-    'nlp_primitives': ['nlp-primitives[complete] >= 1.0.0'],
-    'autonormalize': ['autonormalize >= 1.0.0'],
-    'sklearn_transformer': ['featuretools-sklearn-transformer >= 0.1.1'],
     'koalas': open('koalas-requirements.txt').readlines(),
 }
 extras_require['complete'] = sorted(set(sum(extras_require.values(), [])))


### PR DESCRIPTION
In anticipation of Featuretools 1.0.0rc1 being released, removing the add-on libraries as they will be supported right away.