### PR TITLE
Update makefile package command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,6 @@ upgradebuild:
 .PHONY: package_featuretools
 package_featuretools: upgradepip upgradebuild
 	python -m build
-	$(eval FT_VERSION := $(shell grep '__version__\s=' featuretools/version.py | grep -o '[^ ]*$$'))
+	$(eval FT_VERSION := $(python -c "from pep517.meta import load; metadata = load('.'); print(metadata.version)"))
 	tar -zxvf "dist/featuretools-${FT_VERSION}.tar.gz"
 	mv "featuretools-${FT_VERSION}" unpacked_sdist


### PR DESCRIPTION
### Update makefile package command

Update the way we get the Featuretools verison in `make package_featuretools` to be consistent with how we extract the version number during releases.