### PR TITLE
Remove old categorical code

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,15 +3,17 @@
 Release Notes
 -------------
 
-.. Future Release
-  ==============
+Future Release
+==============
     * Enhancements
     * Fixes
     * Changes
+        * Removes outdated workaround code related to a since-resovled pandas issue (:pr:`1677`)
     * Documentation Changes
     * Testing Changes
 
-.. Thanks to the following people for contributing to this release:
+    Thanks to the following people for contributing to this release:
+    :user:`thehomebrewnerd`
 
 
 v0.27.1 Sep 2, 2021

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -8,7 +8,7 @@ Future Release
     * Enhancements
     * Fixes
     * Changes
-        * Removes outdated workaround code related to a since-resovled pandas issue (:pr:`1677`)
+        * Removes outdated workaround code related to a since-resolved pandas issue (:pr:`1677`)
     * Documentation Changes
     * Testing Changes
 

--- a/featuretools/computational_backends/feature_set_calculator.py
+++ b/featuretools/computational_backends/feature_set_calculator.py
@@ -4,7 +4,6 @@ from functools import partial
 import dask.dataframe as dd
 import numpy as np
 import pandas as pd
-import pandas.api.types as pdtypes
 
 from featuretools import variable_types
 from featuretools.entityset.relationship import RelationshipPath
@@ -710,12 +709,6 @@ class FeatureSetCalculator(object):
                 # rename columns to the correct feature names
                 to_merge.columns = [agg_rename["-".join(x)] for x in to_merge.columns]
                 to_merge = to_merge[list(agg_rename.values())]
-
-                # workaround for pandas bug where categories are in the wrong order
-                # see: https://github.com/pandas-dev/pandas/issues/22501
-                if pdtypes.is_categorical_dtype(frame.index):
-                    categories = pdtypes.CategoricalDtype(categories=frame.index.categories)
-                    to_merge.index = to_merge.index.astype(object).astype(categories)
 
                 if is_instance(frame, (dd, ks), 'DataFrame'):
                     frame = frame.merge(to_merge, left_on=parent_merge_var, right_index=True, how='left')

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -6,7 +6,6 @@ from collections import defaultdict
 import dask.dataframe as dd
 import numpy as np
 import pandas as pd
-import pandas.api.types as pdtypes
 from pandas.api.types import is_dtype_equal, is_numeric_dtype
 
 import featuretools.variable_types.variable as vtypes
@@ -1086,13 +1085,6 @@ class EntitySet(object):
 
             if isinstance(entity.df, pd.DataFrame):
                 df = df.set_index(entity.index, drop=False)
-
-            # ensure filtered df has same categories as original
-            # workaround for issue below
-            # github.com/pandas-dev/pandas/issues/22501#issuecomment-415982538
-            if pdtypes.is_categorical_dtype(entity.df[variable_id]):
-                categories = pd.api.types.CategoricalDtype(categories=entity.df[variable_id].cat.categories)
-                df[variable_id] = df[variable_id].astype(categories)
 
         df = self._handle_time(entity_id=entity_id,
                                df=df,


### PR DESCRIPTION
### Remove old categorical code

Removes old code related to categorical columns. The code was implemented as a workaround for a pandas issue which has since been closed.