### PR TITLE
Add MultiplyNumericBoolean primitive that allows for multiplication between a numeric an a boolean column

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -7,6 +7,7 @@ Future Release
 ==============
     * Enhancements
         * Improve ``UnusedPrimitiveWarning`` with additional information (:pr:`2003`)
+        * Add ``MultiplyNumericBoolean`` primitive (:pr:`2035`)
     * Fixes
         * Fix issue with Ordinal inputs to binary comparison primitives (:pr:`2024`, :pr:`2025`)
     * Changes

--- a/featuretools/feature_base/feature_base.py
+++ b/featuretools/feature_base/feature_base.py
@@ -319,7 +319,7 @@ class FeatureBase(object):
         if isinstance(other, FeatureBase):
             if all(
                 [
-                    isinstance(f.column_schema.logical_type, (Boolean, BooleanNullable))
+                    isinstance(f.column_schema.logical_type, (Boolean))
                     for f in (self, other)
                 ]
             ):

--- a/featuretools/feature_base/feature_base.py
+++ b/featuretools/feature_base/feature_base.py
@@ -1,5 +1,5 @@
 from woodwork.column_schema import ColumnSchema
-from woodwork.logical_types import Boolean
+from woodwork.logical_types import Boolean, BooleanNullable
 
 from featuretools import primitives
 from featuretools.entityset.relationship import Relationship, RelationshipPath
@@ -319,7 +319,7 @@ class FeatureBase(object):
         if isinstance(other, FeatureBase):
             if all(
                 [
-                    isinstance(f.column_schema.logical_type, Boolean)
+                    isinstance(f.column_schema.logical_type, (Boolean, BooleanNullable))
                     for f in (self, other)
                 ]
             ):

--- a/featuretools/feature_base/feature_base.py
+++ b/featuretools/feature_base/feature_base.py
@@ -319,11 +319,24 @@ class FeatureBase(object):
         if isinstance(other, FeatureBase):
             if all(
                 [
-                    isinstance(f.column_schema.logical_type, (Boolean))
+                    isinstance(f.column_schema.logical_type, (Boolean, BooleanNullable))
                     for f in (self, other)
                 ]
             ):
                 return Feature([self, other], primitive=primitives.MultiplyBoolean)
+            if (
+                "numeric" in self.column_schema.semantic_tags
+                and isinstance(
+                    other.column_schema.logical_type, (Boolean, BooleanNullable)
+                )
+                or "numeric" in other.column_schema.semantic_tags
+                and isinstance(
+                    self.column_schema.logical_type, (Boolean, BooleanNullable)
+                )
+            ):
+                return Feature(
+                    [self, other], primitive=primitives.MultiplyNumericBoolean
+                )
         return self._handle_binary_comparision(
             other, primitives.MultiplyNumeric, primitives.MultiplyNumericScalar
         )

--- a/featuretools/primitives/standard/binary_transform.py
+++ b/featuretools/primitives/standard/binary_transform.py
@@ -797,6 +797,42 @@ class MultiplyBoolean(TransformPrimitive):
         return "%s * %s" % (base_feature_names[0], base_feature_names[1])
 
 
+class MultiplyNumericBoolean(TransformPrimitive):
+    """Element-wise multiplication of a numeric list with a boolean list.
+
+    Description:
+        Given a list of numeric values X and a list of 
+        boolean values Y, return the values in X where
+        the corresponding value in Y is True.
+
+    Examples:
+        >>> multiply_numeric_boolean = MultiplyNumericBoolean()
+        >>> multiply_numeric([2, 1, 2], [True, True, False]).tolist()
+        [2, 1, 0]
+    """
+
+    name = "multiply_numeric_boolean"
+    input_types = [
+        [ColumnSchema(semantic_tags={"numeric"}), ColumnSchema(logical_type=BooleanNullable)],
+        [
+            ColumnSchema(semantic_tags={"numeric"}),
+            ColumnSchema(logical_type=Boolean),
+        ],
+    ]
+    return_type = ColumnSchema(semantic_tags={"numeric"})
+    compatibility = [Library.PANDAS, Library.DASK, Library.SPARK]
+    description_template = "the value of {} where {} is True"
+
+    def get_function(self):
+        def multiply_numeric_boolean(vals, mask):
+            breakpoint()
+            return vals.where(mask, mask.replace({False: 0}))
+        return multiply_numeric_boolean
+
+    def generate_name(self, base_feature_names):
+        return "%s * %s" % (base_feature_names[0], base_feature_names[1])
+
+
 class DivideNumeric(TransformPrimitive):
     """Element-wise division of two lists.
 

--- a/featuretools/primitives/standard/binary_transform.py
+++ b/featuretools/primitives/standard/binary_transform.py
@@ -823,7 +823,7 @@ class MultiplyNumericBoolean(TransformPrimitive):
         ],
     ]
     return_type = ColumnSchema(semantic_tags={"numeric"})
-    compatibility = [Library.PANDAS, Library.DASK, Library.SPARK]
+    compatibility = [Library.PANDAS, Library.DASK]
     commutative = True
     description_template = "the product of {} and {}"
 

--- a/featuretools/primitives/standard/binary_transform.py
+++ b/featuretools/primitives/standard/binary_transform.py
@@ -795,12 +795,12 @@ class MultiplyNumericBoolean(TransformPrimitive):
 
     Examples:
         >>> multiply_numeric_boolean = MultiplyNumericBoolean()
-        >>> multiply_numeric([2, 1, 2], [True, True, False]).tolist()
+        >>> multiply_numeric_boolean([2, 1, 2], [True, True, False]).tolist()
         [2, 1, 0]
-        >>> multiply_numeric([2, None, None], [True, True, False]).tolist()
+        >>> multiply_numeric_boolean([2, None, None], [True, True, False]).tolist()
         [2.0, nan, nan]
-        >>> multiply_numeric([2, 1, 2], [True, True, None]).tolist()
-        [2.0, 1, nan]
+        >>> multiply_numeric_boolean([2, 1, 2], [True, True, None]).tolist()
+        [2.0, 1.0, nan]
     """
 
     name = "multiply_numeric_boolean"

