### PR TITLE
Update to fix broken tests and doc builds

### DIFF
--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -156,9 +156,7 @@ def test_add_relationship_diff_param_logical_types(es):
     assert isinstance(es['sessions'].ww.logical_types['id'], Ordinal)
     assert es['sessions'].ww.logical_types['id'] != es['log2'].ww.logical_types['session_id']
 
-    warning_text = 'Logical type Ordinal for child column session_id does not match parent '\
-        'column id logical type Ordinal. There is a conflict between the parameters. '\
-        'Changing child logical type to match parent.'
+    warning_text = 'Changing child logical type to match parent.'
     with pytest.warns(UserWarning, match=warning_text):
         es.add_relationship(u'sessions', 'id', 'log2', 'session_id')
     assert isinstance(es['log2'].ww.logical_types['product_id'], Categorical)

--- a/featuretools/tests/primitive_tests/test_primitive_utils.py
+++ b/featuretools/tests/primitive_tests/test_primitive_utils.py
@@ -17,6 +17,7 @@ from featuretools.primitives import (
     Min,
     Mode,
     Month,
+    MultiplyNumeric,
     NumCharacters,
     NumUnique,
     NumWords,
@@ -32,6 +33,7 @@ from featuretools.primitives import (
     get_transform_primitives
 )
 from featuretools.primitives.base import PrimitiveBase
+from featuretools.primitives.standard.binary_transform import MultiplyNumeric
 from featuretools.primitives.utils import (
     _apply_roll_with_offset_gap,
     _get_descriptions,
@@ -68,10 +70,10 @@ def test_list_primitives_order():
 def test_valid_input_types():
     actual = _get_unique_input_types(Haversine.input_types)
     assert actual == {'<ColumnSchema (Logical Type = LatLong)>'}
-    actual = _get_unique_input_types(GreaterThan.input_types)
-    assert actual == {'<ColumnSchema (Logical Type = Datetime)>',
-                      "<ColumnSchema (Semantic Tags = ['numeric'])>",
-                      '<ColumnSchema (Logical Type = Ordinal)>'}
+    actual = _get_unique_input_types(MultiplyNumeric.input_types)
+    assert actual == {"<ColumnSchema (Semantic Tags = ['numeric'])>",
+                      '<ColumnSchema (Logical Type = Boolean)>',
+                      '<ColumnSchema (Logical Type = BooleanNullable)>'}
     actual = _get_unique_input_types(Sum.input_types)
     assert actual == {"<ColumnSchema (Semantic Tags = ['numeric'])>"}
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,6 +64,7 @@ dev =
     nbsphinx == 0.8.7
     pydata-sphinx-theme== 0.7.1
     Sphinx == 4.2.0
+    jinja2 == 3.0.3
     sphinx-inline-tabs == 2021.3.28b7; python_version == '3.7'
     sphinx-inline-tabs == 2022.1.2b11; python_version >= '3.8'
     sphinx-copybutton == 0.4.0


### PR DESCRIPTION
### Update to fix broken tests and doc builds

Updates tests to accommodate new repr for `Ordinal` logical type introduced in Woodwork version 0.15.0.

Also, pins `jinja2` version to fix docs build issue.