### PR TITLE
Add banner to all docs pages about upcoming 1.0 release

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,15 +2,17 @@
 
 Release Notes
 -------------
-.. Future Release
-  ==============
+Future Release
+==============
     * Enhancements
     * Fixes
     * Changes
     * Documentation Changes
+        * Add banner to docs about upcoming Featuretools 1.0 release (:pr:`1669`)
     * Testing Changes
 
-.. Thanks to the following people for contributing to this release:
+    Thanks to the following people for contributing to this release:
+    :user:`thehomebrewnerd`
 
 v0.27.0 Aug 31, 2021
 ====================

--- a/docs/source/templates/layout.html
+++ b/docs/source/templates/layout.html
@@ -22,6 +22,25 @@
 
 {% endblock %}
 
+{% block docs_body %}
+<section>
+<div class="admonition warning">
+  <p class="admonition-title"> NOTICE</p>
+  <p>
+    The upcoming release of Featuretools 1.0.0 will contain several breaking changes. Users are encouraged to test this version prior
+    to release by installing the release candidate: <code>1.0.0rc1</code>. For details on migrating to the new version, refer
+    to <a href="">Transitioning to Featuretools Version 1.0</a>.
+  </p>
+  <p>
+    Please report any issues by submitting an issue in the <a href="https://github.com/alteryx/featuretools">Featuretools GitHub repo</a>
+    or by messaging in <a href="https://join.slack.com/t/featuretools/shared_invite/enQtNTEwODEzOTEwMjg4LTQ1MjZlOWFmZDk2YzAwMjEzNTkwZTZkN2NmOGFjOGI4YzE5OGMyMGM5NGIxNTE4NjkzYWI3OWEwZjkyZGExYmQ">Alteryx Open Source Slack</a>.
+  </p>
+</div>
+<br>
+</section>
+{{ super() }}
+{% endblock %}
+
 {%- block footer %}
 
 <footer class="footer">

--- a/docs/source/templates/layout.html
+++ b/docs/source/templates/layout.html
@@ -35,7 +35,7 @@
   </p>
   <p>
     For details on migrating to the new version, refer to 
-    <a href="https://feature-labs-inc-featuretools--1664.com.readthedocs.build/en/1664/resources/transition_to_ft_v1.0.html">Transitioning to Featuretools Version 1.0</a>.
+    <a href="https://featuretools.alteryx.com/en/woodwork-integration/resources/transition_to_ft_v1.0.html">Transitioning to Featuretools Version 1.0</a>.
     Please report any issues by submitting an issue in the <a href="https://github.com/alteryx/featuretools">Featuretools GitHub repo</a>
     or by messaging in <a href="https://join.slack.com/t/featuretools/shared_invite/enQtNTEwODEzOTEwMjg4LTQ1MjZlOWFmZDk2YzAwMjEzNTkwZTZkN2NmOGFjOGI4YzE5OGMyMGM5NGIxNTE4NjkzYWI3OWEwZjkyZGExYmQ">Alteryx Open Source Slack</a>.
   </p>

--- a/docs/source/templates/layout.html
+++ b/docs/source/templates/layout.html
@@ -27,7 +27,7 @@
 <div class="admonition warning">
   <p class="admonition-title"> NOTICE</p>
   <p>
-    The upcoming release of Featuretools 1.0.0 will contain several breaking changes. Users are encouraged to test this version prior
+    The upcoming release of Featuretools 1.0.0 contains several breaking changes. Users are encouraged to test this version prior
     to release by installing from GitHub:
   </p>
   <p>
@@ -36,7 +36,7 @@
   <p>
     For details on migrating to the new version, refer to 
     <a href="https://featuretools.alteryx.com/en/woodwork-integration/resources/transition_to_ft_v1.0.html">Transitioning to Featuretools Version 1.0</a>.
-    Please report any issues by submitting an issue in the <a href="https://github.com/alteryx/featuretools">Featuretools GitHub repo</a>
+    Please report any issues in the <a href="https://github.com/alteryx/featuretools">Featuretools GitHub repo</a>
     or by messaging in <a href="https://join.slack.com/t/featuretools/shared_invite/enQtNTEwODEzOTEwMjg4LTQ1MjZlOWFmZDk2YzAwMjEzNTkwZTZkN2NmOGFjOGI4YzE5OGMyMGM5NGIxNTE4NjkzYWI3OWEwZjkyZGExYmQ">Alteryx Open Source Slack</a>.
   </p>
 </div>

--- a/docs/source/templates/layout.html
+++ b/docs/source/templates/layout.html
@@ -28,7 +28,8 @@
   <p class="admonition-title"> NOTICE</p>
   <p>
     The upcoming release of Featuretools 1.0.0 will contain several breaking changes. Users are encouraged to test this version prior
-    to release by installing the release candidate: <code>1.0.0rc1</code>. For details on migrating to the new version, refer
+    to release by installing the release candidate: <code>pip install https://github.com/alteryx/featuretools/archive/woodwork-integration.zip
+</code>. For details on migrating to the new version, refer
     to <a href="">Transitioning to Featuretools Version 1.0</a>.
   </p>
   <p>

--- a/docs/source/templates/layout.html
+++ b/docs/source/templates/layout.html
@@ -28,11 +28,14 @@
   <p class="admonition-title"> NOTICE</p>
   <p>
     The upcoming release of Featuretools 1.0.0 will contain several breaking changes. Users are encouraged to test this version prior
-    to release by installing the release candidate: <code>pip install https://github.com/alteryx/featuretools/archive/woodwork-integration.zip
-</code>. For details on migrating to the new version, refer
-    to <a href="">Transitioning to Featuretools Version 1.0</a>.
+    to release by installing from GitHub:
   </p>
   <p>
+    <code>pip install https://github.com/alteryx/featuretools/archive/woodwork-integration.zip</code>
+  </p>
+  <p>
+    For details on migrating to the new version, refer to 
+    <a href="https://feature-labs-inc-featuretools--1664.com.readthedocs.build/en/1664/resources/transition_to_ft_v1.0.html">Transitioning to Featuretools Version 1.0</a>.
     Please report any issues by submitting an issue in the <a href="https://github.com/alteryx/featuretools">Featuretools GitHub repo</a>
     or by messaging in <a href="https://join.slack.com/t/featuretools/shared_invite/enQtNTEwODEzOTEwMjg4LTQ1MjZlOWFmZDk2YzAwMjEzNTkwZTZkN2NmOGFjOGI4YzE5OGMyMGM5NGIxNTE4NjkzYWI3OWEwZjkyZGExYmQ">Alteryx Open Source Slack</a>.
   </p>


### PR DESCRIPTION
### Add banner to all docs pages about upcoming 1.0 release

- Adds a banner to all pages in the docs informing users about the upcoming 1.0 release.
- Fixes #1659 
