### PR TITLE
Add feature origin to all feature matrix columns

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,15 +3,17 @@
 Release Notes
 -------------
 
-.. Future Release
-  ==============
+Future Release
+==============
     * Enhancements
     * Fixes
+        * Add feature origin information to all multi-output feature columns (:pr:`2102`)
     * Changes
     * Documentation Changes
     * Testing Changes
 
-.. Thanks to the following people for contributing to this release:
+    Thanks to the following people for contributing to this release:
+    :user:`thehomebrewnerd`
 
 v1.9.1 May 27, 2022
 ===================

--- a/featuretools/computational_backends/utils.py
+++ b/featuretools/computational_backends/utils.py
@@ -358,10 +358,10 @@ def get_ww_types_from_features(
 
             if logical_types[name] is None and "numeric" in semantic_tags[name]:
                 logical_types[name] = Double
-        if all([f.primitive is None for f in feature.get_dependencies(deep=True)]):
-            origins[name] = "base"
-        else:
-            origins[name] = "engineered"
+            if all([f.primitive is None for f in feature.get_dependencies(deep=True)]):
+                origins[name] = "base"
+            else:
+                origins[name] = "engineered"
 
     if pass_columns:
         cutoff_schema = cutoff_time.ww.schema


### PR DESCRIPTION
### Add feature origin to all feature matrix columns

Closes #2100 

Updates `get_ww_types_from_features` util function to make sure feature origins are added to all columns in a feature matrix. Previously, only the last column of a multi-output feature had the origin information added.
