### PR TITLE
Allow DFS to take in strings or datetime values into cutoff_time argument

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -5,7 +5,7 @@ Release Notes
 Future Release
 ==============
     * Enhancements
-        * Add datetime and string types as valid arguments to dfs ``cutoff_time`` (:pr:) 
+        * Add datetime and string types as valid arguments to dfs ``cutoff_time`` (:pr:`2147`) 
     * Fixes
     * Changes
     * Documentation Changes

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,15 +2,17 @@
 
 Release Notes
 -------------
-.. Future Release
-  ==============
+Future Release
+==============
     * Enhancements
+        * Add datetime and string types as valid arguments to dfs ``cutoff_time`` (:pr:) 
     * Fixes
     * Changes
     * Documentation Changes
     * Testing Changes
 
-.. Thanks to the following people for contributing to this release:
+Thanks to the following people for contributing to this release: 
+    :user:`sbadithe`
 
 v1.10.0 June 23, 2022
 =====================

--- a/featuretools/computational_backends/utils.py
+++ b/featuretools/computational_backends/utils.py
@@ -1,7 +1,8 @@
-from datetime import datetime
 import logging
 import os
+import typing
 import warnings
+from datetime import datetime
 from functools import wraps
 
 import dask.dataframe as dd
@@ -9,7 +10,6 @@ import numpy as np
 import pandas as pd
 import psutil
 from woodwork.logical_types import Datetime, Double
-import typing 
 
 from featuretools.entityset.relationship import RelationshipPath
 from featuretools.feature_base import AggregationFeature, DirectFeature
@@ -217,7 +217,10 @@ def get_client_cluster():
     return Client, LocalCluster
 
 
-def _validate_cutoff_time(cutoff_time : typing.Union[dd.DataFrame, pd.DataFrame, str, datetime], target_dataframe):
+def _validate_cutoff_time(
+    cutoff_time: typing.Union[dd.DataFrame, pd.DataFrame, str, datetime],
+    target_dataframe,
+):
     """
     Verify that the cutoff time is a single value or a pandas dataframe with the proper columns
     containing no duplicate rows
@@ -281,7 +284,7 @@ def _validate_cutoff_time(cutoff_time : typing.Union[dd.DataFrame, pd.DataFrame,
         assert (
             cutoff_time[["instance_id", "time"]].duplicated().sum() == 0
         ), "Duplicated rows in cutoff time dataframe."
-    if isinstance(cutoff_time, str): 
+    if isinstance(cutoff_time, str):
         try:
             cutoff_time = pd.to_datetime(cutoff_time)
         except ValueError as e:

--- a/featuretools/computational_backends/utils.py
+++ b/featuretools/computational_backends/utils.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import logging
 import os
 import warnings
@@ -8,6 +9,7 @@ import numpy as np
 import pandas as pd
 import psutil
 from woodwork.logical_types import Datetime, Double
+import typing 
 
 from featuretools.entityset.relationship import RelationshipPath
 from featuretools.feature_base import AggregationFeature, DirectFeature
@@ -215,7 +217,7 @@ def get_client_cluster():
     return Client, LocalCluster
 
 
-def _validate_cutoff_time(cutoff_time, target_dataframe):
+def _validate_cutoff_time(cutoff_time : typing.Union[dd.DataFrame, pd.DataFrame, str, datetime], target_dataframe):
     """
     Verify that the cutoff time is a single value or a pandas dataframe with the proper columns
     containing no duplicate rows
@@ -279,6 +281,13 @@ def _validate_cutoff_time(cutoff_time, target_dataframe):
         assert (
             cutoff_time[["instance_id", "time"]].duplicated().sum() == 0
         ), "Duplicated rows in cutoff time dataframe."
+    if isinstance(cutoff_time, str): 
+        try:
+            cutoff_time = pd.to_datetime(cutoff_time)
+        except ValueError as e:
+            raise ValueError(f"While parsing cutoff_time: {str(e)}")
+        except OverflowError as e:
+            raise OverflowError(f"While parsing cutoff_time: {str(e)}")
     else:
         if isinstance(cutoff_time, list):
             raise TypeError("cutoff_time must be a single value or DataFrame")

