### PR TITLE
Limit woodwork <0.16.0

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -14,6 +14,7 @@ Future Release
         * Remove extra NaN checking in LatLong primitives (:pr:`1924`)
         * Normalize LatLong NaN values during EntitySet creation (:pr:`1924`)
         * Pass primitive dictionaries into ``check_primitive`` to avoid repetitive calls (:pr:`2016`)
+        * Temporarily restrict Woodwork version to <0.16.0 (:pr:`2029`)
     * Documentation Changes
         * Update README text to Alteryx (:pr:`2010`, :pr:`2015`)
     * Testing Changes

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ install_requires =
     dask[dataframe] >= 2021.10.0
     psutil >= 5.6.6
     click >= 7.0.0
-    woodwork >= 0.14.0
+    woodwork >= 0.14.0, <0.16.0
     holidays >= 0.13
 python_requires = >=3.7, <4
 


### PR DESCRIPTION
Temporarily limit Woodwork to `<0.16.0` while new failures introduced by the 0.16.0 release are investigated.
