### PR TITLE
Upgrade compose to version 0.8.0

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,7 +6,7 @@ autopep8==1.5.7
 ipython==7.28.0
 isort==5.9.3
 jupyter==1.0.0
-matplotlib==3.2.2  # koalas and composeml pinned below 3.3.0
+matplotlib==3.3.3
 nbconvert==6.2.0
 nbsphinx==0.8.7
 Sphinx==4.2.0

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -15,9 +15,10 @@ Future Release
         * Add check for package conflicts with install workflow (:pr:`1843`)
         * Change auto approve workflow to use assignee (:pr:`1843`)
         * Update auto approve workflow to delete branch and change on trigger (:pr:`1852`)
+        * Upgrade tests to use compose version 0.8.0 (:pr:`1856`)
 
     Thanks to the following people for contributing to this release:
-    :user:`gsheni`, :user:`tuethan1999`, :user:`dvreed77`
+    :user:`dvreed77`, :user:`gsheni`, :user:`thehomebrewnerd`, :user:`tuethan1999`
 
 v1.4.0 Jan 10, 2022
 ===================

--- a/featuretools/tests/conftest.py
+++ b/featuretools/tests/conftest.py
@@ -394,7 +394,7 @@ def lt(es):
         return df['value'].sum() > 10
 
     lm = cp.LabelMaker(
-        target_entity='id',
+        target_dataframe_name='id',
         time_index='datetime',
         labeling_function=label_func,
         window_size='1m'

--- a/featuretools/tests/requirement_files/minimum_test_requirements.txt
+++ b/featuretools/tests/requirement_files/minimum_test_requirements.txt
@@ -8,6 +8,6 @@ graphviz==0.8.4
 moto[all]==1.3.15
 smart-open==5.0.0
 boto3==1.17.46
-composeml==0.3.0
+composeml==0.8.0
 urllib3==1.26.5
 pyarrow==3.0.0

--- a/featuretools/tests/synthesis/test_dfs_method.py
+++ b/featuretools/tests/synthesis/test_dfs_method.py
@@ -104,7 +104,7 @@ def test_accepts_cutoff_time_compose(dataframes, relationships):
         return df['fraud'].any()
 
     lm = cp.LabelMaker(
-        target_entity='card_id',
+        target_dataframe_name='card_id',
         time_index='transaction_time',
         labeling_function=fraud_occured,
         window_size=1

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,6 +8,6 @@ graphviz>=0.8.4
 moto[all]>=1.3.15
 smart-open>=5.0.0
 boto3>=1.17.46
-composeml>=0.3.0
+composeml>=0.8.0
 urllib3>=1.26.5
 pyarrow>=3.0.0


### PR DESCRIPTION
### Upgrade compose to version 0.8.0

Updates `test-requirements.txt` to use `compose>=0.8.0` and fixes `LabelMaker` calls to use updated API.