### PR TITLE
Conditionally run scheduled workflows

### DIFF
--- a/.github/workflows/auto_approve_dependency_PRs.yml
+++ b/.github/workflows/auto_approve_dependency_PRs.yml
@@ -12,6 +12,7 @@ on:
       - completed
 jobs:
   build:
+    if: ${{ github.repository_owner == 'alteryx' }}
     runs-on: ubuntu-latest
     steps:
       - name: Find dependency PRs

--- a/.github/workflows/latest_dependency_checker.yml
+++ b/.github/workflows/latest_dependency_checker.yml
@@ -8,6 +8,7 @@ on:
   workflow_dispatch:
 jobs:
   build:
+    if: ${{ github.repository_owner == 'alteryx' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test_with_woodwork_main_branch.yml
+++ b/.github/workflows/test_with_woodwork_main_branch.yml
@@ -5,6 +5,7 @@ on:
   workflow_dispatch:
 jobs:
   scheduled_unit_latest_tests:
+    if: ${{ github.repository_owner == 'alteryx' }}
     name: ${{ matrix.python_version }} unit tests ${{ matrix.libraries }}
     runs-on: ubuntu-latest
     strategy:

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,15 +3,17 @@
 Release Notes
 -------------
 
-.. Future Release
-  ==============
+Future Release
+==============
     * Enhancements
     * Fixes
     * Changes
     * Documentation Changes
     * Testing Changes
+        * Updated scheduled workflows to only run on Alteryx owned repos (:pr:`1973`)
 
-.. Thanks to the following people for contributing to this release:
+    Thanks to the following people for contributing to this release:
+    :user:`thehomebrewnerd`
 
 v1.7.0 Mar 16, 2022
 ===================


### PR DESCRIPTION
### Conditionally run scheduled workflows

Closes #1955 

Update scheduled workflows to run only if repository_owner is alteryx. This should prevent these scheduled workflows from running on repo forks and failing repeatedly.
