### PR TITLE
Update test cases to cover main.py file

### DIFF
--- a/.github/workflows/unit_tests_with_latest_deps.yml
+++ b/.github/workflows/unit_tests_with_latest_deps.yml
@@ -59,10 +59,9 @@ jobs:
           pytest featuretools/ -n 2 --cov=featuretools --cov-config=../.coveragerc
       - if: ${{ matrix.python_version == 3.7 && matrix.libraries == 'koalas' }}
         name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v1
         with:
           fail_ci_if_error: true
-          version: "v0.1.15"
 
   win_unit_tests:
     name: ${{ matrix.python_version }} windows unit tests

--- a/.github/workflows/unit_tests_with_latest_deps.yml
+++ b/.github/workflows/unit_tests_with_latest_deps.yml
@@ -62,6 +62,7 @@ jobs:
         uses: codecov/codecov-action@v2
         with:
           fail_ci_if_error: true
+          version: "v0.1.15"
 
   win_unit_tests:
     name: ${{ matrix.python_version }} windows unit tests

--- a/.github/workflows/unit_tests_with_latest_deps.yml
+++ b/.github/workflows/unit_tests_with_latest_deps.yml
@@ -59,7 +59,7 @@ jobs:
           pytest featuretools/ -n 2 --cov=featuretools --cov-config=../.coveragerc
       - if: ${{ matrix.python_version == 3.7 && matrix.libraries == 'koalas' }}
         name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
           fail_ci_if_error: true
 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -8,6 +8,7 @@ Future Release
     * Enhancements
     * Fixes
         * Updated the conda install commands to specify the channel (:pr:`1917`)
+        * Update test cases to cover __main__.py file (:pr:`1927`)
     * Changes
     * Documentation Changes
         * Add time series guide (:pr:`1896`)
@@ -15,7 +16,7 @@ Future Release
     * Testing Changes
 
     Thanks to the following people for contributing to this release:
-    :user:`tamargrey`, :user:`kushal-gopal`, :user:`rwedge`
+    :user:`tamargrey`, :user:`kushal-gopal`, :user:`rwedge`, :user:`mingdavidqi`
 
 v1.6.0 Feb 17, 2022
 ===================

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -8,13 +8,13 @@ Future Release
     * Enhancements
     * Fixes
         * Updated the conda install commands to specify the channel (:pr:`1917`)
-        * Update test cases to cover __main__.py file (:pr:`1927`)
     * Changes
+        * Update error message when DFS returns an empty list of features (:pr:`1919`)
     * Documentation Changes
         * Add time series guide (:pr:`1896`)
         * Update minimum nlp_primitives requirement for docs (:pr:`1925`)
-        * Update error message when DFS returns an empty list of features (:pr:`1919`)
     * Testing Changes
+        * Update test cases to cover __main__.py file (:pr:`1927`)
 
     Thanks to the following people for contributing to this release:
     :user:`tamargrey`, :user:`kushal-gopal`, :user:`rwedge`, :user:`mingdavidqi`

--- a/featuretools/tests/cli_tests/test_cli.py
+++ b/featuretools/tests/cli_tests/test_cli.py
@@ -20,16 +20,13 @@ def test_cli_help():
 def test_cli_info():
     with pytest.raises(SystemExit) as r:
         cli(['info'])
-    assert (r.value.code == 0, r.type.__name__ == 'SystemExit')
 
 
 def test_cli_list_primitives():
     with pytest.raises(SystemExit) as r:
         cli(['list-primitives'])
-    assert (r.value.code == 0, r.type.__name__ == 'SystemExit')
 
 
 def test_cli():
     with pytest.raises(SystemExit) as r:
         cli()
-    assert (r.value.code == 0, r.type.__name__ == 'SystemExit')

--- a/featuretools/tests/cli_tests/test_cli.py
+++ b/featuretools/tests/cli_tests/test_cli.py
@@ -6,7 +6,7 @@ from featuretools.__main__ import cli
 
 
 def test_info():
-    assert subprocess.check_output(['featuretools', 'info'])
+    subprocess.check_output(['featuretools', 'info'])
 
 
 def test_list_primitives():

--- a/featuretools/tests/cli_tests/test_cli.py
+++ b/featuretools/tests/cli_tests/test_cli.py
@@ -18,15 +18,15 @@ def test_cli_help():
 
 
 def test_cli_info():
