### PR TITLE
Fix foreign_key tag bug

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -14,6 +14,7 @@ Future Release
         * Fix ``DFSTransformer`` Documentation for Featuretools 1.0 (:pr:`1605`)
         * Fix ``calculate_feature_matrix`` time type check and ``encode_features`` for synthesis tests (:pr:`1580`)
         * Revert reordering of categories in ``Equal`` and ``NotEqual`` primitives (:pr:`1640`)
+        * Fix bug in ``EntitySet.add_relationship`` that caused ``foreign_key`` tag to be lost (:pr:`1675`)
     * Changes
         * Remove ``add_interesting_values`` from ``Entity`` (:pr:`1269`)
         * Move ``set_secondary_time_index`` method from ``Entity`` to ``EntitySet`` (:pr:`1280`)

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -205,6 +205,14 @@ You can list all the available semantic tags by calling ``featuretools.list_sema
 
     >>> ft.list_semantic_tags()
 
+v0.27.1 Sep 2, 2021
+===================
+    * Documentation Changes
+        * Add banner to docs about upcoming Featuretools 1.0 release (:pr:`1669`)
+
+    Thanks to the following people for contributing to this release:
+    :user:`thehomebrewnerd`
+
 v0.27.0 Aug 31, 2021
 ====================
     * Changes

--- a/docs/source/templates/layout.html
+++ b/docs/source/templates/layout.html
@@ -22,6 +22,29 @@
 
 {% endblock %}
 
+{% block docs_body %}
+<section>
+<div class="admonition warning">
+  <p class="admonition-title"> NOTICE</p>
+  <p>
+    The upcoming release of Featuretools 1.0.0 contains several breaking changes. Users are encouraged to test this version prior
+    to release by installing from GitHub:
+  </p>
+  <p>
+    <code>pip install https://github.com/alteryx/featuretools/archive/woodwork-integration.zip</code>
+  </p>
+  <p>
+    For details on migrating to the new version, refer to 
+    <a href="https://featuretools.alteryx.com/en/woodwork-integration/resources/transition_to_ft_v1.0.html">Transitioning to Featuretools Version 1.0</a>.
+    Please report any issues in the <a href="https://github.com/alteryx/featuretools">Featuretools GitHub repo</a>
+    or by messaging in <a href="https://join.slack.com/t/featuretools/shared_invite/enQtNTEwODEzOTEwMjg4LTQ1MjZlOWFmZDk2YzAwMjEzNTkwZTZkN2NmOGFjOGI4YzE5OGMyMGM5NGIxNTE4NjkzYWI3OWEwZjkyZGExYmQ">Alteryx Open Source Slack</a>.
+  </p>
+</div>
+<br>
+</section>
+{{ super() }}
+{% endblock %}
+
 {%- block footer %}
 
 <footer class="footer">

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -339,8 +339,6 @@ class EntitySet(object):
             raise ValueError(msg.format(child_column, child_df.ww.name))
         parent_df = relationship.parent_dataframe
         parent_column = relationship._parent_column_name
-        if 'foreign_key' not in child_df.ww.semantic_tags[child_column]:
-            child_df.ww.add_semantic_tags({child_column: 'foreign_key'})
 
         if parent_df.ww.index != parent_column:
             parent_df.ww.set_index(parent_column)
@@ -365,6 +363,9 @@ class EntitySet(object):
                           f'parent column {parent_column} logical type {parent_ltype}. {difference_msg}'
                           'Changing child logical type to match parent.')
             child_df.ww.set_types(logical_types={child_column: parent_ltype})
+
+        if 'foreign_key' not in child_df.ww.semantic_tags[child_column]:
+            child_df.ww.add_semantic_tags({child_column: 'foreign_key'})
 
         self.relationships.append(relationship)
         self.reset_data_description()

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -206,6 +206,7 @@ def test_add_relationship_different_logical_types_same_dtype(es):
         es.add_relationship(u'products', 'id', 'log2', 'product_id')
     assert isinstance(es['log2'].ww.logical_types['product_id'], Categorical)
     assert isinstance(es['products'].ww.logical_types['id'], Categorical)
+    assert 'foreign_key' in es['log2'].ww.semantic_tags['product_id']
 
 
 def test_add_relationship_different_compatible_dtypes(es):


### PR DESCRIPTION
### Fix foreign_key tag bug

Closes #1674 

Updates `EntitySet.add_relationship` to make sure `foreign_key` tags are retained when changing child column logical type. 