### PR TITLE
Update UnusedPrimitiveWarning text

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -6,6 +6,7 @@ Release Notes
 Future Release
 ==============
     * Enhancements
+        * Improve ``UnusedPrimitiveWarning`` with additional information (:pr:`2003`)
     * Fixes
     * Changes
         * Updated autonormalize version requirement (:pr:`2002`)
@@ -13,7 +14,7 @@ Future Release
     * Testing Changes
 
     Thanks to the following people for contributing to this release:
-    :user:`dvreed77`
+    :user:`dvreed77`, :user:`thehomebrewnerd`
 
 v1.8.0 Mar 31, 2022
 ===================

--- a/featuretools/synthesis/dfs.py
+++ b/featuretools/synthesis/dfs.py
@@ -314,7 +314,8 @@ def warn_unused_primitives(unused_primitives):
     warning_msg = (
         "Some specified primitives were not used during DFS:\n{}".format(unused_string)
         + "This may be caused by a using a value of max_depth that is too small, not setting interesting values, "
-        + "or it may indicate no compatible columns for the primitive were found in the data."
+        + "or it may indicate no compatible columns for the primitive were found in the data. If the DFS call "
+        + "contained multiple instances of a primitive in the list above, none of them were used."
     )
 
     warnings.warn(warning_msg, UnusedPrimitiveWarning)

--- a/featuretools/tests/synthesis/test_dfs_method.py
+++ b/featuretools/tests/synthesis/test_dfs_method.py
@@ -374,7 +374,8 @@ def test_warns_with_unused_primitives(es):
         "Some specified primitives were not used during DFS:\n"
         + "  trans_primitives: ['add_numeric']\n  agg_primitives: ['max', 'min']\n"
         + "This may be caused by a using a value of max_depth that is too small, not setting interesting values, "
-        + "or it may indicate no compatible columns for the primitive were found in the data."
+        + "or it may indicate no compatible columns for the primitive were found in the data. If the DFS call "
+        + "contained multiple instances of a primitive in the list above, none of them were used."
     )
 
     with pytest.warns(UnusedPrimitiveWarning) as record:
@@ -454,7 +455,8 @@ def test_warns_with_unused_where_primitives(es):
         "Some specified primitives were not used during DFS:\n"
         + "  where_primitives: ['count', 'sum']\n"
         + "This may be caused by a using a value of max_depth that is too small, not setting interesting values, "
-        + "or it may indicate no compatible columns for the primitive were found in the data."
+        + "or it may indicate no compatible columns for the primitive were found in the data. If the DFS call "
+        + "contained multiple instances of a primitive in the list above, none of them were used."
     )
 
     with pytest.warns(UnusedPrimitiveWarning) as record:
@@ -475,7 +477,8 @@ def test_warns_with_unused_groupby_primitives(pd_es):
         "Some specified primitives were not used during DFS:\n"
         + "  groupby_trans_primitives: ['cum_sum']\n"
         + "This may be caused by a using a value of max_depth that is too small, not setting interesting values, "
-        + "or it may indicate no compatible columns for the primitive were found in the data."
+        + "or it may indicate no compatible columns for the primitive were found in the data. If the DFS call "
+        + "contained multiple instances of a primitive in the list above, none of them were used."
     )
 
     with pytest.warns(UnusedPrimitiveWarning) as record:
@@ -514,7 +517,8 @@ def test_warns_with_unused_custom_primitives(pd_es):
         "Some specified primitives were not used during DFS:\n"
         + "  trans_primitives: ['above_ten']\n"
         + "This may be caused by a using a value of max_depth that is too small, not setting interesting values, "
-        + "or it may indicate no compatible columns for the primitive were found in the data."
+        + "or it may indicate no compatible columns for the primitive were found in the data. If the DFS call "
+        + "contained multiple instances of a primitive in the list above, none of them were used."
     )
 
     with pytest.warns(UnusedPrimitiveWarning) as record:
@@ -549,7 +553,8 @@ def test_warns_with_unused_custom_primitives(pd_es):
         "Some specified primitives were not used during DFS:\n"
         + "  agg_primitives: ['max_above_ten']\n"
         + "This may be caused by a using a value of max_depth that is too small, not setting interesting values, "
-        + "or it may indicate no compatible columns for the primitive were found in the data."
+        + "or it may indicate no compatible columns for the primitive were found in the data. If the DFS call "
+        + "contained multiple instances of a primitive in the list above, none of them were used."
     )
 
     with pytest.warns(UnusedPrimitiveWarning) as record:


### PR DESCRIPTION
### Update UnusedPrimitiveWarning text

Closes #1141 

Add clarifying text to UnusedPrimitiveWarning to explain behavior if multiple instances of a primitive are unused.