### PR TITLE
Remove outdated pandas workaround code in feature_set_calculator.py

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,15 +3,18 @@
 Release Notes
 -------------
 
-.. Future Release
-      ==============
-        * Enhancements
-        * Fixes
-        * Changes
-        * Documentation Changes
-        * Testing Changes
+Future Release
+==============
+    * Enhancements
+    * Fixes
+    * Changes
+        * Removes outdated pandas workaround code (:pr:`1906`)
+    * Documentation Changes
+    * Testing Changes
 
-    .. Thanks to the following people for contributing to this release:
+    Thanks to the following people for contributing to this release:
+    :user:`thehomebrewnerd`
+
 
 v1.5.0 Feb 14, 2022
 ===================

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -8,7 +8,7 @@ Future Release
     * Enhancements
     * Fixes
     * Changes
-        * Removes outdated pandas workaround code (:pr:`1906`)
+        * Remove outdated pandas workaround code (:pr:`1906`)
     * Documentation Changes
     * Testing Changes
 

--- a/featuretools/computational_backends/feature_set_calculator.py
+++ b/featuretools/computational_backends/feature_set_calculator.py
@@ -738,14 +738,6 @@ class FeatureSetCalculator(object):
 
         frame = frame.fillna(fillna_dict)
 
-        # convert boolean dtypes to floats as appropriate
-        # pandas behavior: https://github.com/pydata/pandas/issues/3752
-        for f in features:
-            if (f.number_output_features == 1 and
-                    'numeric' in f.column_schema.semantic_tags and
-                    frame[f.get_name()].dtype.name in ['object', 'bool']):
-                frame[f.get_name()] = frame[f.get_name()].astype(float)
-
         return frame
 
     def _necessary_columns(self, dataframe_name, feature_names):


### PR DESCRIPTION
### Remove outdated pandas workaround code in feature_set_calculator.py
Closes #1711 

The pandas issue that caused the code to be added appears to be resolved in more recent pandas releases, so this code is no longer necessary. See #1711 for more details.