### PR TITLE
Update Makefile command for zsh compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,9 +25,8 @@ testcoverage:
 	pytest featuretools/ --cov=featuretools
 
 .PHONY: installdeps
-installdeps:
-	pip install --upgrade pip
-	pip install -e .[dev]
+installdeps: upgradepip
+	pip install -e ".[dev]"
 
 .PHONY: checkdeps
 checkdeps:


### PR DESCRIPTION
Update `pip install -e .[dev]` to `pip install -e ".[dev]"` so that `make installdeps` will work with zsh.