### PR TITLE
Update DateToHoliday and DistanceToHoliday primitives to work with timezone-aware inputs

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -6,6 +6,7 @@ Release Notes
 Future Release
 ==============
     * Enhancements
+        * Update ``DateToHoliday`` and ``DistanceToHoliday`` primitives to work with timezone-aware inputs (:pr:`2056`)
     * Fixes
     * Changes
         * Delete setup.py, MANIFEST.in and move configuration to pyproject.toml (:pr:`2046`)

--- a/featuretools/primitives/standard/datetime_transform_primitives.py
+++ b/featuretools/primitives/standard/datetime_transform_primitives.py
@@ -98,7 +98,7 @@ class DateToHoliday(TransformPrimitive):
         def date_to_holiday(x):
             holiday_df = self.holidayUtil.to_df()
             df = pd.DataFrame({"date": x})
-            df.date = df.date.dt.normalize().astype("datetime64")
+            df.date = df.date.dt.normalize().dt.date.astype("datetime64[ns]")
 
             df = df.merge(
                 holiday_df, how="left", left_on="date", right_on="holiday_date"
@@ -201,7 +201,7 @@ class DistanceToHoliday(TransformPrimitive):
             df["x_index"] = df.index  # store original index as a column
             df = df.dropna()
             df = df.sort_values("date")
-            df.date = df.date.dt.normalize()
+            df.date = df.date.dt.normalize().dt.date.astype("datetime64[ns]")
 
             matches = pd.merge_asof(
                 df,

--- a/featuretools/primitives/standard/datetime_transform_primitives.py
+++ b/featuretools/primitives/standard/datetime_transform_primitives.py
@@ -98,7 +98,7 @@ class DateToHoliday(TransformPrimitive):
         def date_to_holiday(x):
             holiday_df = self.holidayUtil.to_df()
             df = pd.DataFrame({"date": x})
-            df.date = df.date.dt.normalize().dt.date.astype("datetime64[ns]")
+            df["date"] = df["date"].dt.date.astype("datetime64[ns]")
 
             df = df.merge(
                 holiday_df, how="left", left_on="date", right_on="holiday_date"
@@ -201,7 +201,7 @@ class DistanceToHoliday(TransformPrimitive):
             df["x_index"] = df.index  # store original index as a column
             df = df.dropna()
             df = df.sort_values("date")
-            df.date = df.date.dt.normalize().dt.date.astype("datetime64[ns]")
+            df["date"] = df["date"].dt.date.astype("datetime64[ns]")
 
             matches = pd.merge_asof(
                 df,

--- a/featuretools/tests/primitive_tests/test_datetoholiday_primitive.py
+++ b/featuretools/tests/primitive_tests/test_datetoholiday_primitive.py
@@ -109,3 +109,26 @@ def test_multiple_countries():
     ]
     for x in countries:
         DateToHoliday(country=x)
+
+
+def test_with_timezone_aware_datetimes():
+    df = pd.DataFrame(
+        {
+            "non_timezone_aware_with_time": pd.date_range(
+                "2018-07-03 09:00", periods=3
+            ),
+            "non_timezone_aware_no_time": pd.date_range("2018-07-03", periods=3),
+            "timezone_aware_with_time": pd.date_range(
+                "2018-07-03 09:00", periods=3
+            ).tz_localize(tz="US/Eastern"),
+            "timezone_aware_no_time": pd.date_range(
+                "2018-07-03", periods=3
+            ).tz_localize(tz="US/Eastern"),
+        }
+    )
+
+    date_to_holiday = DateToHoliday(country="US")
+    expected = [np.nan, "Independence Day", np.nan]
+    for col in df.columns:
+        actual = date_to_holiday(df[col]).astype("str")
+        np.testing.assert_array_equal(actual, expected)

--- a/featuretools/tests/primitive_tests/test_distancetoholiday_primitive.py
+++ b/featuretools/tests/primitive_tests/test_distancetoholiday_primitive.py
@@ -80,3 +80,26 @@ def test_valid_country():
     answer = [143, -10, -70, 144]
     given_answer = distance_to_holiday(case).astype("float")
     np.testing.assert_array_equal(given_answer, answer)
+
+
+def test_with_timezone_aware_datetimes():
+    df = pd.DataFrame(
+        {
+            "non_timezone_aware_with_time": pd.date_range(
+                "2018-07-03 09:00", periods=3
+            ),
+            "non_timezone_aware_no_time": pd.date_range("2018-07-03", periods=3),
+            "timezone_aware_with_time": pd.date_range(
+                "2018-07-03 09:00", periods=3
+            ).tz_localize(tz="US/Eastern"),
+            "timezone_aware_no_time": pd.date_range(
+                "2018-07-03", periods=3
+            ).tz_localize(tz="US/Eastern"),
+        }
+    )
+
+    distance_to_holiday = DistanceToHoliday("Independence Day", country="US")
+    expected = [1, 0, -1]
+    for col in df.columns:
+        actual = distance_to_holiday(df[col])
+        np.testing.assert_array_equal(actual, expected)


### PR DESCRIPTION
This PR updates the `DateToHoliday` and `DistanceToHoliday` primitives to work with timezone-aware inputs and adds new tests to verify the correct answer is returned.
