### PR TITLE
Update auto approve workflow schedule, and use PR number

### DIFF
--- a/.github/workflows/auto_approve_dependency_PRs.yml
+++ b/.github/workflows/auto_approve_dependency_PRs.yml
@@ -7,29 +7,19 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
       - name: Find dependency PRs
         id: find_prs
         run: |
           gh auth status
-          rm -f dep_PRs_waiting_approval.json
           gh pr list --repo "${{ github.repository }}" --author "machineFL" --base main --state open --search "status:success review:required" --limit 1 --json number > dep_PRs_waiting_approval.json
-          cat dep_PRs_waiting_approval.json
           dep_pull_request=$(cat dep_PRs_waiting_approval.json | grep -Eo "[0-9]*")
-          echo $dep_pull_request
           echo ::set-output name=dep_pull_request::${dep_pull_request}
         env:
           GITHUB_TOKEN: ${{ secrets.AUTO_APPROVE_TOKEN }}
       - name: Approve dependency PRs and enable auto-merge
         id: approve_prs
-        if: >-
-          ${{
-            steps.find_prs.outputs.dep_pull_request != '' &&
-            steps.find_prs.outputs.dep_pull_request != null &&
-            steps.find_prs.outputs.dep_pull_request > 1
-          }}
+        if: ${{ steps.find_prs.outputs.dep_pull_request > 1 }}
         run: |
-          echo ${{ steps.find_prs.outputs.dep_pull_request }}
           gh pr review --repo "${{ github.repository }}" --comment --body "auto approve" ${{ steps.find_prs.outputs.dep_pull_request }}
           gh pr review --repo "${{ github.repository }}" --approve ${{ steps.find_prs.outputs.dep_pull_request }}
           gh pr merge --repo "${{ github.repository }}" --auto --squash ${{ steps.find_prs.outputs.dep_pull_request }}

--- a/.github/workflows/auto_approve_dependency_PRs.yml
+++ b/.github/workflows/auto_approve_dependency_PRs.yml
@@ -17,7 +17,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.AUTO_APPROVE_TOKEN }}
       - name: Approve dependency PRs and enable auto-merge
-        id: approve_prs
         if: ${{ steps.find_prs.outputs.dep_pull_request > 1 }}
         run: |
           gh pr review --repo "${{ github.repository }}" --comment --body "auto approve" ${{ steps.find_prs.outputs.dep_pull_request }}

--- a/.github/workflows/auto_approve_dependency_PRs.yml
+++ b/.github/workflows/auto_approve_dependency_PRs.yml
@@ -1,30 +1,37 @@
 name: Auto Approve Dependency PRs
 on:
   schedule:
-    - cron: '0 * * * *'
+    - cron: '*/30 * * * *'
+  workflow_dispatch:
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Find dependency PRs
-      id: find_prs
-      run: |
-        gh pr list --author "machineFL" --base main --state open --search "status:success review:required" --limit 1 --json url > dep_PRs_waiting_approval.json
-        echo "dep_pull_request_url=$(cat dep_PRs_waiting_approval.json | grep -Eo "(https)://[a-zA-Z0-9./?=_%:-]*")" >> $GITHUB_ENV
-        echo "${{ env.dep_pull_request_url }}"
-        if [[ "${{ env.dep_pull_request_url }}" -gt 8 ]]; then
-          echo ::set-output name=dep_pull_request_url::${dep_pull_request_url}
-        else 
-          echo No matching PR found;
-        fi
-      env:
-        GITHUB_TOKEN: ${{ secrets.REPO_SCOPED_TOKEN }}
-    - name: Approve dependency PRs and enable auto-merge 
-      if: steps.find_prs.outputs.dep_pull_request_url && steps.find_prs.outputs.dep_pull_request_url != null
-      run: |
-        gh pr review ${{ steps.find_prs.outputs.dep_pull_request_url }} --approve --comment --body "auto approve"
-        gh pr merge ${{ steps.find_prs.outputs.dep_pull_request_url }} --auto --squash
-        rm dep_PRs_waiting_approval.json
-      env:
-        GITHUB_TOKEN: ${{ secrets.REPO_SCOPED_TOKEN }}
+      - uses: actions/checkout@v2
+      - name: Find dependency PRs
+        id: find_prs
+        run: |
+          gh auth status
+          rm -f dep_PRs_waiting_approval.json
+          gh pr list --repo "${{ github.repository }}" --author "machineFL" --base main --state open --search "status:success review:required" --limit 1 --json number > dep_PRs_waiting_approval.json
+          cat dep_PRs_waiting_approval.json
+          dep_pull_request=$(cat dep_PRs_waiting_approval.json | grep -Eo "[0-9]*")
+          echo $dep_pull_request
+          echo ::set-output name=dep_pull_request::${dep_pull_request}
+        env:
+          GITHUB_TOKEN: ${{ secrets.AUTO_APPROVE_TOKEN }}
+      - name: Approve dependency PRs and enable auto-merge
+        id: approve_prs
+        if: >-
+          ${{
+            steps.find_prs.outputs.dep_pull_request != '' &&
+            steps.find_prs.outputs.dep_pull_request != null &&
+            steps.find_prs.outputs.dep_pull_request > 1
+          }}
+        run: |
+          echo ${{ steps.find_prs.outputs.dep_pull_request }}
+          gh pr review --repo "${{ github.repository }}" --comment --body "auto approve" ${{ steps.find_prs.outputs.dep_pull_request }}
+          gh pr review --repo "${{ github.repository }}" --approve ${{ steps.find_prs.outputs.dep_pull_request }}
+          gh pr merge --repo "${{ github.repository }}" --auto --squash ${{ steps.find_prs.outputs.dep_pull_request }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.AUTO_APPROVE_TOKEN }}

--- a/.github/workflows/latest_dependency_checker.yml
+++ b/.github/workflows/latest_dependency_checker.yml
@@ -5,6 +5,7 @@ name: Latest Dependency Checker
 on:
   schedule:
     - cron: '0 * * * *'
+  workflow_dispatch:
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/performance-check.yml
+++ b/.github/workflows/performance-check.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 jobs:
   run-performance-analysis:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit_tests_with_latest_deps.yml
+++ b/.github/workflows/unit_tests_with_latest_deps.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-
+  workflow_dispatch:
 name: Unit Tests - Latest Dependencies
 jobs:
   unit_tests:

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -13,6 +13,7 @@ Future Release
         * Remove testing on conda forge in release.md (:pr:`1811`)
     * Testing Changes
         * Enable auto-merge for minimum and latest dependency merge requests (:pr:`1818`, :pr:`1821`, :pr:`1822`)
+        * Change auto approve workfow to use PR number and run every 30 minutes (:pr:`1827`)
         * Test deserializing from S3 with mocked S3 fixtures only (:pr:`1825`)
 
     Thanks to the following people for contributing to this release:


### PR DESCRIPTION
- Changed auto approve to run every 30 minutes, rather than once every hour
- Use PR number rather than URL for auto approve workflow
- Added **workflow_dispatch** so unit tests, latest dep check, and auto approve can be kickoff off manually.