### PR TITLE
Update binary comparison primitives to properly handle ordinal comparisons

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -8,6 +8,7 @@ Future Release
     * Enhancements
         * Improve ``UnusedPrimitiveWarning`` with additional information (:pr:`2003`)
     * Fixes
+        * Fix issue with Ordinal inputs to binary comparison primitives (:pr:`2024`)
     * Changes
         * Updated autonormalize version requirement (:pr:`2002`)
         * Remove extra NaN checking in LatLong primitives (:pr:`1924`)

--- a/featuretools/primitives/standard/binary_transform.py
+++ b/featuretools/primitives/standard/binary_transform.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+import pandas.api.types as pdtypes
 from woodwork.column_schema import ColumnSchema
 from woodwork.logical_types import Boolean, BooleanNullable, Datetime, Ordinal
 
@@ -70,6 +71,11 @@ class GreaterThanScalar(TransformPrimitive):
 
     def get_function(self):
         def greater_than_scalar(vals):
+            if (
+                pdtypes.is_categorical_dtype(vals)
+                and self.value not in vals.cat.categories
+            ):
+                return np.nan
             return vals > self.value
 
         return greater_than_scalar
@@ -143,6 +149,11 @@ class GreaterThanEqualToScalar(TransformPrimitive):
 
     def get_function(self):
         def greater_than_equal_to_scalar(vals):
+            if (
+                pdtypes.is_categorical_dtype(vals)
+                and self.value not in vals.cat.categories
+            ):
+                return np.nan
             return vals >= self.value
 
         return greater_than_equal_to_scalar
@@ -214,6 +225,11 @@ class LessThanScalar(TransformPrimitive):
 
     def get_function(self):
         def less_than_scalar(vals):
+            if (
+                pdtypes.is_categorical_dtype(vals)
+                and self.value not in vals.cat.categories
+            ):
+                return np.nan
             return vals < self.value
 
         return less_than_scalar
@@ -287,6 +303,11 @@ class LessThanEqualToScalar(TransformPrimitive):
 
     def get_function(self):
         def less_than_equal_to_scalar(vals):
+            if (
+                pdtypes.is_categorical_dtype(vals)
+                and self.value not in vals.cat.categories
+            ):
+                return np.nan
             return vals <= self.value
 
         return less_than_equal_to_scalar

--- a/featuretools/tests/primitive_tests/test_transform_features.py
+++ b/featuretools/tests/primitive_tests/test_transform_features.py
@@ -1459,6 +1459,10 @@ def test_cfm_with_lag_and_non_nullable_column(pd_es):
 
 
 def test_comparisons_with_ordinal(es):
+    if es.dataframe_type == Library.SPARK.value:
+        pytest.xfail(
+            "Categorical dtypes not used in Spark, and comparison works as expected without error."
+        )
     valid_features = [
         ft.Feature(es["log"].ww["priority_level"]) > 1,
         ft.Feature(es["log"].ww["priority_level"]) >= 1,

--- a/featuretools/tests/primitive_tests/test_transform_features.py
+++ b/featuretools/tests/primitive_tests/test_transform_features.py
@@ -1456,3 +1456,36 @@ def test_cfm_with_lag_and_non_nullable_column(pd_es):
         .isnull()
         .all()
     )
+
+
+def test_comparisons_with_ordinal(es):
+    valid_features = [
+        ft.Feature(es["log"].ww["priority_level"]) > 1,
+        ft.Feature(es["log"].ww["priority_level"]) >= 1,
+        ft.Feature(es["log"].ww["priority_level"]) < 1,
+        ft.Feature(es["log"].ww["priority_level"]) <= 1,
+    ]
+    fm = ft.calculate_feature_matrix(
+        entityset=es,
+        features=valid_features,
+    )
+    feature_cols = [f.get_name() for f in valid_features]
+    fm = to_pandas(fm)
+    for col in feature_cols:
+        assert fm[col].notnull().any()
+
+    invalid_features = [
+        ft.Feature(es["log"].ww["priority_level"]) > 10,
+        ft.Feature(es["log"].ww["priority_level"]) >= 10,
+        ft.Feature(es["log"].ww["priority_level"]) < 10,
+        ft.Feature(es["log"].ww["priority_level"]) <= 10,
+    ]
+    fm = ft.calculate_feature_matrix(
+        entityset=es,
+        features=invalid_features,
+    )
+
+    feature_cols = [f.get_name() for f in invalid_features]
+    fm = to_pandas(fm)
+    for col in feature_cols:
+        assert fm[col].isnull().all()


### PR DESCRIPTION
### Update binary comparison primitives to properly handle ordinal comparisons

Closes #2021 

Updates the following primitives to return null values if the scalar value used for the comparison is not one of the Ordinal values:
- `GreaterThanScalar`
- `GreaterThanEqualToScalar`
- `LessThanScalar`
- `LessThanEqualToScalar`
