### PR TITLE
Add notebook cleaner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,13 @@ clean:
 .PHONY: lint
 lint:
 	flake8 featuretools && isort --check-only featuretools
+	python docs/notebook_cleaner.py check-execution
 
 .PHONY: lint-fix
 lint-fix:
 	autopep8 --in-place --recursive --max-line-length=100 --exclude="*/migrations/*" --select="E225,E303,E302,E203,E128,E231,E251,E271,E127,E126,E301,W291,W293,E226,E306,E221,E261,E111,E114" featuretools
 	isort featuretools
+	python docs/notebook_cleaner.py standardize
 
 .PHONY: test
 test: lint

--- a/docs/notebook_cleaner.py
+++ b/docs/notebook_cleaner.py
@@ -1,6 +1,7 @@
-import click
 import json
 import os
+
+import click
 
 DOCS_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "source")
 

--- a/docs/notebook_cleaner.py
+++ b/docs/notebook_cleaner.py
@@ -20,15 +20,16 @@ def _get_ipython_notebooks(docs_source):
 def _check_delete_empty_cell(notebook, delete=True):
     with open(notebook, "r") as f:
         source = json.load(f)
-        cell = source["cells"][-1]
-        if cell["cell_type"] == "code" and cell["source"] == []:
-            # this is an empty cell, which we should delete
-            if delete:
-                source["cells"] = source["cells"][:-1]
-            else:
-                return False
+    cell = source["cells"][-1]
+    if cell["cell_type"] == "code" and cell["source"] == []:
+        # this is an empty cell, which we should delete
+        if delete:
+            source["cells"] = source["cells"][:-1]
+        else:
+            return False
     if delete:
-        json.dump(source, open(notebook, "w"), ensure_ascii=False, indent=1)
+        with open(notebook, "w") as f:
+            json.dump(source, f, ensure_ascii=False, indent=1)
     else:
         return True
 
@@ -36,38 +37,34 @@ def _check_delete_empty_cell(notebook, delete=True):
 def _check_execution_and_output(notebook):
     with open(notebook, "r") as f:
         source = json.load(f)
-        for cells in source["cells"]:
-            if cells["cell_type"] == "code" and (cells["execution_count"] is not None or cells['outputs']!= []):
-                return False
+    for cells in source["cells"]:
+        if cells["cell_type"] == "code" and (cells["execution_count"] is not None or cells['outputs']!= []):
+            return False
     return True
 
 
 def _fix_execution_and_output(notebook):
     with open(notebook, "r") as f:
         source = json.load(f)
-        for cells in source["cells"]:
-            if cells["cell_type"] == "code" and cells["execution_count"] is not None:
-                cells["execution_count"] = None
-                cells["outputs"] = []
-        source["metadata"]["kernelspec"]["display_name"] = "Python 3"
-        source["metadata"]["kernelspec"]["name"] = "python3"
-    json.dump(source, open(notebook, "w"), ensure_ascii=False, indent=1)
+    for cells in source["cells"]:
+        if cells["cell_type"] == "code" and cells["execution_count"] is not None:
+            cells["execution_count"] = None
+            cells["outputs"] = []
+    source["metadata"]["kernelspec"]["display_name"] = "Python 3"
+    source["metadata"]["kernelspec"]["name"] = "python3"
+    with open(notebook, "w") as f:
+        json.dump(source, f, ensure_ascii=False, indent=1)
 
 
-def _get_notebooks_with_executions(notebooks):
+def _get_notebooks_with_executions_and_empty(notebooks):
     executed = []
+    empty_last_cell = []
     for notebook in notebooks:
         if not _check_execution_and_output(notebook):
             executed.append(notebook)
-    return executed
-
-
-def _get_notebook_with_empty_last_cell(notebooks):
-    empty_last_cell = []
-    for notebook in notebooks:
         if not _check_delete_empty_cell(notebook, delete=False):
             empty_last_cell.append(notebook)
-    return empty_last_cell
+    return (executed, empty_last_cell)
 
 
 def _remove_notebook_empty_last_cell(notebooks):
@@ -88,8 +85,7 @@ def cli():
 @cli.command()
 def standardize():
     notebooks = _get_ipython_notebooks(DOCS_PATH)
-    executed_notebooks = _get_notebooks_with_executions(notebooks)
-    empty_cells = _get_notebook_with_empty_last_cell(notebooks)
+    executed_notebooks, empty_cells = _get_notebooks_with_executions_and_empty(notebooks)
     if executed_notebooks:
         _standardize_outputs(executed_notebooks)
         executed_notebooks = ["\t" + notebook for notebook in executed_notebooks]
@@ -109,8 +105,7 @@ def standardize():
 @cli.command()
 def check_execution():
     notebooks = _get_ipython_notebooks(DOCS_PATH)
-    executed_notebooks = _get_notebooks_with_executions(notebooks)
-    empty_cells = _get_notebook_with_empty_last_cell(notebooks)
+    executed_notebooks, empty_cells = _get_notebooks_with_executions_and_empty(notebooks)
     if executed_notebooks:
         executed_notebooks = ["\t" + notebook for notebook in executed_notebooks]
         executed_notebooks = "\n".join(executed_notebooks)
@@ -121,7 +116,7 @@ def check_execution():
     if empty_cells:
         empty_cells = ["\t" + notebook for notebook in empty_cells]
         empty_cells = "\n".join(empty_cells)
