### PR TITLE
Adding NaN test cases for non-boolean returning datetime primitives

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,15 +2,16 @@
 
 Release Notes
 -------------
-.. Future Release
-  ==============
+Future Release
+==============
     * Enhancements
+        * Include np.nan testing for ``DayOfYear`` and ``DaysInMonth`` primitives (:pr:`2146`)
     * Fixes
     * Changes
     * Documentation Changes
     * Testing Changes
 
-.. Thanks to the following people for contributing to this release:
+Thanks to the following people for contributing to this release:
 
 v1.10.0 June 23, 2022
 =====================

--- a/featuretools/tests/primitive_tests/test_transform_primitive.py
+++ b/featuretools/tests/primitive_tests/test_transform_primitive.py
@@ -114,19 +114,19 @@ def test_age_nan():
 
 def test_day_of_year():
     doy = DayOfYear()
-    dates = pd.Series([datetime(2019, 12, 31), datetime(2020, 12, 31)])
+    dates = pd.Series([datetime(2019, 12, 31), np.nan, datetime(2020, 12, 31)])
     days_of_year = doy(dates)
-    correct_days = [365, 366]
+    correct_days = [365, np.nan, 366]
     np.testing.assert_array_equal(days_of_year, correct_days)
 
 
 def test_days_in_month():
     dim = DaysInMonth()
     dates = pd.Series(
-        [datetime(2010, 1, 1), datetime(2019, 2, 1), datetime(2020, 2, 1)]
+        [datetime(2010, 1, 1), datetime(2019, 2, 1), np.nan, datetime(2020, 2, 1)]
     )
     days_in_month = dim(dates)
-    correct_days = [31, 28, 29]
+    correct_days = [31, 28, np.nan, 29]
     np.testing.assert_array_equal(days_in_month, correct_days)
 
 


### PR DESCRIPTION
Adds test cases for new datetime primitives that checks for np.nan input. 
