### PR TITLE
Remove old categorical code - woodwork-integration branch update

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -53,6 +53,7 @@ Future Release
         * Update ``nlp-primitives`` requirement for Featuretools 1.0 (:pr:`1609`)
         * Remove remaining references to ``Entity`` and ``Variable`` in code (:pr:`1612`)
         * Update Woodwork to version 0.7.1 with changed initialization (:pr:`1648`)
+        * Removes outdated workaround code related to a since-resolved pandas issue (:pr:`1678`)
     * Documentation Changes
         * Add a Woodwork Typing in Featuretools guide (:pr:`1589`)
         * Add a resource guide for transitioning to Featuretools 1.0 (:pr:`1627`)

--- a/featuretools/computational_backends/feature_set_calculator.py
+++ b/featuretools/computational_backends/feature_set_calculator.py
@@ -4,7 +4,6 @@ from functools import partial
 import dask.dataframe as dd
 import numpy as np
 import pandas as pd
-import pandas.api.types as pdtypes
 
 from featuretools.entityset.relationship import RelationshipPath
 from featuretools.exceptions import UnknownFeature
@@ -710,12 +709,6 @@ class FeatureSetCalculator(object):
                 # rename columns to the correct feature names
                 to_merge.columns = [agg_rename["-".join(x)] for x in to_merge.columns]
                 to_merge = to_merge[list(agg_rename.values())]
-
-                # workaround for pandas bug where categories are in the wrong order
-                # see: https://github.com/pandas-dev/pandas/issues/22501
-                if pdtypes.is_categorical_dtype(frame.index):
-                    categories = pdtypes.CategoricalDtype(categories=frame.index.categories)
-                    to_merge.index = to_merge.index.astype(object).astype(categories)
 
                 if is_instance(frame, (dd, ks), 'DataFrame'):
                     frame = frame.merge(to_merge, left_on=parent_merge_col, right_index=True, how='left')

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -1390,14 +1390,6 @@ class EntitySet(object):
             if isinstance(dataframe, pd.DataFrame):
                 df = df.set_index(dataframe.ww.index, drop=False)
 
-            # ensure filtered df has same categories as original
-            # workaround for issue below
-            # github.com/pandas-dev/pandas/issues/22501#issuecomment-415982538
-            # Note: Woodwork stores categorical columns with a `string` dtype for Koalas
-            if dataframe.ww.columns[column_name].is_categorical and not is_instance(df, ks, 'DataFrame'):
-                categories = pd.api.types.CategoricalDtype(categories=dataframe[column_name].cat.categories)
-                df[column_name] = df[column_name].astype(categories)
-
         df = self._handle_time(dataframe_name=dataframe_name,
                                df=df,
                                time_last=time_last,


### PR DESCRIPTION
### Remove old categorical code - woodwork-integration branch update

Removes old code related to categorical columns. The code was implemented as a workaround for a pandas issue which has since been closed.