### PR TITLE
Bump Woodwork min version to 0.8.1

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -57,6 +57,7 @@ Release Notes
         * Remove unused ``_dataframes_equal`` and ``camel_to_snake`` functions (:pr:`1683`)
         * Update Woodwork to version 0.8.0 for improved performance (:pr:`1689`)
         * Remove redundant typecasting in ``encode_features`` (:pr:`1694`)
+        * Update Woodwork to version 0.8.1 for improved performance (:pr:`1702`)
     * Documentation Changes
         * Add a Woodwork Typing in Featuretools guide (:pr:`1589`)
         * Add a resource guide for transitioning to Featuretools 1.0 (:pr:`1627`)

--- a/featuretools/tests/requirement_files/latest_requirements.txt
+++ b/featuretools/tests/requirement_files/latest_requirements.txt
@@ -7,4 +7,4 @@ pandas==1.3.2
 psutil==5.8.0
 scipy==1.7.1
 tqdm==4.62.2
-woodwork==0.8.0
+woodwork==0.8.1

--- a/featuretools/tests/requirement_files/minimum_core_requirements.txt
+++ b/featuretools/tests/requirement_files/minimum_core_requirements.txt
@@ -8,4 +8,4 @@ distributed==2021.2.0
 dask[dataframe]==2021.2.0
 psutil==5.6.6
 click==7.0.0
-woodwork==0.8.0
+woodwork==0.8.1

--- a/featuretools/tests/requirement_files/minimum_koalas_requirements.txt
+++ b/featuretools/tests/requirement_files/minimum_koalas_requirements.txt
@@ -10,4 +10,4 @@ distributed==2021.2.0
 dask[dataframe]==2021.2.0
 psutil==5.6.6
 click==7.0.0
-woodwork==0.8.0
+woodwork==0.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ distributed>=2021.2.0
 dask[dataframe]>=2021.2.0
 psutil>=5.6.6
 click>=7.0.0
-woodwork>=0.8.0
+woodwork>=0.8.1


### PR DESCRIPTION
### Bump Woodwork min version to 0.8.1

Bump Woodwork min version to 0.8.1 to include datetime inference performance gains from Woodwork update.