### PR TITLE
Add GitHub URL for PyPi in setup.py

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -17,7 +17,7 @@ Future Release
     * Testing Changes
 
     Thanks to the following people for contributing to this release:
-    :user:`tamargrey`, :user:`kushal-gopal`, :user:`rwedge`, :user:`mingdavidqi`
+    :user:`tamargrey`, :user:`kushal-gopal`, :user:`rwedge`, :user:`mingdavidqi`, :user:`andriyor`
 
 v1.6.0 Feb 17, 2022
 ===================

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -13,6 +13,7 @@ Future Release
         * Add time series guide (:pr:`1896`)
         * Update minimum nlp_primitives requirement for docs (:pr:`1925`)
         * Update error message when DFS returns an empty list of features (:pr:`1919`)
+        * Add GitHub URL for PyPi (:pr:`1928`)
     * Testing Changes
 
     Thanks to the following people for contributing to this release:

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
     description="a framework for automated feature engineering",
     url="https://featuretools.com",
     project_urls={
+        "Documentation": "https://featuretools.alteryx.com",
         "Source": "https://github.com/alteryx/featuretools",
     },
     license="BSD 3-clause",

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,9 @@ setup(
     packages=find_packages(),
     description="a framework for automated feature engineering",
     url="https://featuretools.com",
+    project_urls={
+        "Source": "https://github.com/alteryx/featuretools",
+    },
     license="BSD 3-clause",
     author="Feature Labs, Inc.",
     author_email="open_source_support@alteryx.com",


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)