### PR TITLE
Encode features - remove typecasting loop now handled by ww

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -55,6 +55,7 @@ Release Notes
         * Update Woodwork to version 0.7.1 with changed initialization (:pr:`1648`)
         * Remove unused ``_dataframes_equal`` and ``camel_to_snake`` functions (:pr:`1683`)
         * Update Woodwork to version 0.8.0 for improved performance (:pr:`1689`)
+        * Remove redundant typecasting in ``encode_features`` (:pr:`1694`)
     * Documentation Changes
         * Add a Woodwork Typing in Featuretools guide (:pr:`1589`)
         * Add a resource guide for transitioning to Featuretools 1.0 (:pr:`1627`)

--- a/featuretools/synthesis/encode_features.py
+++ b/featuretools/synthesis/encode_features.py
@@ -169,12 +169,6 @@ def encode_features(feature_matrix, features, top_n=DEFAULT_TOP_N, include_unkno
                                       total=len(new_X.columns),
                                       desc="Encoding pass 2",
                                       unit="feature")
-    for c in iterator:
-        if c in encoded_columns:
-            try:
-                new_X[c] = pd.to_numeric(new_X[c], errors='raise')
-            except (TypeError, ValueError):
-                pass
 
     entityset = new_feature_list[0].entityset
     ww_init_kwargs = get_ww_types_from_features(new_feature_list, entityset)


### PR DESCRIPTION
Featuretools had a loop in `encode_features` that tried to cast all encoded columns to a numeric type.  Now that woodwork is being initialized on the encoded feature matrix, woodwork should do this anyway when ensuring the dtypes match the schema