### PR TITLE
Update cfm to use nullable types when needed

### DIFF
--- a/.github/workflows/auto_approve_dependency_PRs.yml
+++ b/.github/workflows/auto_approve_dependency_PRs.yml
@@ -1,7 +1,7 @@
 name: Auto Approve Dependency PRs
 on:
   schedule:
-    - cron: '*/30 * * * *'
+    - cron: '*/5 * * * *'
   workflow_dispatch:
 jobs:
   build:

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -8,6 +8,7 @@ Future Release
     * Enhancements
         * Add LatLong transform primitives - GeoMidpoint, IsInGeoBox, CityblockDistance (:pr:`1814`)
     * Fixes
+        * Fix bug where Woodwork initialization could fail on feature matrix if cutoff times caused null values to be introduced (:pr:`1810`)
     * Changes
     * Documentation Changes
         * Remove testing on conda forge in release.md (:pr:`1811`)
@@ -16,8 +17,9 @@ Future Release
         * Test deserializing from S3 with mocked S3 fixtures only (:pr:`1825`)
 
     Thanks to the following people for contributing to this release:
-    :user:`gsheni`, :user:`rwedge`
+    :user:`gsheni`, :user:`rwedge`, :user:`thehomebrewnerd`
     
+
 v1.3.0 Dec 2, 2021
 ==================
     * Enhancements

--- a/featuretools/computational_backends/calculate_feature_matrix.py
+++ b/featuretools/computational_backends/calculate_feature_matrix.py
@@ -10,7 +10,14 @@ import cloudpickle
 import dask.dataframe as dd
 import numpy as np
 import pandas as pd
-from woodwork.logical_types import Age, AgeNullable, Boolean, BooleanNullable, Integer, IntegerNullable
+from woodwork.logical_types import (
+    Age,
+    AgeNullable,
+    Boolean,
+    BooleanNullable,
+    Integer,
+    IntegerNullable
+)
 
 from featuretools.computational_backends.feature_set import FeatureSet
 from featuretools.computational_backends.feature_set_calculator import (

--- a/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
+++ b/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
@@ -13,6 +13,14 @@ import pytest
 from dask import dataframe as dd
 from tqdm import tqdm
 from woodwork.column_schema import ColumnSchema
+from woodwork.logical_types import (
+    Age,
+    AgeNullable,
+    Boolean,
+    BooleanNullable,
+    Integer,
+    IntegerNullable
+)
 
 import featuretools as ft
 from featuretools import EntitySet, Timedelta, calculate_feature_matrix, dfs
@@ -1868,3 +1876,24 @@ def test_cfm_with_invalid_time_index(es):
     match += "which differs from other entityset time indexes"
     with pytest.raises(TypeError, match=match):
         calculate_feature_matrix(features=features, entityset=es)
+
+
+def test_cfm_introduces_nan_values_in_direct_feats(es):
+    es["customers"].ww.set_types(logical_types={"age": "Age",
+                                                "engagement_level": "Integer"})
+    age_feat = ft.Feature(es["customers"].ww["age"])
+    engagement_feat = ft.Feature(es["customers"].ww["engagement_level"])
+    loves_ice_cream_feat = ft.Feature(es["customers"].ww["loves_ice_cream"])
+    features = [age_feat, engagement_feat, loves_ice_cream_feat]
+    fm = calculate_feature_matrix(features=features,
+                                  entityset=es,
+                                  cutoff_time=pd.Timestamp("2010-04-08 04:00"),
+                                  instance_ids=[1])
+
+    assert isinstance(es["customers"].ww.logical_types["age"], Age)
+    assert isinstance(es["customers"].ww.logical_types["engagement_level"], Integer)
+    assert isinstance(es["customers"].ww.logical_types["loves_ice_cream"], Boolean)
+
+    assert isinstance(fm.ww.logical_types["age"], AgeNullable)
+    assert isinstance(fm.ww.logical_types["engagement_level"], IntegerNullable)
+    assert isinstance(fm.ww.logical_types["loves_ice_cream"], BooleanNullable)

--- a/featuretools/tests/synthesis/test_dask_dfs.py
+++ b/featuretools/tests/synthesis/test_dask_dfs.py
@@ -55,7 +55,7 @@ def test_single_table_dask_entityset():
 
     # Use the same columns and make sure both indexes are sorted the same
     dask_computed_fm = dask_fm.compute().set_index('id').loc[fm.index][fm.columns]
-    pd.testing.assert_frame_equal(fm, dask_computed_fm)
+    pd.testing.assert_frame_equal(fm, dask_computed_fm, check_dtype=False)
 
 
 def test_single_table_dask_entityset_ids_not_sorted():
@@ -100,7 +100,7 @@ def test_single_table_dask_entityset_ids_not_sorted():
                    trans_primitives=primitives_list)
 
     # Make sure both indexes are sorted the same
-    pd.testing.assert_frame_equal(fm, dask_fm.compute().set_index('id').loc[fm.index])
+    pd.testing.assert_frame_equal(fm, dask_fm.compute().set_index('id').loc[fm.index], check_dtype=False)
 
 
 def test_single_table_dask_entityset_with_instance_ids():
@@ -149,7 +149,7 @@ def test_single_table_dask_entityset_with_instance_ids():
                    instance_ids=instance_ids)
 
     # Make sure both indexes are sorted the same
-    pd.testing.assert_frame_equal(fm, dask_fm.compute().set_index('id').loc[fm.index])
+    pd.testing.assert_frame_equal(fm, dask_fm.compute().set_index('id').loc[fm.index], check_dtype=False)
 
 
 def test_single_table_dask_entityset_single_cutoff_time():
@@ -196,7 +196,7 @@ def test_single_table_dask_entityset_single_cutoff_time():
                    cutoff_time=pd.Timestamp("2019-01-05 04:00"))
 
     # Make sure both indexes are sorted the same
-    pd.testing.assert_frame_equal(fm, dask_fm.compute().set_index('id').loc[fm.index])
+    pd.testing.assert_frame_equal(fm, dask_fm.compute().set_index('id').loc[fm.index], check_dtype=False)
 
 
 def test_single_table_dask_entityset_cutoff_time_df():
@@ -297,7 +297,7 @@ def test_single_table_dask_entityset_dates_not_sorted():
                    trans_primitives=primitives_list,
                    max_depth=1)
 
-    pd.testing.assert_frame_equal(fm, dask_fm.compute().set_index('id').loc[fm.index])
+    pd.testing.assert_frame_equal(fm, dask_fm.compute().set_index('id').loc[fm.index], check_dtype=False)
 
 
 def test_dask_entityset_secondary_time_index():


### PR DESCRIPTION
### Update cfm to use nullable types when needed

Closes #1692 

Updates the CFM process to use Woodwork nullable logical types when needed, instead of the non nullable types. This is important for situations where the cutoff time settings cause null values to be introduced into the feature matrix for columns that previously did not have null values present.
