### PR TITLE
Remove wheel from setup_requires

### DIFF
--- a/.github/workflows/install_test.yml
+++ b/.github/workflows/install_test.yml
@@ -24,11 +24,11 @@ jobs:
         uses: actions/checkout@v2
       - name: Build featuretools package
         run: make package_featuretools
-      - name: Install complete version of featuretools
+      - name: Install complete version of featuretools from sdist
         run: |
           pip config --site set global.progress_bar off
           python -m pip install --upgrade pip
-          python -m pip install -e unpacked_sdist/[complete]
+          python -m pip install unpacked_sdist/[complete]
       - name: Test by importing packages
         run: |
           python -c "import alteryx_open_src_update_checker"

--- a/.github/workflows/install_test.yml
+++ b/.github/workflows/install_test.yml
@@ -27,7 +27,6 @@ jobs:
       - name: Install complete version of featuretools from sdist
         run: |
           pip config --site set global.progress_bar off
-          python -m pip install --upgrade pip
           python -m pip install unpacked_sdist/[complete]
       - name: Test by importing packages
         run: |

--- a/Makefile
+++ b/Makefile
@@ -34,9 +34,17 @@ checkdeps:
 	$(eval allow_list='holidays|scipy|numpy|pandas|tqdm|cloudpickle|distributed|dask|psutil|click|pyspark|koalas|woodwork')
 	pip freeze | grep -v "alteryx/featuretools.git" | grep -E $(allow_list) > $(OUTPUT_PATH)
 
+.PHONY: upgradepip
+upgradepip:
+	python -m pip install --upgrade pip
+
+.PHONY: upgradebuild
+upgradebuild:
+	python -m pip install --upgrade build
+
 .PHONY: package_featuretools
-package_featuretools:
-	python setup.py sdist
-	$(eval FT_VERSION=$(shell python setup.py --version))
+package_featuretools: upgradepip upgradebuild
+	python -m build
+	$(eval FT_VERSION := $(shell grep '__version__\s=' featuretools/version.py | grep -o '[^ ]*$$'))
 	tar -zxvf "dist/featuretools-${FT_VERSION}.tar.gz"
 	mv "featuretools-${FT_VERSION}" unpacked_sdist

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -11,7 +11,7 @@ Future Release
     * Changes
         * Update error message when DFS returns an empty list of features (:pr:`1919`)
         * Remove ``list_variable_types`` and related directories (:pr:`1929`)
-        * Transition to use pyproject.toml and setup.cfg (moving away from setup.py) (:pr:`1941`)
+        * Transition to use pyproject.toml and setup.cfg (moving away from setup.py) (:pr:`1941`, :pr:`1950`)
     * Documentation Changes
         * Add time series guide (:pr:`1896`)
         * Update minimum nlp_primitives requirement for docs (:pr:`1925`)

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,6 @@ install_requires =
     holidays >= 0.13
 setup_requires = 
     setuptools >= 47
-    wheel >= 0.37.0
 python_requires = >=3.7, <4
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,8 +48,6 @@ install_requires =
     click >= 7.0.0
     woodwork >= 0.8.1
     holidays >= 0.13
-setup_requires = 
-    setuptools >= 47
 python_requires = >=3.7, <4
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -115,9 +115,6 @@ complete =
     * __pycache__
     *.py[co]
 
-[bdist_wheel]
-universal = 1
-
 [options.entry_points]
 console_scripts =
     featuretools = featuretools.__main__:cli


### PR DESCRIPTION
Need to remove `wheel` from `setup_requires` in `setup.cfg` as this will cause issues with building distribution with `python -m build`. 
