### PR TITLE
Update release.yml to use upload action v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: PyPI Upload
-      uses: FeatureLabs/gh-action-pypi-upload@v1
+      uses: FeatureLabs/gh-action-pypi-upload@v2
       env:
         PYPI_USERNAME: ${{ secrets.PYPI_USERNAME }}
         PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -11,7 +11,7 @@ Future Release
     * Changes
         * Update error message when DFS returns an empty list of features (:pr:`1919`)
         * Remove ``list_variable_types`` and related directories (:pr:`1929`)
-        * Transition to use pyproject.toml and setup.cfg (moving away from setup.py) (:pr:`1941`, :pr:`1950`, :pr:`1952`)
+        * Transition to use pyproject.toml and setup.cfg (moving away from setup.py) (:pr:`1941`, :pr:`1950`, :pr:`1952`, :pr:`1954`)
     * Documentation Changes
         * Add time series guide (:pr:`1896`)
         * Update minimum nlp_primitives requirement for docs (:pr:`1925`)


### PR DESCRIPTION
Updates `release.yml` to use the newly released v2 of `gh-action-pypi-upload`