--- a/featuretools/primitives/standard/binary_transform.py
+++ b/featuretools/primitives/standard/binary_transform.py
@@ -813,13 +813,28 @@ class MultiplyNumericBoolean(TransformPrimitive):
             ColumnSchema(semantic_tags={"numeric"}),
             ColumnSchema(logical_type=BooleanNullable),
         ],
+        [
+            ColumnSchema(logical_type=Boolean),
+            ColumnSchema(semantic_tags={"numeric"}),
+        ],
+        [
+            ColumnSchema(logical_type=BooleanNullable),
+            ColumnSchema(semantic_tags={"numeric"}),
+        ],
     ]
     return_type = ColumnSchema(semantic_tags={"numeric"})
     compatibility = [Library.PANDAS, Library.DASK, Library.SPARK]
-    description_template = "the value of {} where {} is True"
+    commutative = True
+    description_template = "the product of {} and {}"
 
     def get_function(self):
-        def multiply_numeric_boolean(vals, mask):
+        def multiply_numeric_boolean(ser1, ser2):
+            if pdtypes.is_bool_dtype(ser1):
+                mask = ser1
+                vals = ser2
+            else:
+                mask = ser2
+                vals = ser1
             vals_not_null = vals.notnull()
             # Only apply mask where the input is not null
             mask = mask.where(vals_not_null)

--- a/featuretools/tests/primitive_tests/test_transform_features.py
+++ b/featuretools/tests/primitive_tests/test_transform_features.py
@@ -700,6 +700,8 @@ def test_boolean_multiply(boolean_mult_es):
     es = boolean_mult_es
     to_test = [
         ("numeric", "numeric"),
+        ("numeric", "bool"),
+        ("bool", "numeric"),
         ("bool", "bool"),
     ]
     features = []

--- a/featuretools/tests/primitive_tests/test_transform_features.py
+++ b/featuretools/tests/primitive_tests/test_transform_features.py
@@ -1568,3 +1568,22 @@ def test_comparisons_with_ordinal_valid_inputs_that_dont_work_but_should(pd_es):
     fm = to_pandas(fm)
     for col in feature_cols:
         assert fm[col].isnull().all()
+
+def test_multiply_numeric_boolean():
+    df = pd.DataFrame({
+    'id': [0, 1, 2],
+    'val_no_nan': [100, 200, 300],
+    'val_with_nan': [100, 200, pd.NA],
+    'mask_no_nan': [True, False, True],
+    'mask_with_nan': pd.Series([pd.NA, False, pd.NA], dtype='boolean'),
+    }) 
+
+    es = ft.EntitySet()
+    es.add_dataframe(dataframe_name="df", dataframe=df)
+    es["df"].ww.set_types(logical_types={'val_no_nan': 'Integer',
+                                     'val_with_nan': 'IntegerNullable',
+                                     'mask_no_nan': 'Boolean',
+                                     'mask_with_nan': 'BooleanNullable'})
+
+    fm, features = ft.dfs(entityset=es, target_dataframe_name="df", trans_primitives=["multiply_numeric_boolean"])
+    breakpoint()

