### PR TITLE
Fix pass through columns for parallel pandas computation

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -11,6 +11,7 @@ Future Release
         * Pin upper bound for pyspark (:pr:`1748`)
         * Fix ``get_unused_primitives`` only recognizes lowercase primitive strings (:pr:`1733`)
         * Require newer versions of dask and distributed (:pr:`1762`)
+        * Fix bug with pass-through columns of cutoff_time df when n_jobs > 1 (:pr:`1765`)
     * Changes
         * Add new version of nlp_primitives as an add-on library (:pr:`1743`)
     * Documentation Changes


### PR DESCRIPTION
Fixes #1763 

WIP for now, ideally we wouldn't need to pass schema separately.  Initialize woodwork on the chunked cutoff times before sending them to the dask workers had an issue where when the worker got them they wouldn't be initialized