### PR TITLE
Fix Woodwork main install in test with WW main branch

### DIFF
--- a/.github/workflows/unit_tests_with_woodwork_main_branch.yml
+++ b/.github/workflows/unit_tests_with_woodwork_main_branch.yml
@@ -38,7 +38,8 @@ jobs:
       - name: Install Woodwork & Featuretools - test requirements
         run: |
           python -m pip install -e unpacked_sdist/[test]
-          python -m pip install --force-reinstall https://github.com/alteryx/woodwork/archive/main.zip
+          python -m pip uninstall -y woodwork
+          python -m pip install https://github.com/alteryx/woodwork/archive/main.zip
       - if: ${{ !( matrix.libraries == 'spark' && matrix.python_version == '3.10') }}
         name: Run unit tests without code coverage
         run: |

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -13,6 +13,7 @@ Future Release
         * Update slack invite link to new (:pr:`2044`)
     * Testing Changes
         * Skip test for ``normalize_dataframe`` due to different error coming from Woodwork in 0.16.3 (:pr:`2052`)
+        * Fix Woodwork install in test with Woodwork main branch (:pr:`2055`)
 
     Thanks to the following people for contributing to this release:
     :user:`gsheni`, :user:`thehomebrewnerd`


### PR DESCRIPTION
Updates how Woodwork is installed from main to prevent reinstalling other packages (like pandas) along with the Woodwork install.
