### PR TITLE
Add min version for wheel and limit lint CI tests to Python 3.10 only

### DIFF
--- a/.github/workflows/lint_check.yml
+++ b/.github/workflows/lint_check.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: "3.10"
+        python_version: ["3.10"]
     steps:
       - name: Set up python ${{ matrix.python_version }}
         uses: actions/setup-python@v2

--- a/.github/workflows/lint_check.yml
+++ b/.github/workflows/lint_check.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: ["3.7", "3.8", "3.9", "3.10"]
+        python_version: "3.10"
     steps:
       - name: Set up python ${{ matrix.python_version }}
         uses: actions/setup-python@v2

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -22,6 +22,7 @@ Future Release
         * Upgrade moto requirement (:pr:`1929`, :pr:`1938`)
         * Add Python 3.9 linting, install complete, and docs build CI tests (:pr:`1934`)
         * Add support for Python 3.10 (:pr:`1940`)
+        * Add lower bound for wheel for minimum dependency checker and limit lint CI tests to Python 3.10 (:pr:`1945`)
 
     Thanks to the following people for contributing to this release:
     :user:`tamargrey`, :user:`kushal-gopal`, :user:`rwedge`, :user:`mingdavidqi`, :user:`andriyor`, :user:`thehomebrewnerd`

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ install_requires =
     holidays >= 0.13
 setup_requires = 
     setuptools >= 47
-    wheel
+    wheel >= 0.37.0
 python_requires = >=3.7, <4
 
 [options.extras_require]


### PR DESCRIPTION
### Add min version for wheel and limit lint CI tests to Python 3.10 only

Closes #1944 