### PR TITLE
Fix s3 credentials test issue

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -13,9 +13,10 @@ Future Release
         * Remove testing on conda forge in release.md (:pr:`1811`)
     * Testing Changes
         * Enable auto-merge for minimum and latest dependency merge requests (:pr:`1818`, :pr:`1821`, :pr:`1822`)
-        
+        * Test deserializing from S3 with mocked S3 fixtures only (:pr:`1825`)
+
     Thanks to the following people for contributing to this release:
-    :user:`gsheni`
+    :user:`gsheni`, :user:`rwedge`
     
 v1.3.0 Dec 2, 2021
 ==================

--- a/featuretools/tests/entityset_tests/test_serialization.py
+++ b/featuretools/tests/entityset_tests/test_serialization.py
@@ -208,58 +208,33 @@ def make_public(s3_client, s3_bucket):
 
 
 # TODO: tmp file disappears after deserialize step, cannot check equality with Dask, Koalas
-def test_serialize_s3_csv(es, s3_client, s3_bucket):
+@pytest.mark.parametrize("profile_name", [None, False])
+def test_serialize_s3_csv(es, s3_client, s3_bucket, profile_name):
     if es.dataframe_type != Library.PANDAS.value:
         pytest.xfail('tmp file disappears after deserialize step, cannot check equality with Dask')
-    es.to_csv(TEST_S3_URL, encoding='utf-8', engine='python')
+    es.to_csv(TEST_S3_URL, encoding='utf-8', engine='python', profile_name=profile_name)
     make_public(s3_client, s3_bucket)
-    new_es = deserialize.read_entityset(TEST_S3_URL)
+    new_es = deserialize.read_entityset(TEST_S3_URL, profile_name=profile_name)
     assert es.__eq__(new_es, deep=True)
 
 
 # Dask and Koalas do not support to_pickle
-def test_serialize_s3_pickle(pd_es, s3_client, s3_bucket):
-    pd_es.to_pickle(TEST_S3_URL)
+@pytest.mark.parametrize("profile_name", [None, False])
+def test_serialize_s3_pickle(pd_es, s3_client, s3_bucket, profile_name):
+    pd_es.to_pickle(TEST_S3_URL, profile_name=profile_name)
     make_public(s3_client, s3_bucket)
-    new_es = deserialize.read_entityset(TEST_S3_URL)
+    new_es = deserialize.read_entityset(TEST_S3_URL, profile_name=profile_name)
     assert pd_es.__eq__(new_es, deep=True)
 
 
 # TODO: tmp file disappears after deserialize step, cannot check equality with Dask, Koalas
-def test_serialize_s3_parquet(es, s3_client, s3_bucket):
+@pytest.mark.parametrize("profile_name", [None, False])
+def test_serialize_s3_parquet(es, s3_client, s3_bucket, profile_name):
     if es.dataframe_type != Library.PANDAS.value:
         pytest.xfail('tmp file disappears after deserialize step, cannot check equality with Dask or Koalas')
-    es.to_parquet(TEST_S3_URL)
+    es.to_parquet(TEST_S3_URL, profile_name=profile_name)
     make_public(s3_client, s3_bucket)
-    new_es = deserialize.read_entityset(TEST_S3_URL)
-    assert es.__eq__(new_es, deep=True)
-
-
-# TODO: tmp file disappears after deserialize step, cannot check equality with Dask, Koalas
-def test_serialize_s3_anon_csv(es, s3_client, s3_bucket):
-    if es.dataframe_type != Library.PANDAS.value:
-        pytest.xfail('tmp file disappears after deserialize step, cannot check equality with Dask or Koalas')
-    es.to_csv(TEST_S3_URL, encoding='utf-8', engine='python', profile_name=False)
-    make_public(s3_client, s3_bucket)
-    new_es = deserialize.read_entityset(TEST_S3_URL, profile_name=False)
-    assert es.__eq__(new_es, deep=True)
-
-
-# Dask/Koalas do not support to_pickle
-def test_serialize_s3_anon_pickle(pd_es, s3_client, s3_bucket):
-    pd_es.to_pickle(TEST_S3_URL, profile_name=False)
-    make_public(s3_client, s3_bucket)
-    new_es = deserialize.read_entityset(TEST_S3_URL, profile_name=False)
-    assert pd_es.__eq__(new_es, deep=True)
-
-
-# TODO: tmp file disappears after deserialize step, cannot check equality with Dask, Koalas
-def test_serialize_s3_anon_parquet(es, s3_client, s3_bucket):
-    if es.dataframe_type != Library.PANDAS.value:
-        pytest.xfail('tmp file disappears after deserialize step, cannot check equality with Dask')
-    es.to_parquet(TEST_S3_URL, profile_name=False)
-    make_public(s3_client, s3_bucket)
-    new_es = deserialize.read_entityset(TEST_S3_URL, profile_name=False)
+    new_es = deserialize.read_entityset(TEST_S3_URL, profile_name=profile_name)
     assert es.__eq__(new_es, deep=True)
 
 
@@ -344,12 +319,7 @@ def test_deserialize_url_csv(es):
     assert es.__eq__(new_es, deep=True)
 
 
-def test_default_s3_csv(es):
-    new_es = deserialize.read_entityset(S3_URL)
-    assert es.__eq__(new_es, deep=True)
-
-
-def test_anon_s3_csv(es):
+def test_deserialize_s3_csv(es):
     new_es = deserialize.read_entityset(S3_URL, profile_name=False)
     assert es.__eq__(new_es, deep=True)
 

--- a/featuretools/tests/primitive_tests/test_feature_serialization.py
+++ b/featuretools/tests/primitive_tests/test_feature_serialization.py
@@ -222,7 +222,8 @@ def setup_test_profile(monkeypatch, tmpdir):
     os.remove(test_path_config)
 
 
-def test_s3_test_profile(es, s3_client, s3_bucket, setup_test_profile):
+@pytest.mark.parametrize("profile_name", ["test", False])
+def test_s3_test_profile(es, s3_client, s3_bucket, setup_test_profile, profile_name):
     features_original = ft.dfs(target_dataframe_name='sessions', entityset=es, features_only=True)
 
     ft.save_features(features_original, TEST_S3_URL, profile_name='test')
@@ -230,11 +231,11 @@ def test_s3_test_profile(es, s3_client, s3_bucket, setup_test_profile):
     obj = list(s3_bucket.objects.all())[0].key
     s3_client.ObjectAcl(BUCKET_NAME, obj).put(ACL='public-read-write')
 
-    features_deserialized = ft.load_features(TEST_S3_URL, profile_name='test')
+    features_deserialized = ft.load_features(TEST_S3_URL, profile_name=profile_name)
     assert_features(features_original, features_deserialized)
 
 
-@pytest.mark.parametrize("url,profile_name", [(S3_URL, None), (S3_URL, False),
+@pytest.mark.parametrize("url,profile_name", [(S3_URL, False),
                                               (URL, None)])
 def test_deserialize_features_s3(pd_es, url, profile_name):
     agg_primitives = [Sum, Std, Max, Skew, Min, Mean, Count, PercentTrue,


### PR DESCRIPTION
Some unit tests were failing to download public files if existing AWS credentials were detected

This PR shifts testing S3 deserializing with credentials to only in tests with mocked S3 fixtures, leaving the real S3 tests that do not use credentials
