### PR TITLE
Fix non-deterministic test in test_es.py

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -6,6 +6,7 @@ Release Notes
 Future Release
 ==============
     * Enhancements
+        * Add support for Python 3.10 (:pr:`1940`)
         * Added the SquareRoot, NaturalLogarithm, Sine, Cosine and Tangent primitives (:pr:`1948`)
     * Fixes
         * Updated the conda install commands to specify the channel (:pr:`1917`)
@@ -24,8 +25,8 @@ Future Release
         * Upgrade moto requirement (:pr:`1929`, :pr:`1938`)
         * Add Python 3.9 linting, install complete, and docs build CI tests (:pr:`1934`)
         * Add CI workflow to test with latest woodwork main branch (:pr:`1936`)
-        * Add support for Python 3.10 (:pr:`1940`)
         * Add lower bound for wheel for minimum dependency checker and limit lint CI tests to Python 3.10 (:pr:`1945`)
+        * Fix non-deterministic test in ``test_es.py`` (:pr:`1961`)
 
     Thanks to the following people for contributing to this release:
     :user:`jeff-hernandez`, :user:`tamargrey`, :user:`kushal-gopal`, :user:`rwedge`, :user:`mingdavidqi`, :user:`andriyor`, :user:`thehomebrewnerd`, :user:`tvdboom`

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -409,8 +409,8 @@ def test_query_by_indexed_column(es):
         dataframe_name='log',
         instance_vals=['taco clock'],
         column_name='product_id')
-    df = to_pandas(df)
-
+    # Account for different ordering between pandas and dask/spark
+    df = to_pandas(df).reset_index(drop=True).sort_values('id')
     assert list(df['id'].values) == [15, 16]
 
 


### PR DESCRIPTION
Fix non-deterministic test in `test_es.py`. Failure showed up after switching from Koalas to the pyspark pandas API and failed because rows were returned in a different order with spark.
