### PR TITLE
Update primitives loading to be more robust

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -8,13 +8,21 @@ Future Release
     * Fixes
     * Changes
         * Remove autonormalize, tsfresh, nlp_primitives, sklearn_transformer, caegorical_encoding as an add-on libraries (will be added back later) (:pr:`1644`)
+        * Emit a warning message when a ``featuretools_primitives`` entrypoint
+          throws an exception (:pr:`1662`)
+        * Throw a ``RuntimeError`` when two primitives with the same name are
+          encountered during ``featuretools_primitives`` entrypoint handling
+          (:pr:`1662`)
+        * Prevent the ``featuretools_primitives`` entrypoint loader from
+          loading non-class objects as well as the ``AggregationPrimitive`` and
+          ``TransformPrimitive`` base classes (:pr:`1662`)
     * Documentation Changes
     * Testing Changes
         * Update latest dependency checker with proper install command (:pr:`1652`)
         * Update isort dependency (:pr:`1654`)
 
     Thanks to the following people for contributing to this release:
-    :user:`gsheni`, :user:`rwedge`
+    :user:`davesque`, :user:`gsheni`, :user:`rwedge`
 
 
 v0.26.2 Aug 17, 2021

--- a/featuretools/primitives/__init__.py
+++ b/featuretools/primitives/__init__.py
@@ -1,19 +1,45 @@
-# flake8: noqa
-from .api import *
+import inspect
+import logging
 
 import pkg_resources
-# Load in a list of primitives registered by other libraries into Featuretools
+
+from .api import *  # noqa: F403
+
+# Load in a list of primitives registered by other libraries into Featuretools.
+#
 # Example entry_points definition for a library using this entry point:
+#
 #    entry_points={
 #        "featuretools_primitives": [
 #            other_library = other_library:LIST_OF_PRIMITIVES
 #        ]
 #    }
+#
+# where `LIST_OF_PRIMITIVES` is an iterable of primitive class objects defined
+# in module `other_library`.
+
 for entry_point in pkg_resources.iter_entry_points('featuretools_primitives'):
     try:
         loaded = entry_point.load()
-        for primitive in loaded:
-            if issubclass(primitive, (AggregationPrimitive, TransformPrimitive)):
-                globals()[primitive.__name__] = primitive
-    except Exception:
-        pass
+    except Exception as e:
+        logging.warning(
+            "entry point \"%s\" in package \"%s\" threw exception while loading: %s",
+            entry_point.name,
+            entry_point.dist.project_name,
+            repr(e),
+        )
+        continue
+
+    for primitive in loaded:
+        if primitive.__name__ in globals():
+            raise RuntimeError(
+                f"primitive with name \"{primitive.__name__}\" already exists"
+            )
+
+        if (
+            inspect.isclass(primitive) and
+            issubclass(primitive, (AggregationPrimitive, TransformPrimitive)) and  # noqa: F405
+            primitive is not AggregationPrimitive and  # noqa: F405
+            primitive is not TransformPrimitive  # noqa: F405
+        ):
+            globals()[primitive.__name__] = primitive

--- a/featuretools/primitives/__init__.py
+++ b/featuretools/primitives/__init__.py
@@ -18,7 +18,7 @@ from .api import *  # noqa: F403
 # where `LIST_OF_PRIMITIVES` is an iterable of primitive class objects defined
 # in module `other_library`.
 
-for entry_point in pkg_resources.iter_entry_points('featuretools_primitives'):
+for entry_point in pkg_resources.iter_entry_points('featuretools_primitives'):  # pragma: no cover
     try:
         loaded = entry_point.load()
     except Exception as e:


### PR DESCRIPTION
* Emit warning when primitives entry point throws error
* Prevent overwriting of names in primitive namespace
* Avoid loading non-class objects and the `AggregationPrimitive` and `TransformPrimitive` base classes