### PR TITLE
Update for new holidays library error

### DIFF
--- a/featuretools/primitives/utils.py
+++ b/featuretools/primitives/utils.py
@@ -424,7 +424,7 @@ class HolidayUtil(object):
     def __init__(self, country='US'):
         try:
             holidays.CountryHoliday(country)
-        except KeyError:
+        except (KeyError, NotImplementedError):
             available_countries = 'https://github.com/dr-prodigy/python-holidays#available-countries'
             error = 'must be one of the available countries:\n%s' % available_countries
             raise ValueError(error)


### PR DESCRIPTION
### Update for new holidays library error

Updates our `HolidayUtil` class to catch a `NotImplementedError` in addition to the previous `KeyError`. Version 0.13.0 of `holidays` will now raise a `NotImplementedError` if an unknown country is provided instead of the previous `KeyError`. Catching both errors will allow for compatibility with the new version as well as older versions.
