### PR TITLE
Encode Features - prefer runtime over space if not inplace

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -57,6 +57,7 @@ Release Notes
         * Remove unused ``_dataframes_equal`` and ``camel_to_snake`` functions (:pr:`1683`)
         * Update Woodwork to version 0.8.0 for improved performance (:pr:`1689`)
         * Remove redundant typecasting in ``encode_features`` (:pr:`1694`)
+        * Speed up ``encode_features`` if not inplace, some space cost (:pr:`1699`)
     * Documentation Changes
         * Add a Woodwork Typing in Featuretools guide (:pr:`1589`)
         * Add a resource guide for transitioning to Featuretools 1.0 (:pr:`1627`)

--- a/featuretools/synthesis/encode_features.py
+++ b/featuretools/synthesis/encode_features.py
@@ -104,6 +104,7 @@ def encode_features(feature_matrix, features, top_n=DEFAULT_TOP_N, include_unkno
     new_feature_list = []
     kept_columns = []
     encoded_columns = []
+    columns_info = feature_matrix.ww.columns
 
     for f in iterator:
         # TODO: features with multiple columns are not encoded by this method,
@@ -175,10 +176,9 @@ def encode_features(feature_matrix, features, top_n=DEFAULT_TOP_N, include_unkno
 
     # Grab ww metadata from feature matrix since it may be more exact
     for column in kept_columns:
-        column_info = feature_matrix.ww.columns[column]
-        ww_init_kwargs["logical_types"][column] = column_info.logical_type
-        ww_init_kwargs["semantic_tags"][column] = column_info.semantic_tags
-        ww_init_kwargs["column_origins"][column] = column_info.origin
+        ww_init_kwargs["logical_types"][column] = columns_info[column].logical_type
+        ww_init_kwargs["semantic_tags"][column] = columns_info[column].semantic_tags
+        ww_init_kwargs["column_origins"][column] = columns_info[column].origin
 
     X.ww.init(**ww_init_kwargs)
     return X, new_feature_list


### PR DESCRIPTION
* Remove tqdm progress bar for step that was removed previously
* Speed up adding encoded columns to the encoded matrix by adding them all at once if `inplace=False` 
* Skip dropping the original columns if `inplace=False`, omit them from the concat instead