--- a/featuretools/tests/primitive_tests/test_transform_features.py
+++ b/featuretools/tests/primitive_tests/test_transform_features.py
@@ -41,6 +41,7 @@ from featuretools.primitives import (
     LessThanScalar,
     Longitude,
     Mode,
+    MultiplyBoolean,
     MultiplyNumeric,
     MultiplyNumericBoolean,
     MultiplyNumericScalar,
@@ -1601,9 +1602,29 @@ def test_feature_multiplication(es):
     mult_numeric = numeric_ft * numeric_ft
     mult_boolean = boolean_ft * boolean_ft
     mult_numeric_boolean = numeric_ft * boolean_ft
-    breakpoint()
-    assert isinstance(type(mult_numeric), MultiplyNumeric)
 
-    # Should not work
-    invalid = boolean_ft * numeric_ft
-    breakpoint()
+    assert issubclass(type(mult_numeric.primitive), MultiplyNumeric)
+    assert issubclass(type(mult_boolean.primitive), MultiplyBoolean)
+    assert issubclass(type(mult_numeric_boolean.primitive), MultiplyNumericBoolean)
+
+    error_message = "Provided inputs don't match input type requirements"
+    with pytest.raises(AssertionError, match=error_message):
+        boolean_ft * numeric_ft
+
+    # Test with nullable types
+    es["customers"].ww.set_types(
+        logical_types={"age": "IntegerNullable", "loves_ice_cream": "BooleanNullable"}
+    )
+    numeric_ft = ft.Feature(es["customers"].ww["age"])
+    boolean_ft = ft.Feature(es["customers"].ww["loves_ice_cream"])
+    mult_numeric = numeric_ft * numeric_ft
+    mult_boolean = boolean_ft * boolean_ft
+    mult_numeric_boolean = numeric_ft * boolean_ft
+
+    assert issubclass(type(mult_numeric.primitive), MultiplyNumeric)
+    assert issubclass(type(mult_boolean.primitive), MultiplyBoolean)
+    assert issubclass(type(mult_numeric_boolean.primitive), MultiplyNumericBoolean)
+
+    error_message = "Provided inputs don't match input type requirements"
+    with pytest.raises(AssertionError, match=error_message):
+        boolean_ft * numeric_ft

--- a/featuretools/tests/primitive_tests/test_transform_features.py
+++ b/featuretools/tests/primitive_tests/test_transform_features.py
@@ -701,7 +701,6 @@ def test_boolean_multiply(boolean_mult_es):
     to_test = [
         ("numeric", "numeric"),
         ("numeric", "bool"),
-        ("bool", "numeric"),
         ("bool", "bool"),
     ]
     features = []

--- a/featuretools/tests/primitive_tests/test_transform_features.py
+++ b/featuretools/tests/primitive_tests/test_transform_features.py
@@ -701,6 +701,7 @@ def test_boolean_multiply(boolean_mult_es):
     to_test = [
         ("numeric", "numeric"),
         ("numeric", "bool"),
+        ("bool", "numeric"),
         ("bool", "bool"),
     ]
     features = []
@@ -1601,14 +1602,13 @@ def test_feature_multiplication(es):
     mult_numeric = numeric_ft * numeric_ft
     mult_boolean = boolean_ft * boolean_ft
     mult_numeric_boolean = numeric_ft * boolean_ft
+    mult_numeric_boolean2 = boolean_ft * numeric_ft
+
 
     assert issubclass(type(mult_numeric.primitive), MultiplyNumeric)
     assert issubclass(type(mult_boolean.primitive), MultiplyBoolean)
     assert issubclass(type(mult_numeric_boolean.primitive), MultiplyNumericBoolean)
-
-    error_message = "Provided inputs don't match input type requirements"
-    with pytest.raises(AssertionError, match=error_message):
-        boolean_ft * numeric_ft
+    assert issubclass(type(mult_numeric_boolean2.primitive), MultiplyNumericBoolean)
 
     # Test with nullable types
     es["customers"].ww.set_types(
@@ -1619,11 +1619,9 @@ def test_feature_multiplication(es):
     mult_numeric = numeric_ft * numeric_ft
     mult_boolean = boolean_ft * boolean_ft
     mult_numeric_boolean = numeric_ft * boolean_ft
+    mult_numeric_boolean2 = boolean_ft * numeric_ft
 
     assert issubclass(type(mult_numeric.primitive), MultiplyNumeric)
     assert issubclass(type(mult_boolean.primitive), MultiplyBoolean)
     assert issubclass(type(mult_numeric_boolean.primitive), MultiplyNumericBoolean)
-
-    error_message = "Provided inputs don't match input type requirements"
-    with pytest.raises(AssertionError, match=error_message):
-        boolean_ft * numeric_ft
+    assert issubclass(type(mult_numeric_boolean2.primitive), MultiplyNumericBoolean)

--- a/featuretools/tests/primitive_tests/test_transform_features.py
+++ b/featuretools/tests/primitive_tests/test_transform_features.py
@@ -1602,7 +1602,6 @@ def test_feature_multiplication(es):
     mult_numeric_boolean = numeric_ft * boolean_ft
     mult_numeric_boolean2 = boolean_ft * numeric_ft
 
-
     assert issubclass(type(mult_numeric.primitive), MultiplyNumeric)
     assert issubclass(type(mult_boolean.primitive), MultiplyBoolean)
     assert issubclass(type(mult_numeric_boolean.primitive), MultiplyNumericBoolean)


### PR DESCRIPTION
### Add MultiplyNumericBoolean primitive that allows for multiplication between a numeric an a boolean column

Replaces functionality that is removed in #2022 with a more appropriately named primitive.

Closes #2026 