-        click.echo(
+        raise SystemExit(
             f"The following notebooks have empty cells at the end:\n {empty_cells}\n"
             "Please run make lint-fix to fix this."
         )

--- a/docs/notebook_cleaner.py
+++ b/docs/notebook_cleaner.py
@@ -1,0 +1,86 @@
+import click
+import json
+import os
+
+DOCS_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "source")
+
+
+def _get_ipython_notebooks(docs_source):
+    directories_to_skip = ["_templates", "generated", ".ipynb_checkpoints"]
+    notebooks = []
+    for root, _, filenames in os.walk(docs_source):
+        if any(dir_ in root for dir_ in directories_to_skip):
+            continue
+        for filename in filenames:
+            if filename.endswith(".ipynb"):
+                notebooks.append(os.path.join(root, filename))
+    return notebooks
+
+
+def _check_execution_and_output(notebook):
+    with open(notebook, "r") as f:
+        source = json.load(f)
+        for cells in source["cells"]:
+            if cells["cell_type"] == "code" and cells["execution_count"] != None:
+                return False
+    return True
+
+
+def _fix_execution_and_output(notebook):
+    with open(notebook, "r") as f:
+        source = json.load(f)
+        for cells in source["cells"]:
+            if cells["cell_type"] == "code" and cells["execution_count"] != None:
+                cells["execution_count"] = None
+                cells["outputs"] = []
+        source["metadata"]["kernelspec"]["display_name"] = "Python 3"
+        source["metadata"]["kernelspec"]["name"] = "python3"
+    json.dump(source, open(notebook, "w"), ensure_ascii=False, indent=1)
+
+
+def _get_notebooks_with_executions(notebooks):
+    executed = []
+    for notebook in notebooks:
+        if not _check_execution_and_output(notebook):
+            executed.append(notebook)
+    return executed
+
+
+def _standardize_outputs(notebooks):
+    for notebook in notebooks:
+        _fix_execution_and_output(notebook)
+
+
+@click.group()
+def cli():
+    """no-op"""
+
+
+@cli.command()
+def standardize():
+    notebooks = _get_ipython_notebooks(DOCS_PATH)
+    executed_notebooks = _get_notebooks_with_executions(notebooks)
+    if executed_notebooks:
+        _standardize_outputs(executed_notebooks)
+        executed_notebooks = ["\t" + notebook for notebook in executed_notebooks]
+        executed_notebooks = "\n".join(executed_notebooks)
+        click.echo(
+            f"Removed the outputs for:\n {executed_notebooks}"
+        )
+
+
+@cli.command()
+def check_execution():
+    notebooks = _get_ipython_notebooks(DOCS_PATH)
+    executed_notebooks = _get_notebooks_with_executions(notebooks)
+    if executed_notebooks:
+        executed_notebooks = ["\t" + notebook for notebook in executed_notebooks]
+        executed_notebooks = "\n".join(executed_notebooks)
+        raise SystemExit(
+            f"The following notebooks have executed outputs:\n {executed_notebooks}\n"
+            "Please run make lint-fix to fix this."
+        )
+
+
+if __name__ == "__main__":
+    cli()

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -8,13 +8,14 @@ Future Release
     * Enhancements
     * Fixes
     * Changes
+        * Added Jupyter notebook cleaner to the linters (:pr:`1719`)
     * Documentation Changes
        * Update installation instructions for 1.0.0rc1 announcement in docs (:pr:`1707`, :pr:`1708`, :pr:`1713`, :pr:`1716`)
     * Testing Changes
         * Update reviewers for minimum and latest dependency checkers (:pr:`1715`)
 
     Thanks to the following people for contributing to this release:
-    :user:`gsheni`, :user:`rwedge`, :user:`thehomebrewnerd`
+    :user:`gsheni`, :user:`rwedge`, :user:`thehomebrewnerd`, :user:`bchen1116`
 
 v1.0.0rc1 Sep 17, 2021
 ======================

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -8,10 +8,10 @@ Future Release
     * Enhancements
     * Fixes
     * Changes
-        * Added Jupyter notebook cleaner to the linters (:pr:`1719`)
     * Documentation Changes
        * Update installation instructions for 1.0.0rc1 announcement in docs (:pr:`1707`, :pr:`1708`, :pr:`1713`, :pr:`1716`)
     * Testing Changes
+        * Added Jupyter notebook cleaner to the linters (:pr:`1719`)
         * Update reviewers for minimum and latest dependency checkers (:pr:`1715`)
 
     Thanks to the following people for contributing to this release:


### PR DESCRIPTION
Remove executed output of notebooks

<img width="620" alt="git status" src="https://user-images.githubusercontent.com/22552445/134563531-2ad5d276-5d86-4dbd-b059-5c87ddb25c69.png">

Example changes:
<img width="1488" alt="Pasted Graphic 10" src="https://user-images.githubusercontent.com/22552445/134563551-465c2a8f-8b9a-4005-b2c9-dfdd1ed17d8f.png">
<img width="1492" alt="diff --git adocssourceindex ipynb bdocssourceindex ipynb" src="https://user-images.githubusercontent.com/22552445/134563560-452ae485-c0f9-4017-bd6b-34032b0d805f.png">

Lint:
<img width="967" alt="make lint" src="https://user-images.githubusercontent.com/22552445/134563576-958678d0-7240-4aca-8642-2cc5bdfb4565.png">

Lint-fix:
<img width="1495" alt="make lint-fix" src="https://user-images.githubusercontent.com/22552445/134563589-8399531e-d862-478e-baf1-b3eae994351d.png">

Remaining diff:
<img width="955" alt="index 3fd8d6d 0dla8ab 100644" src="https://user-images.githubusercontent.com/22552445/134563618-bcf3d16c-2513-40cc-bab9-5bbbe5d01d9b.png">

**NOTE**: We see that the python version changes to my local version, and the `id` values for the cells are removed. The removal of IDs don't seem to be detrimental for anything, and there is no set python version, so these changes should be fine.

Added support of removing last cell if it is empty, which can be seen [here](https://github.com/alteryx/woodwork/pull/1153#issuecomment-926084592)