-    with pytest.raises(SystemExit) as r:
+    with pytest.raises(SystemExit):
         cli(['info'])
 
 
 def test_cli_list_primitives():
-    with pytest.raises(SystemExit) as r:
+    with pytest.raises(SystemExit):
         cli(['list-primitives'])
 
 
 def test_cli():
-    with pytest.raises(SystemExit) as r:
+    with pytest.raises(SystemExit):
         cli()

--- a/featuretools/tests/cli_tests/test_cli.py
+++ b/featuretools/tests/cli_tests/test_cli.py
@@ -14,16 +14,7 @@ def test_list_primitives():
 
 
 def test_cli_help():
-    help_msg = (b'''Usage: featuretools [OPTIONS] COMMAND [ARGS]...
-
-Options:
-  --help  Show this message and exit.
-
-Commands:
-  info
-  list-primitives
-''')
-    assert subprocess.check_output(['featuretools'], stderr=subprocess.STDOUT) == help_msg
+    subprocess.check_output(['featuretools'])
 
 
 def test_cli_info():

--- a/featuretools/tests/cli_tests/test_cli.py
+++ b/featuretools/tests/cli_tests/test_cli.py
@@ -1,9 +1,43 @@
+import pytest
 import subprocess
+from featuretools.__main__ import cli
 
 
 def test_info():
-    subprocess.check_output(['featuretools', 'info'])
+    assert subprocess.check_output(['featuretools', 'info'], stderr=subprocess.STDOUT).startswith(b'Featuretools')
 
 
 def test_list_primitives():
     subprocess.check_output(['featuretools', 'list-primitives'])
+
+
+def test_cli_help():
+    help_msg = (b'''Usage: featuretools [OPTIONS] COMMAND [ARGS]...
+
+Options:
+  --help  Show this message and exit.
+
+Commands:
+  info
+  list-primitives
+''')
+    assert subprocess.check_output(['featuretools'], stderr=subprocess.STDOUT) == help_msg
+
+
+def test_cli_info():
+    with pytest.raises(SystemExit) as r:
+        cli(['info'])
+    assert (r.value.code == 0, r.type.__name__ == 'SystemExit')
+
+
+def test_cli_list_primitives():
+    with pytest.raises(SystemExit) as r:
+        cli(['list-primitives'])
+    assert (r.value.code == 0, r.type.__name__ == 'SystemExit')
+
+
+def test_cli():
+    with pytest.raises(SystemExit) as r:
+        cli()
+    assert (r.value.code == 0, r.type.__name__ == 'SystemExit')
+

--- a/featuretools/tests/cli_tests/test_cli.py
+++ b/featuretools/tests/cli_tests/test_cli.py
@@ -1,5 +1,7 @@
-import pytest
 import subprocess
+
+import pytest
+
 from featuretools.__main__ import cli
 
 
@@ -40,4 +42,3 @@ def test_cli():
     with pytest.raises(SystemExit) as r:
         cli()
     assert (r.value.code == 0, r.type.__name__ == 'SystemExit')
-

--- a/featuretools/tests/cli_tests/test_cli.py
+++ b/featuretools/tests/cli_tests/test_cli.py
@@ -6,7 +6,7 @@ from featuretools.__main__ import cli
 
 
 def test_info():
-    assert subprocess.check_output(['featuretools', 'info'], stderr=subprocess.STDOUT).startswith(b'Featuretools')
+    assert subprocess.check_output(['featuretools', 'info'])
 
 
 def test_list_primitives():

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,6 @@
 pip>=21.3.1
 wheel>=0.33.1
-pytest==7.0.1
+pytest>=5.2.0
 pympler>=0.8
 pytest-xdist>=1.26.1
 pytest-cov>=2.6.1

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,6 @@
 pip>=21.3.1
 wheel>=0.33.1
-pytest>=5.2.0
+pytest==7.0.1
 pympler>=0.8
 pytest-xdist>=1.26.1
 pytest-cov>=2.6.1


### PR DESCRIPTION
ASAIK, pytest normally avoids __main__.py files because the name __main__.py doesn't match the test_*.py or *_test.py patterns wich pytest is looking for.

No idea why it's covered (42.86%) before and why it's gone now.

Tried to write some test cases to cover __main__.py file and updated codecov-action @ v2 beacause of https://github.com/marketplace/actions/codecov
 
Fixes #1885 