### PR TITLE
Add pandas workaround back in

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -12,6 +12,8 @@ Future Release
        * Update installation instructions for 1.0.0rc1 announcement in docs (:pr:`1707`, :pr:`1708`, :pr:`1713`, :pr:`1716`)
        * Fixed broken link for Demo notebook in README.md (:pr:`1728`)
        * Update ``contributing.md`` to improve instructions for external contributors (:pr:`1723`)
+       * Manually revert changes made by :pr:`1677` and :pr:`1679`.  The
+         related bug in pandas still exists. (:pr:`1731`)
     * Testing Changes
         * Added Jupyter notebook cleaner to the linters (:pr:`1719`)
         * Update reviewers for minimum and latest dependency checkers (:pr:`1715`)

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -1390,6 +1390,18 @@ class EntitySet(object):
             if isinstance(dataframe, pd.DataFrame):
                 df = df.set_index(dataframe.ww.index, drop=False)
 
+            # ensure filtered df has same categories as original
+            # workaround for issue below
+            # github.com/pandas-dev/pandas/issues/22501#issuecomment-415982538
+            #
+            # Pandas claims that bug is fixed but it still shows up in some
+            # cases.  More investigation needed.
+            #
+            # Note: Woodwork stores categorical columns with a `string` dtype for Koalas
+            if dataframe.ww.columns[column_name].is_categorical and not is_instance(df, ks, 'DataFrame'):
+                categories = pd.api.types.CategoricalDtype(categories=dataframe[column_name].cat.categories)
+                df[column_name] = df[column_name].astype(categories)
+
         df = self._handle_time(dataframe_name=dataframe_name,
                                df=df,
                                time_last=time_last,


### PR DESCRIPTION
### Pull Request Description

We realized earlier today that the pandas workarounds that were removed by #1677 and #1679 are probably still needed as the bug reported in https://github.com/pandas-dev/pandas/issues/22501 may still exist.  More investigation is needed to understand exactly what causes data frames with misaligned categorical indices to be merged incorrectly.  For now, we should at least revert the changes made by the two aforementioned PRs.

Left to do:
- [ ] More investigation into what causes the categorical merge bug to show up
- [ ] Regression tests that check for improper merges in `_calculate_agg_features` resulting from the categorical merge bug
- [ ] Add more details in this ticket about the code that revealed the issue