### PR TITLE
Add primitive init tests

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -14,6 +14,7 @@ Future Release
     * Testing Changes
         * Added Jupyter notebook cleaner to the linters (:pr:`1719`)
         * Update reviewers for minimum and latest dependency checkers (:pr:`1715`)
+        * Add tests to verify all primitives can be initialized without parameter values (:pr:`1726`)
 
     Thanks to the following people for contributing to this release:
     :user:`gsheni`, :user:`rwedge`, :user:`thehomebrewnerd`, :user:`bchen1116`

--- a/featuretools/tests/primitive_tests/test_agg_primitives.py
+++ b/featuretools/tests/primitive_tests/test_agg_primitives.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 from pandas.core.dtypes.dtypes import CategoricalDtype
 
-from featuretools.primitives import NMostCommon
+from featuretools.primitives import NMostCommon, get_aggregation_primitives
 
 
 def test_nmostcommon_categorical():
@@ -20,3 +20,9 @@ def test_nmostcommon_categorical():
     extra_dtype = CategoricalDtype(categories=[1, 2, 3])
     cats_extra = pd.Series([1, 2, 1, 1]).astype(extra_dtype)
     assert pd.Series(n_most(cats_extra)).equals(expected)
+
+
+def test_agg_primitives_can_init_without_params():
+    agg_primitives = get_aggregation_primitives().values()
+    for agg_primitive in agg_primitives:
+        agg_primitive()

--- a/featuretools/tests/primitive_tests/test_transform_primitive.py
+++ b/featuretools/tests/primitive_tests/test_transform_primitive.py
@@ -12,7 +12,8 @@ from featuretools.primitives import (
     URLToDomain,
     URLToProtocol,
     URLToTLD,
-    Week
+    Week,
+    get_transform_primitives
 )
 
 
@@ -373,3 +374,9 @@ def test_email_address_to_domain_all_nan():
     answers = pd.Series(email_address_to_domain(array))
     correct_answers = pd.Series([np.nan, np.nan], dtype=object)
     pd.testing.assert_series_equal(answers, correct_answers)
+
+
+def test_trans_primitives_can_init_without_params():
+    trans_primitives = get_transform_primitives().values()
+    for trans_primitive in trans_primitives:
+        trans_primitive()


### PR DESCRIPTION
### Add primitive init tests

Closes #1717 

Adds explicit tests to verify all primitives can be initialized without specifying any parameter values.
