### PR TITLE
Update auto approve dependency PR to run on workflow completion

### DIFF
--- a/.github/workflows/auto_approve_dependency_PRs.yml
+++ b/.github/workflows/auto_approve_dependency_PRs.yml
@@ -1,7 +1,5 @@
 name: Auto Approve Dependency PRs
 on:
-  schedule:
-    - cron: '*/5 * * * *'
   workflow_dispatch:
   workflow_run:
     workflows: ["Unit Tests - Latest Dependencies"]

--- a/.github/workflows/auto_approve_dependency_PRs.yml
+++ b/.github/workflows/auto_approve_dependency_PRs.yml
@@ -3,6 +3,13 @@ on:
   schedule:
     - cron: '*/5 * * * *'
   workflow_dispatch:
+  workflow_run:
+    workflows: ["Unit Tests - Latest Dependencies"]
+    branches:    
+      - 'latest-dep-update-[a-f0-9]+'
+      - 'min-dep-update-[a-f0-9]+'
+    types:
+      - completed
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -19,6 +19,7 @@ Future Release
     * Testing Changes
         * Enable auto-merge for minimum and latest dependency merge requests (:pr:`1818`, :pr:`1821`, :pr:`1822`)
         * Change auto approve workfow to use PR number and run every 30 minutes (:pr:`1827`)
+        * Add auto approve workflow to run when unit tests complete (:pr:`1837`)
         * Test deserializing from S3 with mocked S3 fixtures only (:pr:`1825`)
         * Remove fastparquet as a test requirement (:pr:`1833`)
 


### PR DESCRIPTION
- This will make it so that when a workflow (unit tests) completes on a branch, the auto approve workflow will run.