--- a/featuretools/synthesis/dfs.py
+++ b/featuretools/synthesis/dfs.py
@@ -245,12 +245,16 @@ def dfs(
         entityset = EntitySet("dfs", dataframes, relationships)
 
     if isinstance(cutoff_time, str):
-        try: 
+        try:
             cutoff_time = dateutil.parser.parse(cutoff_time)
         except dateutil.parser.ParserError:
-            raise ValueError(f"The provided cutoff_time of {cutoff_time} is either an invalid date or in an unknown format")
-        except OverflowError: 
-            raise OverflowError("The parsed date would exceed the largest valid integer") 
+            raise ValueError(
+                f"The provided cutoff_time of {cutoff_time} is either an invalid date or in an unknown format"
+            )
+        except OverflowError:
+            raise OverflowError(
+                "The parsed date would exceed the largest valid integer"
+            )
 
     dfs_object = DeepFeatureSynthesis(
         target_dataframe_name,

--- a/featuretools/synthesis/dfs.py
+++ b/featuretools/synthesis/dfs.py
@@ -245,9 +245,12 @@ def dfs(
         entityset = EntitySet("dfs", dataframes, relationships)
 
     if isinstance(cutoff_time, str):
-        cutoff_time = pd.to_datetime(cutoff_time) 
-        if pd.isna(cutoff_time): 
-            raise ValueError("invalid time") 
+        try: 
+            cutoff_time = pd.to_datetime(cutoff_time) 
+        except ValueError: 
+            raise(f"Cutoff time {cutoff_time} was not able to be parsed")
+        except OverflowError: 
+            raise(f"Cutoff time {cutoff_time} was parsed into an integer that cannot be stored on your system") 
 
     dfs_object = DeepFeatureSynthesis(
         target_dataframe_name,

--- a/featuretools/synthesis/dfs.py
+++ b/featuretools/synthesis/dfs.py
@@ -1,5 +1,7 @@
 import warnings
 
+import dateutil
+
 from featuretools.computational_backends import calculate_feature_matrix
 from featuretools.entityset import EntitySet
 from featuretools.exceptions import UnusedPrimitiveWarning
@@ -7,7 +9,6 @@ from featuretools.synthesis.deep_feature_synthesis import DeepFeatureSynthesis
 from featuretools.synthesis.utils import _categorize_features, get_unused_primitives
 from featuretools.utils import entry_point
 
-import dateutil 
 
 @entry_point("featuretools_dfs")
 def dfs(
@@ -243,8 +244,8 @@ def dfs(
     if not isinstance(entityset, EntitySet):
         entityset = EntitySet("dfs", dataframes, relationships)
 
-    if isinstance(cutoff_time, str): 
-        cutoff_time = dateutil.parser.parse(cutoff_time) 
+    if isinstance(cutoff_time, str):
+        cutoff_time = dateutil.parser.parse(cutoff_time)
 
     dfs_object = DeepFeatureSynthesis(
         target_dataframe_name,

--- a/featuretools/synthesis/dfs.py
+++ b/featuretools/synthesis/dfs.py
@@ -245,7 +245,12 @@ def dfs(
         entityset = EntitySet("dfs", dataframes, relationships)
 
     if isinstance(cutoff_time, str):
-        cutoff_time = dateutil.parser.parse(cutoff_time)
+        try: 
+            cutoff_time = dateutil.parser.parse(cutoff_time)
+        except dateutil.parser.ParserError:
+            raise ValueError(f"The provided cutoff_time of {cutoff_time} is either an invalid date or in an unknown format")
+        except OverflowError: 
+            raise ValueError("The parsed date would exceed the largest valid integer") 
 
     dfs_object = DeepFeatureSynthesis(
         target_dataframe_name,

--- a/featuretools/synthesis/dfs.py
+++ b/featuretools/synthesis/dfs.py
@@ -244,14 +244,6 @@ def dfs(
     if not isinstance(entityset, EntitySet):
         entityset = EntitySet("dfs", dataframes, relationships)
 
-    if isinstance(cutoff_time, str):
-        try:
-            cutoff_time = pd.to_datetime(cutoff_time)
-        except ValueError as e:
-            raise ValueError(f"While parsing cutoff_time: {str(e)}")
-        except OverflowError as e:
-            raise OverflowError(f"While parsing cutoff_time: {str(e)}")
-
     dfs_object = DeepFeatureSynthesis(
         target_dataframe_name,
         entityset,

--- a/featuretools/synthesis/dfs.py
+++ b/featuretools/synthesis/dfs.py
@@ -1,7 +1,5 @@
 import warnings
 
-import pandas as pd
-
 from featuretools.computational_backends import calculate_feature_matrix
 from featuretools.entityset import EntitySet
 from featuretools.exceptions import UnusedPrimitiveWarning

--- a/featuretools/synthesis/dfs.py
+++ b/featuretools/synthesis/dfs.py
@@ -62,16 +62,16 @@ def dfs(
 
         target_dataframe_name (str): Name of dataframe on which to make predictions.
 
-        cutoff_time (pd.DataFrame or Datetime): Specifies times at which to calculate
+        cutoff_time (pd.DataFrame or Datetime or str): Specifies times at which to calculate
             the features for each instance. The resulting feature matrix will use data
-            up to and including the cutoff_time. Can either be a DataFrame or a single
-            value. If a DataFrame is passed the instance ids for which to calculate features
-            must be in a column with the same name as the target dataframe index or a column
-            named `instance_id`. The cutoff time values in the DataFrame must be in a column with
-            the same name as the target dataframe time index or a column named `time`. If the
-            DataFrame has more than two columns, any additional columns will be added to the
-            resulting feature matrix. If a single value is passed, this value will be used for
-            all instances.
+            up to and including the cutoff_time. Can either be a DataFrame, a single
+            value, or a string that can be parsed into a datetime. If a DataFrame is passed
+            the instance ids for which to calculate features must be in a column with the
+            same name as the target dataframe index or a column named `instance_id`.
+            The cutoff time values in the DataFrame must be in a column with the same name as
+            the target dataframe time index or a column named `time`. If the DataFrame has more
+            than two columns, any additional columns will be added to the resulting feature
+            matrix. If a single value is passed, this value will be used for all instances.
 
         instance_ids (list): List of instances on which to calculate features. Only
             used if cutoff_time is a single datetime.

--- a/featuretools/synthesis/dfs.py
+++ b/featuretools/synthesis/dfs.py
@@ -1,6 +1,6 @@
 import warnings
 
-import dateutil
+import pandas as pd 
 
 from featuretools.computational_backends import calculate_feature_matrix
 from featuretools.entityset import EntitySet
@@ -245,16 +245,9 @@ def dfs(
         entityset = EntitySet("dfs", dataframes, relationships)
 
     if isinstance(cutoff_time, str):
-        try:
-            cutoff_time = dateutil.parser.parse(cutoff_time)
-        except dateutil.parser.ParserError:
-            raise ValueError(
-                f"The provided cutoff_time of {cutoff_time} is either an invalid date or in an unknown format"
-            )
-        except OverflowError:
-            raise OverflowError(
-                "The parsed date would exceed the largest valid integer"
-            )
+        cutoff_time = pd.to_datetime(cutoff_time) 
+        if pd.isna(cutoff_time): 
+            raise ValueError("invalid time") 
 
     dfs_object = DeepFeatureSynthesis(
         target_dataframe_name,

--- a/featuretools/synthesis/dfs.py
+++ b/featuretools/synthesis/dfs.py
@@ -7,6 +7,7 @@ from featuretools.synthesis.deep_feature_synthesis import DeepFeatureSynthesis
 from featuretools.synthesis.utils import _categorize_features, get_unused_primitives
 from featuretools.utils import entry_point
 
+import dateutil 
 
 @entry_point("featuretools_dfs")
 def dfs(
@@ -241,6 +242,9 @@ def dfs(
     """
     if not isinstance(entityset, EntitySet):
         entityset = EntitySet("dfs", dataframes, relationships)
+
+    if isinstance(cutoff_time, str): 
+        cutoff_time = dateutil.parser.parse(cutoff_time) 
 
     dfs_object = DeepFeatureSynthesis(
         target_dataframe_name,

--- a/featuretools/synthesis/dfs.py
+++ b/featuretools/synthesis/dfs.py
@@ -1,6 +1,6 @@
 import warnings
 
-import pandas as pd 
+import pandas as pd
 
 from featuretools.computational_backends import calculate_feature_matrix
 from featuretools.entityset import EntitySet
@@ -245,12 +245,14 @@ def dfs(
         entityset = EntitySet("dfs", dataframes, relationships)
 
     if isinstance(cutoff_time, str):
-        try: 
-            cutoff_time = pd.to_datetime(cutoff_time) 
-        except ValueError: 
-            raise(f"Cutoff time {cutoff_time} was not able to be parsed")
-        except OverflowError: 
-            raise(f"Cutoff time {cutoff_time} was parsed into an integer that cannot be stored on your system") 
+        try:
+            cutoff_time = pd.to_datetime(cutoff_time)
+        except ValueError:
+            raise ValueError(f"Cutoff time {cutoff_time} was not able to be parsed")
+        except OverflowError:
+            raise OverflowError(
+                f"Cutoff time {cutoff_time} was parsed into an integer that cannot be stored on your system"
+            )
 
     dfs_object = DeepFeatureSynthesis(
         target_dataframe_name,

--- a/featuretools/synthesis/dfs.py
+++ b/featuretools/synthesis/dfs.py
@@ -250,7 +250,7 @@ def dfs(
         except dateutil.parser.ParserError:
             raise ValueError(f"The provided cutoff_time of {cutoff_time} is either an invalid date or in an unknown format")
         except OverflowError: 
-            raise ValueError("The parsed date would exceed the largest valid integer") 
+            raise OverflowError("The parsed date would exceed the largest valid integer") 
 
     dfs_object = DeepFeatureSynthesis(
         target_dataframe_name,

--- a/featuretools/synthesis/dfs.py
+++ b/featuretools/synthesis/dfs.py
@@ -247,12 +247,10 @@ def dfs(
     if isinstance(cutoff_time, str):
         try:
             cutoff_time = pd.to_datetime(cutoff_time)
-        except ValueError:
-            raise ValueError(f"Cutoff time {cutoff_time} was not able to be parsed")
-        except OverflowError:
-            raise OverflowError(
-                f"Cutoff time {cutoff_time} was parsed into an integer that cannot be stored on your system"
-            )
+        except ValueError as e:
+            raise ValueError(f"While parsing cutoff_time: {str(e)}")
+        except OverflowError as e:
+            raise OverflowError(f"While parsing cutoff_time: {str(e)}")
 
     dfs_object = DeepFeatureSynthesis(
         target_dataframe_name,

--- a/featuretools/tests/requirement_files/latest_requirements.txt
+++ b/featuretools/tests/requirement_files/latest_requirements.txt
@@ -1,7 +1,7 @@
 click==8.1.3
 cloudpickle==2.1.0
-dask==2022.6.0
-distributed==2022.6.0
+dask==2022.6.1
+distributed==2022.6.1
 holidays==0.14.2
 numpy==1.23.0
 pandas==1.3.5

--- a/featuretools/tests/synthesis/test_dfs_method.py
+++ b/featuretools/tests/synthesis/test_dfs_method.py
@@ -365,7 +365,6 @@ def test_accepts_pd_dateoffset_training_window(datetime_es):
 
 
 def test_accepts_datetime_and_string_offset(datetime_es):
-    # TODO: Update to use Dask dataframes when issue #882 is closed
     feature_matrix, _ = dfs(
         entityset=datetime_es,
         target_dataframe_name="transactions",

--- a/featuretools/tests/synthesis/test_dfs_method.py
+++ b/featuretools/tests/synthesis/test_dfs_method.py
@@ -1,13 +1,13 @@
 from unittest.mock import patch
 
 import composeml as cp
+import dateutil
 import numpy as np
 import pandas as pd
 import pytest
 from dask import dataframe as dd
 from woodwork.column_schema import ColumnSchema
 from woodwork.logical_types import NaturalLanguage
-import dateutil  
 
 from featuretools.computational_backends.calculate_feature_matrix import (
     FEATURE_CALCULATION_PERCENTAGE,

--- a/featuretools/tests/synthesis/test_dfs_method.py
+++ b/featuretools/tests/synthesis/test_dfs_method.py
@@ -1,7 +1,6 @@
 from unittest.mock import patch
 
 import composeml as cp
-import dateutil
 import numpy as np
 import pandas as pd
 import pytest
@@ -370,7 +369,7 @@ def test_accepts_datetime_and_string_offset(datetime_es):
     feature_matrix, _ = dfs(
         entityset=datetime_es,
         target_dataframe_name="transactions",
-        cutoff_time=dateutil.parser.parse("2012-3-31 04:00"),
+        cutoff_time=pd.to_datetime("2012-3-31 04:00"),
         training_window=pd.DateOffset(months=2),
     )
 
@@ -385,7 +384,7 @@ def test_accepts_datetime_and_string_offset(datetime_es):
     assert (feature_matrix.index == feature_matrix_2.index).all()
 
 
-def test_handles_parseutil_parser_error(datetime_es):
+def test_handles_pandas_parser_error(datetime_es):
     with pytest.raises(ValueError):
         _, _ = dfs(
             entityset=datetime_es,
@@ -395,7 +394,7 @@ def test_handles_parseutil_parser_error(datetime_es):
         )
 
 
-def test_handles_parseutil_overflow_error(datetime_es):
+def test_handles_pandas_overflow_error(datetime_es):
     with pytest.raises(OverflowError):
         _, _ = dfs(
             entityset=datetime_es,

--- a/featuretools/tests/synthesis/test_dfs_method.py
+++ b/featuretools/tests/synthesis/test_dfs_method.py
@@ -7,6 +7,7 @@ import pytest
 from dask import dataframe as dd
 from woodwork.column_schema import ColumnSchema
 from woodwork.logical_types import NaturalLanguage
+import dateutil  
 
 from featuretools.computational_backends.calculate_feature_matrix import (
     FEATURE_CALCULATION_PERCENTAGE,
@@ -357,6 +358,26 @@ def test_accepts_pd_dateoffset_training_window(datetime_es):
         entityset=datetime_es,
         target_dataframe_name="transactions",
         cutoff_time=pd.Timestamp("2012-3-31 04:00"),
+        training_window=pd.offsets.BDay(44),
+    )
+
+    assert (feature_matrix.index == [2, 3, 4]).all()
+    assert (feature_matrix.index == feature_matrix_2.index).all()
+
+
+def test_accepts_datetime_and_string_offset(datetime_es):
+    # TODO: Update to use Dask dataframes when issue #882 is closed
+    feature_matrix, _ = dfs(
+        entityset=datetime_es,
+        target_dataframe_name="transactions",
+        cutoff_time=dateutil.parser.parse("2012-3-31 04:00"),
+        training_window=pd.DateOffset(months=2),
+    )
+
+    feature_matrix_2, _ = dfs(
+        entityset=datetime_es,
+        target_dataframe_name="transactions",
+        cutoff_time="2012-3-31 04:00",
         training_window=pd.offsets.BDay(44),
     )
 

--- a/featuretools/tests/synthesis/test_dfs_method.py
+++ b/featuretools/tests/synthesis/test_dfs_method.py
@@ -395,6 +395,16 @@ def test_handles_parseutil_parser_error(datetime_es):
         )
 
 
+def test_handles_parseutil_overflow_error(datetime_es):
+    with pytest.raises(OverflowError):
+        _, _ = dfs(
+            entityset=datetime_es,
+            target_dataframe_name="transactions",
+            cutoff_time="200000000000000000000000000000000000000000000000000000000000000000-3-31 04:00",
+            training_window=pd.DateOffset(months=2),
+        )
+
+
 def test_warns_with_unused_primitives(es):
     if es.dataframe_type == Library.SPARK.value:
         pytest.skip("Spark throws extra warnings")

--- a/featuretools/tests/synthesis/test_dfs_method.py
+++ b/featuretools/tests/synthesis/test_dfs_method.py
@@ -386,7 +386,7 @@ def test_accepts_datetime_and_string_offset(datetime_es):
 
 
 def test_handles_parseutil_parser_error(datetime_es):
-    with pytest.raises(ValueError):  
+    with pytest.raises(ValueError):
         _, _ = dfs(
             entityset=datetime_es,
             target_dataframe_name="transactions",
@@ -395,8 +395,8 @@ def test_handles_parseutil_parser_error(datetime_es):
         )
 
 
-def test_handles_parseutil_overflow_error(datetime_es): 
-    with pytest.raises(OverflowError): 
+def test_handles_parseutil_overflow_error(datetime_es):
+    with pytest.raises(OverflowError):
         _, _ = dfs(
             entityset=datetime_es,
             target_dataframe_name="transactions",

--- a/featuretools/tests/synthesis/test_dfs_method.py
+++ b/featuretools/tests/synthesis/test_dfs_method.py
@@ -395,16 +395,6 @@ def test_handles_parseutil_parser_error(datetime_es):
         )
 
 
-def test_handles_parseutil_overflow_error(datetime_es):
-    with pytest.raises(OverflowError):
-        _, _ = dfs(
-            entityset=datetime_es,
-            target_dataframe_name="transactions",
-            cutoff_time="200000000000000000000000000000000000000000000000000000000000000000-3-31 04:00",
-            training_window=pd.DateOffset(months=2),
-        )
-
-
 def test_warns_with_unused_primitives(es):
     if es.dataframe_type == Library.SPARK.value:
         pytest.skip("Spark throws extra warnings")

--- a/featuretools/tests/synthesis/test_dfs_method.py
+++ b/featuretools/tests/synthesis/test_dfs_method.py
@@ -387,7 +387,7 @@ def test_accepts_datetime_and_string_offset(datetime_es):
 
 def test_handles_parseutil_parser_error(datetime_es):
     with pytest.raises(ValueError):  
-        feature_matrix, _ = dfs(
+        _, _ = dfs(
             entityset=datetime_es,
             target_dataframe_name="transactions",
             cutoff_time="2--012-----3-----31 04:00",
@@ -396,8 +396,8 @@ def test_handles_parseutil_parser_error(datetime_es):
 
 
 def test_handles_parseutil_overflow_error(datetime_es): 
-    with pytest.raises(ValueError): 
-        feature_matrix, _ = dfs(
+    with pytest.raises(OverflowError): 
+        _, _ = dfs(
             entityset=datetime_es,
             target_dataframe_name="transactions",
             cutoff_time="200000000000000000000000000000000000000000000000000000000000000000-3-31 04:00",

--- a/featuretools/tests/synthesis/test_dfs_method.py
+++ b/featuretools/tests/synthesis/test_dfs_method.py
@@ -385,6 +385,26 @@ def test_accepts_datetime_and_string_offset(datetime_es):
     assert (feature_matrix.index == feature_matrix_2.index).all()
 
 
+def test_handles_parseutil_parser_error(datetime_es):
+    with pytest.raises(ValueError):  
+        feature_matrix, _ = dfs(
+            entityset=datetime_es,
+            target_dataframe_name="transactions",
+            cutoff_time="2--012-----3-----31 04:00",
+            training_window=pd.DateOffset(months=2),
+        )
+
+
+def test_handles_parseutil_overflow_error(datetime_es): 
+    with pytest.raises(ValueError): 
+        feature_matrix, _ = dfs(
+            entityset=datetime_es,
+            target_dataframe_name="transactions",
+            cutoff_time="200000000000000000000000000000000000000000000000000000000000000000-3-31 04:00",
+            training_window=pd.DateOffset(months=2),
+        )
+
+
 def test_warns_with_unused_primitives(es):
     if es.dataframe_type == Library.SPARK.value:
         pytest.skip("Spark throws extra warnings")


### PR DESCRIPTION
Fixes #2014 

Makes it possible for users to pass in strings, or datetime values into dfs's `cutoff_time` argument