### PR TITLE
Refactor feature serialization to avoid storing duplicate primitive information

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -7,7 +7,7 @@ Future Release
     * Enhancements
     * Fixes
     * Changes
-        * Improve serialization and deserialization to reduce storage of duplicate primitive information (:pr:`2136`)
+        * Improve serialization and deserialization to reduce storage of duplicate primitive information (:pr:`2136`, :pr:`2144`)
     * Documentation Changes
     * Testing Changes
 

--- a/featuretools/feature_base/feature_base.py
+++ b/featuretools/feature_base/feature_base.py
@@ -69,9 +69,7 @@ class FeatureBase(object):
         return FeatureOutputSlice(self, key)
 
     @classmethod
-    def from_dictionary(
-        cls, arguments, entityset, dependencies, primitive
-    ):
+    def from_dictionary(cls, arguments, entityset, dependencies, primitive):
         raise NotImplementedError("Must define from_dictionary on FeatureBase subclass")
 
     def rename(self, name):
@@ -450,9 +448,7 @@ class IdentityFeature(FeatureBase):
         )
 
     @classmethod
-    def from_dictionary(
-        cls, arguments, entityset, dependencies, primitive
-    ):
+    def from_dictionary(cls, arguments, entityset, dependencies, primitive):
         dataframe_name = arguments["dataframe_name"]
         column_name = arguments["column_name"]
         column = entityset[dataframe_name].ww[column_name]
@@ -543,9 +539,7 @@ class DirectFeature(FeatureBase):
         return relationship
 
     @classmethod
-    def from_dictionary(
-        cls, arguments, entityset, dependencies, primitive
-    ):
+    def from_dictionary(cls, arguments, entityset, dependencies, primitive):
         base_feature = dependencies[arguments["base_feature"]]
         relationship = Relationship.from_dictionary(
             arguments["relationship"], entityset
@@ -1008,9 +1002,7 @@ class FeatureOutputSlice(FeatureBase):
         }
 
     @classmethod
-    def from_dictionary(
-        cls, arguments, entityset, dependencies, primitive
-    ):
+    def from_dictionary(cls, arguments, entityset, dependencies, primitive):
         base_feature_name = arguments["base_feature"]
         base_feature = dependencies[base_feature_name]
         n = arguments["n"]

--- a/featuretools/feature_base/feature_base.py
+++ b/featuretools/feature_base/feature_base.py
@@ -710,9 +710,7 @@ class AggregationFeature(FeatureBase):
         return relationship_path, path_is_unique
 
     @classmethod
-    def from_dictionary(
-        cls, arguments, entityset, dependencies, primitives_deserializer
-    ):
+    def from_dictionary(cls, arguments, entityset, dependencies, primitive):
         base_features = [dependencies[name] for name in arguments["base_features"]]
         relationship_path = [
             Relationship.from_dictionary(r, entityset)
@@ -720,12 +718,6 @@ class AggregationFeature(FeatureBase):
         ]
         parent_dataframe_name = relationship_path[0].parent_dataframe.ww.name
         relationship_path = RelationshipPath([(False, r) for r in relationship_path])
-
-        primitive_key = arguments["primitive"]
-        primitive_dict = arguments["primitive_definitions"][primitive_key]
-        primitive = primitives_deserializer.deserialize_primitive(
-            primitive_dict, primitive_key
-        )
 
         use_previous_data = arguments["use_previous"]
         use_previous = use_previous_data and Timedelta.from_dictionary(
@@ -826,15 +818,9 @@ class TransformFeature(FeatureBase):
         )
 
     @classmethod
-    def from_dictionary(
-        cls, arguments, entityset, dependencies, primitives_deserializer
-    ):
+    def from_dictionary(cls, arguments, entityset, dependencies, primitive):
         base_features = [dependencies[name] for name in arguments["base_features"]]
-        primitive_key = arguments["primitive"]
-        primitive_dict = arguments["primitive_definitions"][primitive_key]
-        primitive = primitives_deserializer.deserialize_primitive(
-            primitive_dict, primitive_key
-        )
+
         feat = cls(
             base_features=base_features, primitive=primitive, name=arguments["name"]
         )
@@ -882,16 +868,8 @@ class GroupByTransformFeature(TransformFeature):
         )
 
     @classmethod
