### PR TITLE
Add tsfresh back in as featuretools extra addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ python -m pip install "featuretools[update_checker]"
 python -m pip install "featuretools[nlp_primitives]"
 ```
 
+**TSFresh Primitives** - Use 60+ primitives from [tsfresh](https://tsfresh.readthedocs.io/en/latest/) within Featuretools
+
+```
+python -m pip install "featuretools[tsfresh]"
+```
+
 ## Example
 Below is an example of using Deep Feature Synthesis (DFS) to perform automated feature engineering. In this example, we apply DFS to a multi-table dataset consisting of timestamped customer transactions.
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -28,6 +28,11 @@ NLP Primitives:
 
         python -m pip install "featuretools[nlp_primitives]"
 
+TSFresh Primitives:
+    Use 60+ primitives from `tsfresh <https://tsfresh.readthedocs.io/en/latest/>`__ in Featuretools::
+
+        python -m pip install "featuretools[tsfresh]"
+        
 .. _graphviz:
 
 Installing Graphviz

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,15 +3,17 @@
 Release Notes
 -------------
 
-.. Future Release
-  ==============
+Future Release
+==============
     * Enhancements
     * Fixes
     * Changes
+        * Add new version of featuretools_tsfresh_primitives as an add-on library (:pr:`1772`)
     * Documentation Changes
     * Testing Changes
 
-.. Thanks to the following people for contributing to this release:
+    Thanks to the following people for contributing to this release:
+    :user:`tamargrey`
 
 v1.1.0 Nov 2, 2021
 ==================

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ with open(path.join(dirname, 'README.md')) as f:
     long_description = f.read()
 
 extras_require = {
+    'tsfresh': ['featuretools-tsfresh-primitives >= 1.0.0'],
     'update_checker': ['alteryx-open-src-update-checker >= 2.0.0'],
     'nlp_primitives': ['nlp-primitives[complete] >= 2.0.0'],
     'koalas': open('koalas-requirements.txt').readlines(),


### PR DESCRIPTION
Adds tsfresh primitives as optional install in setup.py and update README and install.rst to include instructions on how to install featuretools with tsfresh.

closes #1625 