### PR TITLE
Add Docker install documentation

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -9,21 +9,6 @@ or from the Conda-forge channel on `anaconda.org <https://anaconda.org/conda-for
 
     conda install -c conda-forge featuretools
 
-.. _docker:
-
-Docker
---------
-
-It is also possible to run Featuretools inside a Docker container. 
-You can do so by installing it as a package inside a container (following the normal install guide) or 
-creating a new image with Featuretools pre-installed, using the following commands in your ``Dockerfile``::
-
-    FROM python:3.8-slim-buster
-    RUN apt-get update && apt-get -y update
-    RUN apt-get install -y build-essential python3-pip python3-dev
-    RUN pip -q install pip --upgrade
-    RUN pip install featuretools
-
 .. _addons:
 
 Add-ons
@@ -102,6 +87,20 @@ or use ``pip`` locally if you want to install all dependencies as well::
 You can view the list of all dependencies within the ``extras_require`` field
 of ``setup.py``.
 
+.. _docker:
+
+Docker
+------
+
+It is also possible to run Featuretools inside a Docker container. 
+You can do so by installing it as a package inside a container (following the normal install guide) or 
+creating a new image with Featuretools pre-installed, using the following commands in your ``Dockerfile``::
+
+    FROM python:3.8-slim-buster
+    RUN apt-get update && apt-get -y update
+    RUN apt-get install -y build-essential python3-pip python3-dev
+    RUN pip -q install pip --upgrade
+    RUN pip install featuretools
 
 
 Development

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -9,6 +9,20 @@ or from the Conda-forge channel on `anaconda.org <https://anaconda.org/conda-for
 
     conda install -c conda-forge featuretools
 
+.. _docker:
+
+Docker
+--------
+
+It is also possible to run Featuretools inside a Docker container. 
+You can do so by installing it as a package inside a container (following the normal install guide) or 
+creating a new image with Featuretools pre-installed, using the following commands in your ``Dockerfile``::
+
+    FROM python:3.8-slim-buster
+    RUN apt-get update && apt-get -y update
+    RUN apt-get install -y build-essential python3-pip python3-dev
+    RUN pip -q install pip --upgrade
+    RUN pip install featuretools
 
 .. _addons:
 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -9,9 +9,11 @@ Release Notes
     * Fixes
     * Changes
     * Documentation Changes
+        * Add Docker install instructions and documentation on the install page. (:pr:`1785`)
     * Testing Changes
 
 .. Thanks to the following people for contributing to this release:
+   :user:`HenryRocha`
 
 v1.2.0 Nov 15, 2021
 ===================


### PR DESCRIPTION
Fixed #1767 

Add Docker install instructions and documentation on the install page.