-    def from_dictionary(
-        cls, arguments, entityset, dependencies, primitives_deserializer
-    ):
+    def from_dictionary(cls, arguments, entityset, dependencies, primitive):
         base_features = [dependencies[name] for name in arguments["base_features"]]
-        primitive_key = arguments["primitive"]
-        primitive_dict = arguments["primitive_definitions"][primitive_key]
-        primitive = primitives_deserializer.deserialize_primitive(
-            primitive_dict,
-            primitive_key,
-        )
         groupby = dependencies[arguments["groupby"]]
         feat = cls(
             base_features=base_features,

--- a/featuretools/feature_base/feature_base.py
+++ b/featuretools/feature_base/feature_base.py
@@ -814,7 +814,6 @@ class TransformFeature(FeatureBase):
     @classmethod
     def from_dictionary(cls, arguments, entityset, dependencies, primitive):
         base_features = [dependencies[name] for name in arguments["base_features"]]
-
         feat = cls(
             base_features=base_features, primitive=primitive, name=arguments["name"]
         )

--- a/featuretools/feature_base/feature_base.py
+++ b/featuretools/feature_base/feature_base.py
@@ -70,7 +70,7 @@ class FeatureBase(object):
 
     @classmethod
     def from_dictionary(
-        cls, arguments, entityset, dependencies, primitives_deserializer
+        cls, arguments, entityset, dependencies, primitive
     ):
         raise NotImplementedError("Must define from_dictionary on FeatureBase subclass")
 
@@ -451,7 +451,7 @@ class IdentityFeature(FeatureBase):
 
     @classmethod
     def from_dictionary(
-        cls, arguments, entityset, dependencies, primitives_deserializer
+        cls, arguments, entityset, dependencies, primitive
     ):
         dataframe_name = arguments["dataframe_name"]
         column_name = arguments["column_name"]
@@ -544,7 +544,7 @@ class DirectFeature(FeatureBase):
 
     @classmethod
     def from_dictionary(
-        cls, arguments, entityset, dependencies, primitives_deserializer
+        cls, arguments, entityset, dependencies, primitive
     ):
         base_feature = dependencies[arguments["base_feature"]]
         relationship = Relationship.from_dictionary(
@@ -1009,7 +1009,7 @@ class FeatureOutputSlice(FeatureBase):
 
     @classmethod
     def from_dictionary(
-        cls, arguments, entityset, dependencies, primitives_deserializer
+        cls, arguments, entityset, dependencies, primitive
     ):
         base_feature_name = arguments["base_feature"]
         base_feature = dependencies[base_feature_name]

--- a/featuretools/feature_base/features_deserializer.py
+++ b/featuretools/feature_base/features_deserializer.py
@@ -108,6 +108,10 @@ class FeaturesDeserializer(object):
             return self._deserialized_features[feature_name]
 
         feature_dict = self.features_dict["feature_definitions"][feature_name]
+        primitive_hash = feature_dict["arguments"].get("primitive")
+        if primitive_hash:
+            primitive_dict = self.features_dict["primitive_definitions"][str(primitive_hash)]
+            feature_dict["arguments"]["primitive"] = primitive_dict
         dependencies_list = feature_dict["dependencies"]
 
         # Collect dependencies into a dictionary of name -> feature.

--- a/featuretools/feature_base/features_deserializer.py
+++ b/featuretools/feature_base/features_deserializer.py
@@ -108,12 +108,10 @@ class FeaturesDeserializer(object):
             return self._deserialized_features[feature_name]
 
         feature_dict = self.features_dict["feature_definitions"][feature_name]
-        primitive_hash = feature_dict["arguments"].get("primitive")
-        if primitive_hash:
-            primitive_dict = self.features_dict["primitive_definitions"][
-                str(primitive_hash)
-            ]
-            feature_dict["arguments"]["primitive"] = primitive_dict
+        feature_dict["arguments"]["primitive_definitions"] = self.features_dict[
+            "primitive_definitions"
+        ]
+
         dependencies_list = feature_dict["dependencies"]
 
         # Collect dependencies into a dictionary of name -> feature.

--- a/featuretools/feature_base/features_deserializer.py
+++ b/featuretools/feature_base/features_deserializer.py
@@ -110,7 +110,9 @@ class FeaturesDeserializer(object):
         feature_dict = self.features_dict["feature_definitions"][feature_name]
         primitive_hash = feature_dict["arguments"].get("primitive")
         if primitive_hash:
-            primitive_dict = self.features_dict["primitive_definitions"][str(primitive_hash)]
+            primitive_dict = self.features_dict["primitive_definitions"][
+                str(primitive_hash)
+            ]
             feature_dict["arguments"]["primitive"] = primitive_dict
         dependencies_list = feature_dict["dependencies"]
 

--- a/featuretools/feature_base/features_serializer.py
+++ b/featuretools/feature_base/features_serializer.py
@@ -68,7 +68,7 @@ class FeaturesSerializer(object):
         es = self.feature_list[0].entityset
 
         feature_defs, primitive_defs = self._feature_definitions()
-        
+
         return {
             "schema_version": SCHEMA_VERSION,
             "ft_version": ft_version,

--- a/featuretools/feature_base/features_serializer.py
+++ b/featuretools/feature_base/features_serializer.py
@@ -118,7 +118,7 @@ class FeaturesSerializer(object):
                         primitives_dict_key = str(primitive_number)
                         primitive_id_to_key[primitive_id] = primitives_dict_key
                         self._primitives_dict[
-                            str(primitives_dict_key)
+                            primitives_dict_key
                         ] = serialize_primitive(primitive)
                         self._features_dict[name]["arguments"][
                             "primitive"

--- a/featuretools/primitives/utils.py
+++ b/featuretools/primitives/utils.py
@@ -386,7 +386,6 @@ class PrimitivesDeserializer(object):
             )
         arguments = primitive_dict["arguments"]
         primitive_instance = cls(**arguments)
-        # self.instance_cache[primitive_key] = primitive_instance
 
         return primitive_instance
 

--- a/featuretools/primitives/utils.py
+++ b/featuretools/primitives/utils.py
@@ -366,7 +366,7 @@ class PrimitivesDeserializer(object):
         self.instance_cache = {}
         self.primitive_classes = find_descendents(PrimitiveBase)
 
-    def deserialize_primitive(self, primitive_dict, primitive_key):
+    def deserialize_primitive(self, primitive_dict):
         """
         Construct a primitive from the given dictionary (output from
         serialize_primitive).
@@ -375,22 +375,21 @@ class PrimitivesDeserializer(object):
         module_name = primitive_dict["module"]
         class_cache_key = (class_name, module_name)
 
-        if primitive_key in self.instance_cache:
-            primitive_instance = self.instance_cache[primitive_key]
+        # if primitive_key in self.instance_cache:
+        #     primitive_instance = self.instance_cache[primitive_key]
+        # else:
+        if class_cache_key in self.class_cache:
+            cls = self.class_cache[class_cache_key]
         else:
-            if class_cache_key in self.class_cache:
-                cls = self.class_cache[class_cache_key]
-            else:
-                cls = self._find_class_in_descendants(class_cache_key)
+            cls = self._find_class_in_descendants(class_cache_key)
 
-            if not cls:
-                raise RuntimeError(
-                    'Primitive "%s" in module "%s" not found'
-                    % (class_name, module_name)
-                )
-            arguments = primitive_dict["arguments"]
-            primitive_instance = cls(**arguments)
-            self.instance_cache[primitive_key] = primitive_instance
+        if not cls:
+            raise RuntimeError(
+                'Primitive "%s" in module "%s" not found' % (class_name, module_name)
+            )
+        arguments = primitive_dict["arguments"]
+        primitive_instance = cls(**arguments)
+        # self.instance_cache[primitive_key] = primitive_instance
 
         return primitive_instance
 

--- a/featuretools/primitives/utils.py
+++ b/featuretools/primitives/utils.py
@@ -362,31 +362,21 @@ class PrimitivesDeserializer(object):
         self.class_cache = {}
 
         # Cache to use existing primitive instances
-        # (class_name, module_name, (arg1_key, arg1_value), ...) -> class
+        # primitive key -> primitive instance
         self.instance_cache = {}
         self.primitive_classes = find_descendents(PrimitiveBase)
 
-    def deserialize_primitive(self, primitive_dict):
+    def deserialize_primitive(self, primitive_dict, primitive_key):
         """
         Construct a primitive from the given dictionary (output from
         serialize_primitive).
         """
         class_name = primitive_dict["type"]
         module_name = primitive_dict["module"]
-        arguments = primitive_dict["arguments"]
-        # convert any list args to tuples so they are hashable
-        cleaned_args = {}
-        for k, v in arguments.items():
-            if isinstance(v, list):
-                cleaned_args[k] = tuple(v)
-            else:
-                cleaned_args[k] = v
-        arguments_key = [(k, v) for k, v in cleaned_args.items()]
         class_cache_key = (class_name, module_name)
-        instance_cache_key = (class_name, module_name, *arguments_key)
 
-        if instance_cache_key in self.instance_cache:
-            primitive_instance = self.instance_cache[instance_cache_key]
+        if primitive_key in self.instance_cache:
+            primitive_instance = self.instance_cache[primitive_key]
         else:
             if class_cache_key in self.class_cache:
                 cls = self.class_cache[class_cache_key]
@@ -398,8 +388,9 @@ class PrimitivesDeserializer(object):
                     'Primitive "%s" in module "%s" not found'
                     % (class_name, module_name)
                 )
+            arguments = primitive_dict["arguments"]
             primitive_instance = cls(**arguments)
-            self.instance_cache[instance_cache_key] = primitive_instance
+            self.instance_cache[primitive_key] = primitive_instance
 
         return primitive_instance
 

--- a/featuretools/primitives/utils.py
+++ b/featuretools/primitives/utils.py
@@ -375,9 +375,6 @@ class PrimitivesDeserializer(object):
         module_name = primitive_dict["module"]
         class_cache_key = (class_name, module_name)
 
-        # if primitive_key in self.instance_cache:
-        #     primitive_instance = self.instance_cache[primitive_key]
-        # else:
         if class_cache_key in self.class_cache:
             cls = self.class_cache[class_cache_key]
         else:

--- a/featuretools/tests/primitive_tests/test_agg_feats.py
+++ b/featuretools/tests/primitive_tests/test_agg_feats.py
@@ -23,7 +23,6 @@ from featuretools.primitives import (
     get_aggregation_primitives,
 )
 from featuretools.primitives.base import AggregationPrimitive
-from featuretools.primitives.utils import PrimitivesDeserializer, serialize_primitive
 from featuretools.synthesis.deep_feature_synthesis import (
     DeepFeatureSynthesis,
     check_stacking,
@@ -411,7 +410,6 @@ def test_copy(games_es):
 
 
 def test_serialization(es):
-    primitives_deserializer = PrimitivesDeserializer()
     value = ft.IdentityFeature(es["log"].ww["value"])
     primitive = ft.primitives.Max()
     max1 = ft.AggregationFeature(value, "customers", primitive)
@@ -421,14 +419,14 @@ def test_serialization(es):
         "name": None,
         "base_features": [value.unique_name()],
         "relationship_path": [r.to_dictionary() for r in path],
-        "primitive": serialize_primitive(primitive),
+        "primitive": primitive,
         "where": None,
         "use_previous": None,
     }
 
     assert dictionary == max1.get_arguments()
     deserialized = ft.AggregationFeature.from_dictionary(
-        dictionary, es, {value.unique_name(): value}, primitives_deserializer
+        dictionary, es, {value.unique_name(): value}, primitive
     )
     _assert_agg_feats_equal(max1, deserialized)
 
@@ -442,7 +440,7 @@ def test_serialization(es):
         "name": None,
         "base_features": [value.unique_name()],
         "relationship_path": [r.to_dictionary() for r in path],
-        "primitive": serialize_primitive(primitive),
+        "primitive": primitive,
         "where": is_purchased.unique_name(),
         "use_previous": use_previous.get_arguments(),
     }
@@ -453,7 +451,7 @@ def test_serialization(es):
         is_purchased.unique_name(): is_purchased,
     }
     deserialized = ft.AggregationFeature.from_dictionary(
-        dictionary, es, dependencies, primitives_deserializer
+        dictionary, es, dependencies, primitive
     )
     _assert_agg_feats_equal(max2, deserialized)
 

--- a/featuretools/tests/primitive_tests/test_feature_base.py
+++ b/featuretools/tests/primitive_tests/test_feature_base.py
@@ -234,8 +234,9 @@ def test_to_dictionary_identity(es):
 
 
 def test_to_dictionary_agg(es):
+    primitive = Sum()
     actual = ft.Feature(
-        es["customers"].ww["age"], primitive=Sum, parent_dataframe_name="cohorts"
+        es["customers"].ww["age"], primitive=primitive, parent_dataframe_name="cohorts"
     ).to_dictionary()
 
     expected = {
@@ -252,11 +253,7 @@ def test_to_dictionary_agg(es):
                     "child_column_name": "cohort",
                 }
             ],
-            "primitive": {
-                "type": "Sum",
-                "module": "featuretools.primitives.standard.aggregation_primitives",
-                "arguments": {},
-            },
+            "primitive": primitive,
             "where": None,
             "use_previous": None,
         },
@@ -266,11 +263,12 @@ def test_to_dictionary_agg(es):
 
 
 def test_to_dictionary_where(es):
+    primitive = Sum()
     actual = ft.Feature(
         es["log"].ww["value"],
         parent_dataframe_name="sessions",
         where=ft.IdentityFeature(es["log"].ww["value"]) == 2,
-        primitive=Sum,
+        primitive=primitive,
     ).to_dictionary()
 
     expected = {
@@ -287,11 +285,7 @@ def test_to_dictionary_where(es):
                     "child_column_name": "session_id",
                 }
             ],
-            "primitive": {
-                "type": "Sum",
-                "module": "featuretools.primitives.standard.aggregation_primitives",
-                "arguments": {},
-            },
+            "primitive": primitive,
             "where": "log: value = 2",
             "use_previous": None,
         },
@@ -301,7 +295,8 @@ def test_to_dictionary_where(es):
 
 
 def test_to_dictionary_trans(es):
-    trans_feature = ft.Feature(es["customers"].ww["age"], primitive=Negate)
+    primitive = Negate()
+    trans_feature = ft.Feature(es["customers"].ww["age"], primitive=primitive)
 
     expected = {
         "type": "TransformFeature",
@@ -309,11 +304,7 @@ def test_to_dictionary_trans(es):
         "arguments": {
             "name": None,
             "base_features": ["customers: age"],
-            "primitive": {
-                "type": "Negate",
-                "module": "featuretools.primitives.standard.transform_primitive",
-                "arguments": {},
-            },
+            "primitive": primitive,
         },
     }
 
@@ -321,9 +312,10 @@ def test_to_dictionary_trans(es):
 
 
 def test_to_dictionary_groupby_trans(es):
+    primitive = Negate()
     id_feat = ft.Feature(es["log"].ww["product_id"])
     groupby_feature = ft.Feature(
-        es["log"].ww["value"], primitive=Negate, groupby=id_feat
+        es["log"].ww["value"], primitive=primitive, groupby=id_feat
     )
 
     expected = {
@@ -332,11 +324,7 @@ def test_to_dictionary_groupby_trans(es):
         "arguments": {
             "name": None,
             "base_features": ["log: value"],
-            "primitive": {
-                "type": "Negate",
-                "module": "featuretools.primitives.standard.transform_primitive",
-                "arguments": {},
-            },
+            "primitive": primitive,
             "groupby": "log: product_id",
         },
     }

--- a/featuretools/tests/primitive_tests/test_feature_serialization.py
+++ b/featuretools/tests/primitive_tests/test_feature_serialization.py
@@ -47,7 +47,7 @@ from featuretools.utils.gen_utils import Library
 BUCKET_NAME = "test-bucket"
 WRITE_KEY_NAME = "test-key"
 TEST_S3_URL = "s3://{}/{}".format(BUCKET_NAME, WRITE_KEY_NAME)
-TEST_FILE = "test_feature_serialization_feature_schema_{}_entityset_schema_{}_2022_4_26.json".format(
+TEST_FILE = "test_feature_serialization_feature_schema_{}_entityset_schema_{}_2022_6_28.json".format(
     SCHEMA_VERSION, ENTITYSET_SCHEMA_VERSION
 )
 S3_URL = "s3://featuretools-static/" + TEST_FILE

--- a/featuretools/tests/primitive_tests/test_features_serializer.py
+++ b/featuretools/tests/primitive_tests/test_features_serializer.py
@@ -4,7 +4,7 @@ import featuretools as ft
 from featuretools.entityset.deserialize import description_to_entityset
 from featuretools.feature_base.features_serializer import FeaturesSerializer
 
-SCHEMA_VERSION = "8.0.0"
+SCHEMA_VERSION = "9.0.0"
 
 
 def test_single_feature(es):
@@ -17,6 +17,7 @@ def test_single_feature(es):
         "entityset": es.to_dictionary(),
         "feature_list": [feature.unique_name()],
         "feature_definitions": {feature.unique_name(): feature.to_dictionary()},
+        "primitive_definitions": {},
     }
 
     _compare_feature_dicts(expected, serializer.to_dict())
@@ -38,7 +39,7 @@ def test_base_features_in_list(es):
             value.unique_name(): value.to_dictionary(),
         },
     }
-
+    breakpoint()
     _compare_feature_dicts(expected, serializer.to_dict())
 
 

--- a/featuretools/tests/primitive_tests/test_features_serializer.py
+++ b/featuretools/tests/primitive_tests/test_features_serializer.py
@@ -39,7 +39,7 @@ def test_base_features_in_list(es):
             value.unique_name(): value.to_dictionary(),
         },
     }
-    breakpoint()
+
     _compare_feature_dicts(expected, serializer.to_dict())
 
 

--- a/featuretools/tests/primitive_tests/test_features_serializer.py
+++ b/featuretools/tests/primitive_tests/test_features_serializer.py
@@ -3,6 +3,14 @@ import pandas as pd
 import featuretools as ft
 from featuretools.entityset.deserialize import description_to_entityset
 from featuretools.feature_base.features_serializer import FeaturesSerializer
+from featuretools.primitives import (
+    Count,
+    Max,
+    MultiplyNumericScalar,
+    NMostCommon,
+    NumUnique,
+)
+from featuretools.primitives.utils import serialize_primitive
 
 SCHEMA_VERSION = "9.0.0"
 
@@ -25,7 +33,7 @@ def test_single_feature(es):
 
 def test_base_features_in_list(es):
     value = ft.IdentityFeature(es["log"].ww["value"])
-    max_feature = ft.AggregationFeature(value, "sessions", ft.primitives.Max)
+    max_feature = ft.AggregationFeature(value, "sessions", Max)
     features = [max_feature, value]
     serializer = FeaturesSerializer(features)
 
@@ -39,13 +47,19 @@ def test_base_features_in_list(es):
             value.unique_name(): value.to_dictionary(),
         },
     }
+    expected["primitive_definitions"] = {"0": serialize_primitive(Max())}
+    expected["feature_definitions"][max_feature.unique_name()]["arguments"][
+        "primitive"
+    ] = "0"
 
-    _compare_feature_dicts(expected, serializer.to_dict())
+    actual = serializer.to_dict()
+    _compare_feature_dicts(expected, actual)
 
 
 def test_multi_output_features(es):
     product_id = ft.IdentityFeature(es["log"].ww["product_id"])
-    threecommon = ft.primitives.NMostCommon()
+    threecommon = NMostCommon()
+    num_unique = NumUnique()
     tc = ft.Feature(product_id, parent_dataframe_name="sessions", primitive=threecommon)
 
     features = [tc, product_id]
@@ -54,7 +68,7 @@ def test_multi_output_features(es):
             ft.Feature(
                 tc[i],
                 parent_dataframe_name="customers",
-                primitive=ft.primitives.NumUnique,
+                primitive=num_unique,
             )
         )
         features.append(tc[i])
@@ -72,15 +86,26 @@ def test_multi_output_features(es):
         "feature_list": flist,
         "feature_definitions": fdict,
     }
-    actual = serializer.to_dict()
+    expected["primitive_definitions"] = {
+        "0": serialize_primitive(threecommon),
+        "1": serialize_primitive(num_unique),
+    }
 
+    expected["feature_definitions"][flist[0]]["arguments"]["primitive"] = "0"
+    expected["feature_definitions"][flist[2]]["arguments"]["primitive"] = "1"
+    expected["feature_definitions"][flist[4]]["arguments"]["primitive"] = "1"
+    expected["feature_definitions"][flist[6]]["arguments"]["primitive"] = "1"
+
+    actual = serializer.to_dict()
     _compare_feature_dicts(expected, actual)
 
 
 def test_base_features_not_in_list(es):
+    max_primitive = Max()
+    mult_primitive = MultiplyNumericScalar(value=2)
     value = ft.IdentityFeature(es["log"].ww["value"])
-    value_x2 = ft.TransformFeature(value, ft.primitives.MultiplyNumericScalar(value=2))
-    max_feature = ft.AggregationFeature(value_x2, "sessions", ft.primitives.Max)
+    value_x2 = ft.TransformFeature(value, mult_primitive)
+    max_feature = ft.AggregationFeature(value_x2, "sessions", max_primitive)
     features = [max_feature]
     serializer = FeaturesSerializer(features)
 
@@ -95,15 +120,27 @@ def test_base_features_not_in_list(es):
             value.unique_name(): value.to_dictionary(),
         },
     }
+    expected["primitive_definitions"] = {
+        "0": serialize_primitive(max_primitive),
+        "1": serialize_primitive(mult_primitive),
+    }
+    expected["feature_definitions"][max_feature.unique_name()]["arguments"][
+        "primitive"
+    ] = "0"
+    expected["feature_definitions"][value_x2.unique_name()]["arguments"][
+        "primitive"
+    ] = "1"
 
-    _compare_feature_dicts(expected, serializer.to_dict())
+    actual = serializer.to_dict()
+    _compare_feature_dicts(expected, actual)
 
 
 def test_where_feature_dependency(es):
+    max_primitive = Max()
     value = ft.IdentityFeature(es["log"].ww["value"])
     is_purchased = ft.IdentityFeature(es["log"].ww["purchased"])
     max_feature = ft.AggregationFeature(
-        value, "sessions", ft.primitives.Max, where=is_purchased
+        value, "sessions", max_primitive, where=is_purchased
     )
     features = [max_feature]
     serializer = FeaturesSerializer(features)
@@ -119,15 +156,23 @@ def test_where_feature_dependency(es):
             is_purchased.unique_name(): is_purchased.to_dictionary(),
         },
     }
+    expected["primitive_definitions"] = {
+        "0": serialize_primitive(max_primitive),
+    }
+    expected["feature_definitions"][max_feature.unique_name()]["arguments"][
+        "primitive"
+    ] = "0"
 
-    _compare_feature_dicts(expected, serializer.to_dict())
+    actual = serializer.to_dict()
+    _compare_feature_dicts(expected, actual)
 
 
 def test_feature_use_previous_pd_timedelta(es):
     value = ft.IdentityFeature(es["log"].ww["id"])
     td = pd.Timedelta(12, "W")
+    count_primitive = Count()
     count_feature = ft.AggregationFeature(
-        value, "customers", ft.primitives.Count, use_previous=td
+        value, "customers", count_primitive, use_previous=td
     )
     features = [count_feature, value]
     serializer = FeaturesSerializer(features)
@@ -142,15 +187,21 @@ def test_feature_use_previous_pd_timedelta(es):
             value.unique_name(): value.to_dictionary(),
         },
     }
+    expected["primitive_definitions"] = {"0": serialize_primitive(count_primitive)}
+    expected["feature_definitions"][count_feature.unique_name()]["arguments"][
+        "primitive"
+    ] = "0"
 
-    _compare_feature_dicts(expected, serializer.to_dict())
+    actual = serializer.to_dict()
+    _compare_feature_dicts(expected, actual)
 
 
 def test_feature_use_previous_pd_dateoffset(es):
     value = ft.IdentityFeature(es["log"].ww["id"])
     do = pd.DateOffset(months=3)
+    count_primitive = Count()
     count_feature = ft.AggregationFeature(
-        value, "customers", ft.primitives.Count, use_previous=do
+        value, "customers", count_primitive, use_previous=do
     )
     features = [count_feature, value]
     serializer = FeaturesSerializer(features)
@@ -165,13 +216,18 @@ def test_feature_use_previous_pd_dateoffset(es):
             value.unique_name(): value.to_dictionary(),
         },
     }
+    expected["primitive_definitions"] = {"0": serialize_primitive(count_primitive)}
+    expected["feature_definitions"][count_feature.unique_name()]["arguments"][
+        "primitive"
+    ] = "0"
 
-    _compare_feature_dicts(expected, serializer.to_dict())
+    actual = serializer.to_dict()
+    _compare_feature_dicts(expected, actual)
 
     value = ft.IdentityFeature(es["log"].ww["id"])
     do = pd.DateOffset(months=3, days=2, minutes=30)
     count_feature = ft.AggregationFeature(
-        value, "customers", ft.primitives.Count, use_previous=do
+        value, "customers", count_primitive, use_previous=do
     )
     features = [count_feature, value]
     serializer = FeaturesSerializer(features)
@@ -186,8 +242,12 @@ def test_feature_use_previous_pd_dateoffset(es):
             value.unique_name(): value.to_dictionary(),
         },
     }
-
-    _compare_feature_dicts(expected, serializer.to_dict())
+    expected["primitive_definitions"] = {"0": serialize_primitive(count_primitive)}
+    expected["feature_definitions"][count_feature.unique_name()]["arguments"][
+        "primitive"
+    ] = "0"
+    actual = serializer.to_dict()
+    _compare_feature_dicts(expected, actual)
 
 
 def _compare_feature_dicts(a_dict, b_dict):

--- a/featuretools/tests/primitive_tests/test_groupby_transform_primitives.py
+++ b/featuretools/tests/primitive_tests/test_groupby_transform_primitives.py
@@ -10,7 +10,6 @@ from featuretools.computational_backends.feature_set_calculator import (
 )
 from featuretools.primitives import CumCount, CumMax, CumMean, CumMin, CumSum, Last
 from featuretools.primitives.base import TransformPrimitive
-from featuretools.primitives.utils import PrimitivesDeserializer, serialize_primitive
 from featuretools.synthesis import dfs
 from featuretools.tests.testing_utils import feature_with_name
 
@@ -496,7 +495,7 @@ def test_serialization(pd_es):
     dictionary = {
         "name": None,
         "base_features": [value.unique_name()],
-        "primitive": serialize_primitive(primitive),
+        "primitive": primitive,
         "groupby": zipcode.unique_name(),
     }
 
@@ -506,7 +505,7 @@ def test_serialization(pd_es):
         zipcode.unique_name(): zipcode,
     }
     assert groupby == ft.feature_base.GroupByTransformFeature.from_dictionary(
-        dictionary, pd_es, dependencies, PrimitivesDeserializer()
+        dictionary, pd_es, dependencies, primitive
     )
 
 

--- a/featuretools/tests/primitive_tests/test_transform_features.py
+++ b/featuretools/tests/primitive_tests/test_transform_features.py
@@ -60,7 +60,6 @@ from featuretools.primitives import (
     TransformPrimitive,
     get_transform_primitives,
 )
-from featuretools.primitives.utils import PrimitivesDeserializer, serialize_primitive
 from featuretools.synthesis.deep_feature_synthesis import match
 from featuretools.tests.testing_utils import to_pandas
 from featuretools.utils.gen_utils import Library
@@ -136,12 +135,12 @@ def test_serialization(es):
     dictionary = {
         "name": None,
         "base_features": [value.unique_name()],
-        "primitive": serialize_primitive(primitive),
+        "primitive": primitive,
     }
 
     assert dictionary == value_x2.get_arguments()
     assert value_x2 == ft.TransformFeature.from_dictionary(
-        dictionary, es, {value.unique_name(): value}, PrimitivesDeserializer()
+        dictionary, es, {value.unique_name(): value}, primitive
     )
 
 

--- a/featuretools/utils/gen_utils.py
+++ b/featuretools/utils/gen_utils.py
@@ -53,8 +53,9 @@ def check_schema_version(cls, cls_type):
             version_string = cls.features_dict["schema_version"]
 
         current = SCHEMA_VERSION.split(".")
+        current = [int(val) for val in current]
         saved = version_string.split(".")
-
+        saved = [int(val) for val in saved]
         warning_text_upgrade = (
             "The schema version of the saved %s"
             "(%s) is greater than the latest supported (%s). "

--- a/featuretools/utils/gen_utils.py
+++ b/featuretools/utils/gen_utils.py
@@ -56,6 +56,7 @@ def check_schema_version(cls, cls_type):
         current = [int(val) for val in current]
         saved = version_string.split(".")
         saved = [int(val) for val in saved]
+
         warning_text_upgrade = (
             "The schema version of the saved %s"
             "(%s) is greater than the latest supported (%s). "


### PR DESCRIPTION
### Refactor feature serialization to avoid storing duplicate primitive information

Separates storage of primitive information from feature information to avoid storing duplicate primitive information when serializing features.
