### PR TITLE
Update urls to test deserialization

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -12,9 +12,10 @@ Future Release
         * Remove outdated pandas workaround code (:pr:`1906`)
     * Documentation Changes
     * Testing Changes
+        * Fix URL deserialization file (:pr:`1909`)
 
     Thanks to the following people for contributing to this release:
-    :user:`thehomebrewnerd`
+    :user:`rwedge`, :user:`thehomebrewnerd`
 
 
 v1.5.0 Feb 14, 2022

--- a/featuretools/tests/entityset_tests/test_serialization.py
+++ b/featuretools/tests/entityset_tests/test_serialization.py
@@ -20,7 +20,7 @@ from featuretools.utils.gen_utils import Library
 BUCKET_NAME = "test-bucket"
 WRITE_KEY_NAME = "test-key"
 TEST_S3_URL = "s3://{}/{}".format(BUCKET_NAME, WRITE_KEY_NAME)
-TEST_FILE = "test_serialization_data_entityset_schema_{}_2021_10_28.tar".format(SCHEMA_VERSION)
+TEST_FILE = "test_serialization_data_entityset_schema_{}_2022_2_16.tar".format(SCHEMA_VERSION)
 S3_URL = "s3://featuretools-static/" + TEST_FILE
 URL = "https://featuretools-static.s3.amazonaws.com/" + TEST_FILE
 TEST_KEY = "test_access_key_es"

--- a/featuretools/tests/primitive_tests/test_feature_serialization.py
+++ b/featuretools/tests/primitive_tests/test_feature_serialization.py
@@ -43,7 +43,7 @@ from featuretools.tests.testing_utils import check_names
 BUCKET_NAME = "test-bucket"
 WRITE_KEY_NAME = "test-key"
 TEST_S3_URL = "s3://{}/{}".format(BUCKET_NAME, WRITE_KEY_NAME)
-TEST_FILE = "test_feature_serialization_feature_schema_{}_entityset_schema_{}_2022_01_27.json".format(SCHEMA_VERSION, ENTITYSET_SCHEMA_VERSION)
+TEST_FILE = "test_feature_serialization_feature_schema_{}_entityset_schema_{}_2022_2_16.json".format(SCHEMA_VERSION, ENTITYSET_SCHEMA_VERSION)
 S3_URL = "s3://featuretools-static/" + TEST_FILE
 URL = "https://featuretools-static.s3.amazonaws.com/" + TEST_FILE
 TEST_CONFIG = "CheckConfigPassesOn"


### PR DESCRIPTION
The newest woodwork version handles LatLong nans slightly differently and requires a new file in order to deserialize to the same entityset as the tests expect.  This new file will work with older version of woodwork as well.