### PR TITLE
Limit woodwork version

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -14,6 +14,7 @@ Future Release
         * Add DistanceToHoliday Transform Primitive (:pr:`1853`)
         * Temporarily restrict pandas and koalas max versions (:pr:`1863`)
         * Add ``__setitem__`` method to overload ``add_dataframe`` method on EntitySet (:pr:`1862`)
+        * Temporarily restrict woodwork max version (:pr:`1872`)
     * Documentation Changes
         * Bump ipython version (:pr:`1857`)
     * Testing Changes

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ distributed>=2021.10.0
 dask[dataframe]>=2021.10.0
 psutil>=5.6.6
 click>=7.0.0
-woodwork>=0.8.1
+woodwork>=0.8.1,<0.12.0
 holidays>=0.12


### PR DESCRIPTION
### Limit woodwork version

Restrict WW version to `<0.12.0` while test failures on `main` are investigated