### PR TITLE
Remove setup_requires from minimum dependency generator yaml file

### DIFF
--- a/.github/workflows/minimum_dependency_checker.yml
+++ b/.github/workflows/minimum_dependency_checker.yml
@@ -19,7 +19,7 @@ jobs:
         uses: alteryx/minimum-dependency-generator@v3.1
         with:
           paths: 'setup.cfg'
-          options: 'install_requires setup_requires'
+          options: 'install_requires'
           extras_require: 'test'
       - name: Save min test deps and run diff
         id: check_min_test
@@ -37,7 +37,7 @@ jobs:
         uses: alteryx/minimum-dependency-generator@v3.1
         with:
           paths: 'setup.cfg'
-          options: 'install_requires setup_requires'
+          options: 'install_requires'
       - name: Save min core deps and run diff
         id: check_core_deps
         continue-on-error: true
@@ -53,7 +53,7 @@ jobs:
         uses: alteryx/minimum-dependency-generator@v3.1
         with:
           paths: 'setup.cfg'
-          options: 'install_requires setup_requires'
+          options: 'install_requires'
           extras_require: 'koalas'
       - name: Save min koalas deps and run diff
         id: check_koalas_deps

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -11,7 +11,7 @@ Future Release
     * Changes
         * Update error message when DFS returns an empty list of features (:pr:`1919`)
         * Remove ``list_variable_types`` and related directories (:pr:`1929`)
-        * Transition to use pyproject.toml and setup.cfg (moving away from setup.py) (:pr:`1941`, :pr:`1950`)
+        * Transition to use pyproject.toml and setup.cfg (moving away from setup.py) (:pr:`1941`, :pr:`1950`, :pr:`1952`)
     * Documentation Changes
         * Add time series guide (:pr:`1896`)
         * Update minimum nlp_primitives requirement for docs (:pr:`1925`)


### PR DESCRIPTION
The minimum dependency generator was attempting to use `setup_requires` from `setup.cfg` but this section was removed in #1950 which resulted in a key error in the workflow.
