### PR TITLE
[DRAFT] Standardizing test files in `primitive_tests`

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,15 +2,17 @@
 
 Release Notes
 -------------
-.. Future Release
-  ==============
+Future Release
+==============
     * Enhancements
     * Fixes
     * Changes
     * Documentation Changes
     * Testing Changes
+        * Standardizing test files by removing extraneous ``ft`` inputs (:pr:`2149`)
 
-.. Thanks to the following people for contributing to this release:
+    Thanks to the following people for contributing to this release:
+    :user:`sbadithe`
 
 v1.10.0 June 23, 2022
 =====================

--- a/featuretools/tests/primitive_tests/test_agg_feats.py
+++ b/featuretools/tests/primitive_tests/test_agg_feats.py
@@ -8,10 +8,19 @@ import pytest
 from woodwork.column_schema import ColumnSchema
 from woodwork.logical_types import Datetime
 
-import featuretools as ft
+from featuretools import (
+    AggregationFeature,
+    Feature,
+    IdentityFeature,
+    Timedelta,
+    calculate_feature_matrix,
+    dfs,
+    primitives,
+)
 from featuretools.entityset.relationship import RelationshipPath
 from featuretools.primitives import (
     Count,
+    Max,
     Mean,
     Median,
     NMostCommon,
@@ -48,22 +57,20 @@ def test_primitive():
 
 
 def test_get_depth(es):
-    log_id_feat = ft.IdentityFeature(es["log"].ww["id"])
-    customer_id_feat = ft.IdentityFeature(es["customers"].ww["id"])
-    count_logs = ft.Feature(
-        log_id_feat, parent_dataframe_name="sessions", primitive=Count
-    )
-    sum_count_logs = ft.Feature(
+    log_id_feat = IdentityFeature(es["log"].ww["id"])
+    customer_id_feat = IdentityFeature(es["customers"].ww["id"])
+    count_logs = Feature(log_id_feat, parent_dataframe_name="sessions", primitive=Count)
+    sum_count_logs = Feature(
         count_logs, parent_dataframe_name="customers", primitive=Sum
     )
     num_logs_greater_than_5 = sum_count_logs > 5
-    count_customers = ft.Feature(
+    count_customers = Feature(
         customer_id_feat,
         parent_dataframe_name="régions",
         where=num_logs_greater_than_5,
         primitive=Count,
     )
-    num_customers_region = ft.Feature(count_customers, dataframe_name="customers")
+    num_customers_region = Feature(count_customers, dataframe_name="customers")
 
     depth = num_customers_region.get_depth()
     assert depth == 5
@@ -117,25 +124,25 @@ def test_count_null(pd_es):
         ):
             return "COUNT(%s%s%s)" % (relationship_path_name, where_str, use_prev_str)
 
-    count_null = ft.Feature(
+    count_null = Feature(
         pd_es["log"].ww["value"],
         parent_dataframe_name="sessions",
         primitive=Count(count_null=True),
     )
-    feature_matrix = ft.calculate_feature_matrix([count_null], entityset=pd_es)
+    feature_matrix = calculate_feature_matrix([count_null], entityset=pd_es)
     values = [5, 4, 1, 2, 3, 2]
     assert (values == feature_matrix[count_null.get_name()]).all()
 
 
 def test_check_input_types(es):
-    count = ft.Feature(
+    count = Feature(
         es["sessions"].ww["id"], parent_dataframe_name="customers", primitive=Count
     )
-    mean = ft.Feature(count, parent_dataframe_name="régions", primitive=Mean)
+    mean = Feature(count, parent_dataframe_name="régions", primitive=Mean)
     assert mean._check_input_types()
 
     boolean = count > 3
-    mean = ft.Feature(
+    mean = Feature(
         count, parent_dataframe_name="régions", where=boolean, primitive=Mean
     )
     assert mean._check_input_types()
@@ -159,17 +166,17 @@ def test_mean_nan(es):
     assert isnan(mean_func_nans_true(array_nans))
 
     # test naming
-    default_feat = ft.Feature(
+    default_feat = Feature(
         es["log"].ww["value"], parent_dataframe_name="customers", primitive=Mean
     )
     assert default_feat.get_name() == "MEAN(log.value)"
-    ignore_nan_feat = ft.Feature(
+    ignore_nan_feat = Feature(
         es["log"].ww["value"],
         parent_dataframe_name="customers",
         primitive=Mean(skipna=True),
     )
     assert ignore_nan_feat.get_name() == "MEAN(log.value)"
-    include_nan_feat = ft.Feature(
+    include_nan_feat = Feature(
         es["log"].ww["value"],
         parent_dataframe_name="customers",
         primitive=Mean(skipna=False),
@@ -178,7 +185,7 @@ def test_mean_nan(es):
 
 
 def test_base_of_and_stack_on_heuristic(es, test_primitive):
-    child = ft.Feature(
+    child = Feature(
         es["sessions"].ww["id"], parent_dataframe_name="customers", primitive=Count
     )
     test_primitive.stack_on = []
@@ -225,7 +232,7 @@ def test_base_of_and_stack_on_heuristic(es, test_primitive):
 
 def test_stack_on_self(es, test_primitive):
     # test stacks on self
-    child = ft.Feature(
+    child = Feature(
         es["log"].ww["value"], parent_dataframe_name="régions", primitive=test_primitive
     )
     test_primitive.stack_on = []
@@ -250,11 +257,11 @@ def test_init_and_name(es):
     boolean_nullable = boolean_nullable.ww.set_logical_type("BooleanNullable")
     log.ww["boolean_nullable"] = boolean_nullable
 
-    features = [ft.Feature(es["log"].ww[col]) for col in log.columns]
+    features = [Feature(es["log"].ww[col]) for col in log.columns]
 
     # check all primitives have name
-    for attribute_string in dir(ft.primitives):
-        attr = getattr(ft.primitives, attribute_string)
+    for attribute_string in dir(primitives):
+        attr = getattr(primitives, attribute_string)
         if isclass(attr):
             if issubclass(attr, AggregationPrimitive) and attr != AggregationPrimitive:
                 assert getattr(attr, "name") is not None
@@ -282,23 +289,23 @@ def test_init_and_name(es):
             if len(matching_types) == 0:
                 raise Exception("Agg Primitive %s not tested" % agg_prim.name)
             for t in matching_types:
-                instance = ft.Feature(
+                instance = Feature(
                     t, parent_dataframe_name="sessions", primitive=agg_prim
                 )
 
                 # try to get name and calculate
                 instance.get_name()
-                ft.calculate_feature_matrix([instance], entityset=es)
+                calculate_feature_matrix([instance], entityset=es)
 
 
 def test_invalid_init_args(diamond_es):
     error_text = "parent_dataframe must match first relationship in path"
     with pytest.raises(AssertionError, match=error_text):
         path = backward_path(diamond_es, ["stores", "transactions"])
-        ft.AggregationFeature(
-            ft.IdentityFeature(diamond_es["transactions"].ww["amount"]),
+        AggregationFeature(
+            IdentityFeature(diamond_es["transactions"].ww["amount"]),
             "customers",
-            ft.primitives.Mean,
+            Mean,
             relationship_path=path,
         )
 
@@ -307,10 +314,10 @@ def test_invalid_init_args(diamond_es):
     )
     with pytest.raises(AssertionError, match=error_text):
         path = backward_path(diamond_es, ["regions", "stores"])
-        ft.AggregationFeature(
-            ft.IdentityFeature(diamond_es["transactions"].ww["amount"]),
+        AggregationFeature(
+            IdentityFeature(diamond_es["transactions"].ww["amount"]),
             "regions",
-            ft.primitives.Mean,
+            Mean,
             relationship_path=path,
         )
 
@@ -319,10 +326,10 @@ def test_invalid_init_args(diamond_es):
         backward = backward_path(diamond_es, ["customers", "transactions"])
         forward = RelationshipPath([(True, r) for _, r in backward])
         path = RelationshipPath(list(forward) + list(backward))
-        ft.AggregationFeature(
-            ft.IdentityFeature(diamond_es["transactions"].ww["amount"]),
+        AggregationFeature(
+            IdentityFeature(diamond_es["transactions"].ww["amount"]),
             "transactions",
-            ft.primitives.Mean,
+            Mean,
             relationship_path=path,
         )
 
@@ -333,18 +340,18 @@ def test_init_with_multiple_possible_paths(diamond_es):
         "You must specify a relationship path."
     )
     with pytest.raises(RuntimeError, match=error_text):
-        ft.AggregationFeature(
-            ft.IdentityFeature(diamond_es["transactions"].ww["amount"]),
+        AggregationFeature(
+            IdentityFeature(diamond_es["transactions"].ww["amount"]),
             "regions",
-            ft.primitives.Mean,
+            Mean,
         )
 
     # Does not raise if path specified.
     path = backward_path(diamond_es, ["regions", "customers", "transactions"])
-    ft.AggregationFeature(
-        ft.IdentityFeature(diamond_es["transactions"].ww["amount"]),
+    AggregationFeature(
+        IdentityFeature(diamond_es["transactions"].ww["amount"]),
         "regions",
-        ft.primitives.Mean,
+        Mean,
         relationship_path=path,
     )
 
@@ -352,10 +359,10 @@ def test_init_with_multiple_possible_paths(diamond_es):
 def test_init_with_single_possible_path(diamond_es):
     # This uses diamond_es to test that there being a cycle somewhere in the
     # graph doesn't cause an error.
-    feat = ft.AggregationFeature(
-        ft.IdentityFeature(diamond_es["transactions"].ww["amount"]),
+    feat = AggregationFeature(
+        IdentityFeature(diamond_es["transactions"].ww["amount"]),
         "customers",
-        ft.primitives.Mean,
+        Mean,
     )
     expected_path = backward_path(diamond_es, ["customers", "transactions"])
     assert feat.relationship_path == expected_path
@@ -364,27 +371,27 @@ def test_init_with_single_possible_path(diamond_es):
 def test_init_with_no_path(diamond_es):
     error_text = 'No backward path from "transactions" to "customers" found.'
     with pytest.raises(RuntimeError, match=error_text):
-        ft.AggregationFeature(
-            ft.IdentityFeature(diamond_es["customers"].ww["name"]),
+        AggregationFeature(
+            IdentityFeature(diamond_es["customers"].ww["name"]),
             "transactions",
-            ft.primitives.Count,
+            Count,
         )
 
     error_text = 'No backward path from "transactions" to "transactions" found.'
     with pytest.raises(RuntimeError, match=error_text):
-        ft.AggregationFeature(
-            ft.IdentityFeature(diamond_es["transactions"].ww["amount"]),
+        AggregationFeature(
+            IdentityFeature(diamond_es["transactions"].ww["amount"]),
             "transactions",
-            ft.primitives.Mean,
+            Mean,
         )
 
 
 def test_name_with_multiple_possible_paths(diamond_es):
     path = backward_path(diamond_es, ["regions", "customers", "transactions"])
-    feat = ft.AggregationFeature(
-        ft.IdentityFeature(diamond_es["transactions"].ww["amount"]),
+    feat = AggregationFeature(
+        IdentityFeature(diamond_es["transactions"].ww["amount"]),
         "regions",
-        ft.primitives.Mean,
+        Mean,
         relationship_path=path,
     )
 
@@ -397,11 +404,11 @@ def test_copy(games_es):
         r for r in games_es.relationships if r._child_column_name == "home_team_id"
     )
     path = RelationshipPath([(False, home_games)])
-    feat = ft.AggregationFeature(
-        ft.IdentityFeature(games_es["games"].ww["home_team_score"]),
+    feat = AggregationFeature(
+        IdentityFeature(games_es["games"].ww["home_team_score"]),
         "teams",
         relationship_path=path,
-        primitive=ft.primitives.Mean,
+        primitive=Mean,
     )
     copied = feat.copy()
     assert copied.dataframe_name == feat.dataframe_name
@@ -412,9 +419,9 @@ def test_copy(games_es):
 
 def test_serialization(es):
     primitives_deserializer = PrimitivesDeserializer()
-    value = ft.IdentityFeature(es["log"].ww["value"])
-    primitive = ft.primitives.Max()
-    max1 = ft.AggregationFeature(value, "customers", primitive)
+    value = IdentityFeature(es["log"].ww["value"])
+    primitive = Max()
+    max1 = AggregationFeature(value, "customers", primitive)
 
     path = next(es.find_backward_paths("customers", "log"))
     dictionary = {
@@ -427,14 +434,14 @@ def test_serialization(es):
     }
 
     assert dictionary == max1.get_arguments()
-    deserialized = ft.AggregationFeature.from_dictionary(
+    deserialized = AggregationFeature.from_dictionary(
         dictionary, es, {value.unique_name(): value}, primitives_deserializer
     )
     _assert_agg_feats_equal(max1, deserialized)
 
-    is_purchased = ft.IdentityFeature(es["log"].ww["purchased"])
-    use_previous = ft.Timedelta(3, "d")
-    max2 = ft.AggregationFeature(
+    is_purchased = IdentityFeature(es["log"].ww["purchased"])
+    use_previous = Timedelta(3, "d")
+    max2 = AggregationFeature(
         value, "customers", primitive, where=is_purchased, use_previous=use_previous
     )
 
@@ -452,19 +459,19 @@ def test_serialization(es):
         value.unique_name(): value,
         is_purchased.unique_name(): is_purchased,
     }
-    deserialized = ft.AggregationFeature.from_dictionary(
+    deserialized = AggregationFeature.from_dictionary(
         dictionary, es, dependencies, primitives_deserializer
     )
     _assert_agg_feats_equal(max2, deserialized)
 
 
 def test_time_since_last(pd_es):
-    f = ft.Feature(
+    f = Feature(
         pd_es["log"].ww["datetime"],
         parent_dataframe_name="customers",
         primitive=TimeSinceLast,
     )
-    fm = ft.calculate_feature_matrix(
+    fm = calculate_feature_matrix(
         [f], entityset=pd_es, instance_ids=[0, 1, 2], cutoff_time=datetime(2015, 6, 8)
     )
 
@@ -474,12 +481,12 @@ def test_time_since_last(pd_es):
 
 
 def test_time_since_first(pd_es):
-    f = ft.Feature(
+    f = Feature(
         pd_es["log"].ww["datetime"],
         parent_dataframe_name="customers",
         primitive=TimeSinceFirst,
     )
-    fm = ft.calculate_feature_matrix(
+    fm = calculate_feature_matrix(
         [f], entityset=pd_es, instance_ids=[0, 1, 2], cutoff_time=datetime(2015, 6, 8)
     )
 
@@ -489,12 +496,12 @@ def test_time_since_first(pd_es):
 
 
 def test_median(pd_es):
-    f = ft.Feature(
+    f = Feature(
         pd_es["log"].ww["value_many_nans"],
         parent_dataframe_name="customers",
         primitive=Median,
     )
-    fm = ft.calculate_feature_matrix(
+    fm = calculate_feature_matrix(
         [f], entityset=pd_es, instance_ids=[0, 1, 2], cutoff_time=datetime(2015, 6, 8)
     )
 
@@ -536,14 +543,14 @@ def test_agg_same_method_name(es):
 
             return custom_primitive
 
-    f_sum = ft.Feature(
+    f_sum = Feature(
         es["log"].ww["value"], parent_dataframe_name="customers", primitive=Sum
     )
-    f_max = ft.Feature(
+    f_max = Feature(
         es["log"].ww["value"], parent_dataframe_name="customers", primitive=Max
     )
 
-    fm = ft.calculate_feature_matrix([f_sum, f_max], entityset=es)
+    fm = calculate_feature_matrix([f_sum, f_max], entityset=es)
     assert fm.columns.tolist() == [f_sum.get_name(), f_max.get_name()]
 
     # test with lambdas
@@ -563,13 +570,13 @@ def test_agg_same_method_name(es):
         def get_function(self):
             return lambda x: x.max()
 
-    f_sum = ft.Feature(
+    f_sum = Feature(
         es["log"].ww["value"], parent_dataframe_name="customers", primitive=Sum
     )
-    f_max = ft.Feature(
+    f_max = Feature(
         es["log"].ww["value"], parent_dataframe_name="customers", primitive=Max
     )
-    fm = ft.calculate_feature_matrix([f_sum, f_max], entityset=es)
+    fm = calculate_feature_matrix([f_sum, f_max], entityset=es)
     assert fm.columns.tolist() == [f_sum.get_name(), f_max.get_name()]
 
 
@@ -589,12 +596,12 @@ def test_time_since_last_custom(pd_es):
 
             return time_since_last
 
-    f = ft.Feature(
+    f = Feature(
         pd_es["log"].ww["datetime"],
         parent_dataframe_name="customers",
         primitive=TimeSinceLast,
     )
-    fm = ft.calculate_feature_matrix(
+    fm = calculate_feature_matrix(
         [f], entityset=pd_es, instance_ids=[0, 1, 2], cutoff_time=datetime(2015, 6, 8)
     )
 
@@ -623,7 +630,7 @@ def test_custom_primitive_multiple_inputs(pd_es):
 
             return mean_sunday
 
-    fm, features = ft.dfs(
+    fm, features = dfs(
         entityset=pd_es,
         target_dataframe_name="sessions",
         agg_primitives=[MeanSunday],
@@ -636,7 +643,7 @@ def test_custom_primitive_multiple_inputs(pd_es):
 
     pd_es.add_interesting_values()
     mean_sunday_value_priority_0 = pd.Series([None, None, None, 2.5, 0, None])
-    fm, features = ft.dfs(
+    fm, features = dfs(
         entityset=pd_es,
         target_dataframe_name="sessions",
         agg_primitives=[MeanSunday],
@@ -658,15 +665,15 @@ def test_custom_primitive_default_kwargs(es):
             self.n = n
 
     sum_n_1_n = 1
-    sum_n_1_base_f = ft.Feature(es["log"].ww["value"])
-    sum_n_1 = ft.Feature(
+    sum_n_1_base_f = Feature(es["log"].ww["value"])
+    sum_n_1 = Feature(
         [sum_n_1_base_f],
         parent_dataframe_name="sessions",
         primitive=SumNTimes(n=sum_n_1_n),
     )
     sum_n_2_n = 2
-    sum_n_2_base_f = ft.Feature(es["log"].ww["value_2"])
-    sum_n_2 = ft.Feature(
+    sum_n_2_base_f = Feature(es["log"].ww["value_2"])
+    sum_n_2 = Feature(
         [sum_n_2_base_f],
         parent_dataframe_name="sessions",
         primitive=SumNTimes(n=sum_n_2_n),
@@ -710,7 +717,7 @@ def test_make_three_most_common(pd_es):
 
             return pd_top3
 
-    fm, features = ft.dfs(
+    fm, features = dfs(
         entityset=pd_es,
         target_dataframe_name="customers",
         instance_ids=[0, 1, 2],
@@ -742,7 +749,7 @@ def test_make_three_most_common(pd_es):
 
 def test_stacking_multi(pd_es):
     threecommon = NMostCommon(3)
-    tc = ft.Feature(
+    tc = Feature(
         pd_es["log"].ww["product_id"],
         parent_dataframe_name="sessions",
         primitive=threecommon,
@@ -751,10 +758,10 @@ def test_stacking_multi(pd_es):
     stacked = []
     for i in range(3):
         stacked.append(
-            ft.Feature(tc[i], parent_dataframe_name="customers", primitive=NumUnique)
+            Feature(tc[i], parent_dataframe_name="customers", primitive=NumUnique)
         )
 
-    fm = ft.calculate_feature_matrix(stacked, entityset=pd_es, instance_ids=[0, 1, 2])
+    fm = calculate_feature_matrix(stacked, entityset=pd_es, instance_ids=[0, 1, 2])
 
     correct_vals = [[3, 2, 1], [2, 1, 0], [0, 0, 0]]
     correct_vals1 = [[3, 1, 1], [2, 1, 0], [0, 0, 0]]
@@ -772,14 +779,14 @@ def test_stacking_multi(pd_es):
 
 
 def test_use_previous_pd_dateoffset(es):
-    total_events_pd = ft.Feature(
+    total_events_pd = Feature(
         es["log"].ww["id"],
         parent_dataframe_name="customers",
         use_previous=pd.DateOffset(hours=47, minutes=60),
         primitive=Count,
     )
 
-    feature_matrix = ft.calculate_feature_matrix(
+    feature_matrix = calculate_feature_matrix(
         [total_events_pd],
         es,
         cutoff_time=pd.Timestamp("2011-04-11 10:31:30"),
@@ -835,7 +842,7 @@ def test_override_multi_feature_names(pd_es):
                 use_prev_str,
             )
 
-    fm, features = ft.dfs(
+    fm, features = dfs(
         entityset=pd_es,
         target_dataframe_name="products",
         instance_ids=[0, 1, 2],

--- a/featuretools/tests/primitive_tests/test_agg_feats.py
+++ b/featuretools/tests/primitive_tests/test_agg_feats.py
@@ -12,6 +12,7 @@ from featuretools import (
     AggregationFeature,
     Feature,
     IdentityFeature,
+    PrimitivesDeserializer,
     Timedelta,
     calculate_feature_matrix,
     dfs,

--- a/featuretools/tests/primitive_tests/test_dask_primitives.py
+++ b/featuretools/tests/primitive_tests/test_dask_primitives.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import pytest
 
-import featuretools as ft
+from featuretools import calculate_feature_matrix, dfs, list_primitives
 from featuretools.primitives import get_aggregation_primitives, get_transform_primitives
 from featuretools.utils.gen_utils import Library
 
@@ -21,7 +21,7 @@ def test_transform(pd_es, dask_es):
     pytest.skip(
         "TODO: Dask issue with `series.eq`. Fix once Dask Issue #7957 is closed."
     )
-    primitives = ft.list_primitives()
+    primitives = list_primitives()
     trans_list = primitives[primitives["type"] == "transform"]["name"].tolist()
     trans_primitives = [prim for prim in trans_list if prim not in UNSUPPORTED]
     agg_primitives = []
@@ -31,7 +31,7 @@ def test_transform(pd_es, dask_es):
 
     # Run DFS using each dataframe as a target and confirm results match
     for df in pd_es.dataframes:
-        features = ft.dfs(
+        features = dfs(
             entityset=pd_es,
             target_dataframe_name=df.ww.name,
             trans_primitives=trans_primitives,
@@ -40,7 +40,7 @@ def test_transform(pd_es, dask_es):
             features_only=True,
         )
 
-        dask_features = ft.dfs(
+        dask_features = dfs(
             entityset=dask_es,
             target_dataframe_name=df.ww.name,
             trans_primitives=trans_primitives,
@@ -52,10 +52,10 @@ def test_transform(pd_es, dask_es):
 
         # Calculate feature matrix values to confirm output is the same between dask and pandas.
         # Not testing on all returned features due to long run times.
-        fm = ft.calculate_feature_matrix(
+        fm = calculate_feature_matrix(
             features=features[:100], entityset=pd_es, cutoff_time=cutoff_time
         )
-        dask_fm = ft.calculate_feature_matrix(
+        dask_fm = calculate_feature_matrix(
             features=dask_features[:100], entityset=dask_es, cutoff_time=cutoff_time
         )
 
@@ -70,7 +70,7 @@ def test_transform(pd_es, dask_es):
 
 
 def test_aggregation(pd_es, dask_es):
-    primitives = ft.list_primitives()
+    primitives = list_primitives()
     trans_primitives = []
     agg_list = primitives[primitives["type"] == "aggregation"]["name"].tolist()
     agg_primitives = [prim for prim in agg_list if prim not in UNSUPPORTED]
@@ -79,7 +79,7 @@ def test_aggregation(pd_es, dask_es):
 
     # Run DFS using each dataframe as a target and confirm results match
     for df in pd_es.dataframes:
-        fm, _ = ft.dfs(
+        fm, _ = dfs(
             entityset=pd_es,
             target_dataframe_name=df.ww.name,
             trans_primitives=trans_primitives,
@@ -88,7 +88,7 @@ def test_aggregation(pd_es, dask_es):
             max_depth=2,
         )
 
-        dask_fm, _ = ft.dfs(
+        dask_fm, _ = dfs(
             entityset=dask_es,
             target_dataframe_name=df.ww.name,
             trans_primitives=trans_primitives,

--- a/featuretools/tests/primitive_tests/test_direct_features.py
+++ b/featuretools/tests/primitive_tests/test_direct_features.py
@@ -4,12 +4,11 @@ import pytest
 from woodwork.column_schema import ColumnSchema
 from woodwork.logical_types import Datetime
 
-import featuretools as ft
+from featuretools import DirectFeature, Feature, IdentityFeature
 from featuretools.computational_backends.feature_set import FeatureSet
 from featuretools.computational_backends.feature_set_calculator import (
     FeatureSetCalculator,
 )
-from featuretools.feature_base import DirectFeature, Feature, IdentityFeature
 from featuretools.primitives import (
     AggregationPrimitive,
     Day,
@@ -274,7 +273,7 @@ def test_direct_with_no_path(diamond_es):
 
 
 def test_serialization(es):
-    value = ft.IdentityFeature(es["products"].ww["rating"])
+    value = IdentityFeature(es["products"].ww["rating"])
     direct = DirectFeature(value, "log")
 
     log_to_products = next(

--- a/featuretools/tests/primitive_tests/test_feature_base.py
+++ b/featuretools/tests/primitive_tests/test_feature_base.py
@@ -6,7 +6,7 @@ from pympler.asizeof import asizeof
 from woodwork.column_schema import ColumnSchema
 from woodwork.logical_types import Datetime, Integer
 
-from featuretools import Feature, FeatureOutputSlice, IdentityFeature, config
+from featuretools import Feature, feature_base, IdentityFeature, config
 from featuretools.primitives import (
     Count,
     Diff,
@@ -441,7 +441,7 @@ def test_rename_featureoutputslice(es):
         parent_dataframe_name="customers",
         primitive=NMostCommon(n=2),
     )
-    feat = FeatureOutputSlice(multi_output_feat, 0)
+    feat = feature_base.FeatureOutputSlice(multi_output_feat, 0)
     new_name = "session_test"
     new_names = ["session_test"]
     check_rename(feat, new_name, new_names)

--- a/featuretools/tests/primitive_tests/test_feature_base.py
+++ b/featuretools/tests/primitive_tests/test_feature_base.py
@@ -6,7 +6,7 @@ from pympler.asizeof import asizeof
 from woodwork.column_schema import ColumnSchema
 from woodwork.logical_types import Datetime, Integer
 
-from featuretools import Feature, feature_base, IdentityFeature, config
+from featuretools import Feature, IdentityFeature, config, feature_base, primitive
 from featuretools.primitives import (
     Count,
     Diff,
@@ -293,7 +293,7 @@ def test_to_dictionary_where(es):
 def test_to_dictionary_trans(es):
     trans_feature = Feature(es["customers"].ww["age"], primitive=Negate)
     primitive = Negate()
-    trans_feature = ft.Feature(es["customers"].ww["age"], primitive=primitive)
+    trans_feature = Feature(es["customers"].ww["age"], primitive=primitive)
 
     expected = {
         "type": "TransformFeature",

--- a/featuretools/tests/primitive_tests/test_feature_base.py
+++ b/featuretools/tests/primitive_tests/test_feature_base.py
@@ -5,9 +5,7 @@ from pympler.asizeof import asizeof
 from woodwork.column_schema import ColumnSchema
 from woodwork.logical_types import Datetime, Integer
 
-import featuretools as ft
-from featuretools import config
-from featuretools.feature_base import IdentityFeature
+from featuretools import Feature, FeatureOutputSlice, IdentityFeature, config
 from featuretools.primitives import (
     Count,
     Diff,
@@ -23,22 +21,22 @@ from featuretools.tests.testing_utils import check_rename
 
 
 def test_copy_features_does_not_copy_entityset(es):
-    agg = ft.Feature(
+    agg = Feature(
         es["log"].ww["value"], parent_dataframe_name="sessions", primitive=Sum
     )
-    agg_where = ft.Feature(
+    agg_where = Feature(
         es["log"].ww["value"],
         parent_dataframe_name="sessions",
         where=IdentityFeature(es["log"].ww["value"]) == 2,
         primitive=Sum,
     )
-    agg_use_previous = ft.Feature(
+    agg_use_previous = Feature(
         es["log"].ww["value"],
         parent_dataframe_name="sessions",
         use_previous="4 days",
         primitive=Sum,
     )
-    agg_use_previous_where = ft.Feature(
+    agg_use_previous_where = Feature(
         es["log"].ww["value"],
         parent_dataframe_name="sessions",
         where=IdentityFeature(es["log"].ww["value"]) == 2,
@@ -53,10 +51,10 @@ def test_copy_features_does_not_copy_entityset(es):
 
 
 def test_get_dependencies(es):
-    f = ft.Feature(es["log"].ww["value"])
-    agg1 = ft.Feature(f, parent_dataframe_name="sessions", primitive=Sum)
-    agg2 = ft.Feature(agg1, parent_dataframe_name="customers", primitive=Sum)
-    d1 = ft.Feature(agg2, "sessions")
+    f = Feature(es["log"].ww["value"])
+    agg1 = Feature(f, parent_dataframe_name="sessions", primitive=Sum)
+    agg2 = Feature(agg1, parent_dataframe_name="customers", primitive=Sum)
+    d1 = Feature(agg2, "sessions")
     shallow = d1.get_dependencies(deep=False, ignored=None)
     deep = d1.get_dependencies(deep=True, ignored=None)
     ignored = set([agg1.unique_name()])
@@ -71,12 +69,12 @@ def test_get_dependencies(es):
 
 
 def test_get_depth(es):
-    f = ft.Feature(es["log"].ww["value"])
-    g = ft.Feature(es["log"].ww["value"])
-    agg1 = ft.Feature(f, parent_dataframe_name="sessions", primitive=Last)
-    agg2 = ft.Feature(agg1, parent_dataframe_name="customers", primitive=Last)
-    d1 = ft.Feature(agg2, "sessions")
-    d2 = ft.Feature(d1, "log")
+    f = Feature(es["log"].ww["value"])
+    g = Feature(es["log"].ww["value"])
+    agg1 = Feature(f, parent_dataframe_name="sessions", primitive=Last)
+    agg2 = Feature(agg1, parent_dataframe_name="customers", primitive=Last)
+    d1 = Feature(agg2, "sessions")
+    d2 = Feature(d1, "log")
     assert d2.get_depth() == 4
     # Make sure this works if we pass in two of the same
     # feature. This came up when user supplied duplicates
@@ -90,7 +88,7 @@ def test_get_depth(es):
 
 
 def test_squared(es):
-    feature = ft.Feature(es["log"].ww["value"])
+    feature = Feature(es["log"].ww["value"])
     squared = feature * feature
     assert len(squared.base_features) == 2
     assert (
@@ -99,7 +97,7 @@ def test_squared(es):
 
 
 def test_return_type_inference(es):
-    mode = ft.Feature(
+    mode = Feature(
         es["log"].ww["priority_level"],
         parent_dataframe_name="customers",
         primitive=Mode,
@@ -111,12 +109,12 @@ def test_return_type_inference(es):
 
 
 def test_return_type_inference_direct_feature(es):
-    mode = ft.Feature(
+    mode = Feature(
         es["log"].ww["priority_level"],
         parent_dataframe_name="customers",
         primitive=Mode,
     )
-    mode_session = ft.Feature(mode, "sessions")
+    mode_session = Feature(mode, "sessions")
     assert (
         mode_session.column_schema
         == IdentityFeature(es["log"].ww["priority_level"]).column_schema
@@ -124,7 +122,7 @@ def test_return_type_inference_direct_feature(es):
 
 
 def test_return_type_inference_index(es):
-    last = ft.Feature(
+    last = Feature(
         es["log"].ww["id"], parent_dataframe_name="customers", primitive=Last
     )
     assert "index" not in last.column_schema.semantic_tags
@@ -132,14 +130,14 @@ def test_return_type_inference_index(es):
 
 
 def test_return_type_inference_datetime_time_index(es):
-    last = ft.Feature(
+    last = Feature(
         es["log"].ww["datetime"], parent_dataframe_name="customers", primitive=Last
     )
     assert isinstance(last.column_schema.logical_type, Datetime)
 
 
 def test_return_type_inference_numeric_time_index(int_es):
-    last = ft.Feature(
+    last = Feature(
         int_es["log"].ww["datetime"], parent_dataframe_name="customers", primitive=Last
     )
     assert "numeric" in last.column_schema.semantic_tags
@@ -147,18 +145,18 @@ def test_return_type_inference_numeric_time_index(int_es):
 
 def test_return_type_inference_id(es):
     # direct features should keep foreign key tag
-    direct_id_feature = ft.Feature(es["sessions"].ww["customer_id"], "log")
+    direct_id_feature = Feature(es["sessions"].ww["customer_id"], "log")
     assert "foreign_key" in direct_id_feature.column_schema.semantic_tags
 
     # aggregations of foreign key types should get converted
-    last_feat = ft.Feature(
+    last_feat = Feature(
         es["log"].ww["session_id"], parent_dataframe_name="customers", primitive=Last
     )
     assert "foreign_key" not in last_feat.column_schema.semantic_tags
     assert isinstance(last_feat.column_schema.logical_type, Integer)
 
     # also test direct feature of aggregation
-    last_direct = ft.Feature(last_feat, "sessions")
+    last_direct = Feature(last_feat, "sessions")
     assert "foreign_key" not in last_direct.column_schema.semantic_tags
     assert isinstance(last_direct.column_schema.logical_type, Integer)
 
@@ -194,7 +192,7 @@ def test_set_data_path(es):
 
 
 def test_to_dictionary_direct(es):
-    actual = ft.Feature(
+    actual = Feature(
         IdentityFeature(es["sessions"].ww["customer_id"]), "log"
     ).to_dictionary()
 
@@ -217,7 +215,7 @@ def test_to_dictionary_direct(es):
 
 
 def test_to_dictionary_identity(es):
-    actual = ft.Feature(es["sessions"].ww["customer_id"]).to_dictionary()
+    actual = Feature(es["sessions"].ww["customer_id"]).to_dictionary()
 
     expected = {
         "type": "IdentityFeature",
@@ -233,7 +231,7 @@ def test_to_dictionary_identity(es):
 
 
 def test_to_dictionary_agg(es):
-    actual = ft.Feature(
+    actual = Feature(
         es["customers"].ww["age"], primitive=Sum, parent_dataframe_name="cohorts"
     ).to_dictionary()
 
@@ -265,10 +263,10 @@ def test_to_dictionary_agg(es):
 
 
 def test_to_dictionary_where(es):
-    actual = ft.Feature(
+    actual = Feature(
         es["log"].ww["value"],
         parent_dataframe_name="sessions",
-        where=ft.IdentityFeature(es["log"].ww["value"]) == 2,
+        where=IdentityFeature(es["log"].ww["value"]) == 2,
         primitive=Sum,
     ).to_dictionary()
 
@@ -300,7 +298,7 @@ def test_to_dictionary_where(es):
 
 
 def test_to_dictionary_trans(es):
-    trans_feature = ft.Feature(es["customers"].ww["age"], primitive=Negate)
+    trans_feature = Feature(es["customers"].ww["age"], primitive=Negate)
 
     expected = {
         "type": "TransformFeature",
@@ -320,10 +318,8 @@ def test_to_dictionary_trans(es):
 
 
 def test_to_dictionary_groupby_trans(es):
-    id_feat = ft.Feature(es["log"].ww["product_id"])
-    groupby_feature = ft.Feature(
-        es["log"].ww["value"], primitive=Negate, groupby=id_feat
-    )
+    id_feat = Feature(es["log"].ww["product_id"])
+    groupby_feature = Feature(es["log"].ww["value"], primitive=Negate, groupby=id_feat)
 
     expected = {
         "type": "GroupByTransformFeature",
@@ -344,7 +340,7 @@ def test_to_dictionary_groupby_trans(es):
 
 
 def test_to_dictionary_multi_slice(es):
-    slice_feature = ft.Feature(
+    slice_feature = Feature(
         es["log"].ww["product_id"],
         parent_dataframe_name="customers",
         primitive=NMostCommon(n=2),
@@ -365,14 +361,14 @@ def test_to_dictionary_multi_slice(es):
 
 def test_multi_output_base_error_agg(es):
     three_common = NMostCommon(3)
-    tc = ft.Feature(
+    tc = Feature(
         es["log"].ww["product_id"],
         parent_dataframe_name="sessions",
         primitive=three_common,
     )
     error_text = "Cannot stack on whole multi-output feature."
     with pytest.raises(ValueError, match=error_text):
-        ft.Feature(tc, parent_dataframe_name="customers", primitive=NumUnique)
+        Feature(tc, parent_dataframe_name="customers", primitive=NumUnique)
 
 
 def test_multi_output_base_error_trans(es):
@@ -382,15 +378,15 @@ def test_multi_output_base_error_trans(es):
         return_type = ColumnSchema(semantic_tags={"numeric"})
         number_output_features = 6
 
-    tc = ft.Feature(es["customers"].ww["birthday"], primitive=TestTime)
+    tc = Feature(es["customers"].ww["birthday"], primitive=TestTime)
 
     error_text = "Cannot stack on whole multi-output feature."
     with pytest.raises(ValueError, match=error_text):
-        ft.Feature(tc, primitive=Diff)
+        Feature(tc, primitive=Diff)
 
 
 def test_multi_output_attributes(es):
-    tc = ft.Feature(
+    tc = Feature(
         es["log"].ww["product_id"],
         parent_dataframe_name="sessions",
         primitive=NMostCommon,
@@ -408,14 +404,14 @@ def test_multi_output_attributes(es):
 
 def test_multi_output_index_error(es):
     error_text = "can only access slice of multi-output feature"
-    three_common = ft.Feature(
+    three_common = Feature(
         es["log"].ww["product_id"],
         parent_dataframe_name="sessions",
         primitive=NMostCommon,
     )
 
     with pytest.raises(AssertionError, match=error_text):
-        single = ft.Feature(
+        single = Feature(
             es["log"].ww["product_id"],
             parent_dataframe_name="sessions",
             primitive=NumUnique,
@@ -432,7 +428,7 @@ def test_multi_output_index_error(es):
 
 
 def test_rename(es):
-    feat = ft.Feature(
+    feat = Feature(
         es["log"].ww["id"], parent_dataframe_name="sessions", primitive=Count
     )
     new_name = "session_test"
@@ -441,7 +437,7 @@ def test_rename(es):
 
 
 def test_rename_multioutput(es):
-    feat = ft.Feature(
+    feat = Feature(
         es["log"].ww["product_id"],
         parent_dataframe_name="customers",
         primitive=NMostCommon(n=2),
@@ -452,12 +448,12 @@ def test_rename_multioutput(es):
 
 
 def test_rename_featureoutputslice(es):
-    multi_output_feat = ft.Feature(
+    multi_output_feat = Feature(
         es["log"].ww["product_id"],
         parent_dataframe_name="customers",
         primitive=NMostCommon(n=2),
     )
-    feat = ft.feature_base.FeatureOutputSlice(multi_output_feat, 0)
+    feat = FeatureOutputSlice(multi_output_feat, 0)
     new_name = "session_test"
     new_names = ["session_test"]
     check_rename(feat, new_name, new_names)

--- a/featuretools/tests/primitive_tests/test_feature_serialization.py
+++ b/featuretools/tests/primitive_tests/test_feature_serialization.py
@@ -321,7 +321,6 @@ def test_serialize_url(es):
         save_features(features_original, URL)
 
 
-
 def test_custom_feature_names_retained_during_serialization(pd_es, tmpdir):
     class MultiCumulative(TransformPrimitive):
         name = "multi_cum_sum"
@@ -359,8 +358,8 @@ def test_custom_feature_names_retained_during_serialization(pd_es, tmpdir):
         stacked_feat,
     ]
     file = os.path.join(tmpdir, "features.json")
-    ft.save_features(features, file)
-    deserialized_features = ft.load_features(file)
+    save_features(features, file)
+    deserialized_features = load_features(file)
 
     new_trans, new_agg, new_groupby, new_stacked = deserialized_features
     assert new_trans.get_feature_names() == trans_names
@@ -392,8 +391,8 @@ def test_deserializer_uses_common_primitive_instances_no_args(es, tmp_path):
     assert all([f.primitive is sum_primitive for f in sum_features])
 
     file = os.path.join(tmp_path, "features.json")
-    ft.save_features(features, file)
-    deserialized_features = ft.load_features(file)
+    save_features(features, file)
+    deserialized_features = load_features(file)
     new_is_null_features = [
         f for f in deserialized_features if f.primitive.name == "is_null"
     ]
@@ -438,7 +437,7 @@ def test_deserializer_uses_common_primitive_instances_with_args(es, tmp_path):
     assert all([f.primitive is scalar5 for f in scalar5_features])
 
     file = os.path.join(tmp_path, "features.json")
-    ft.save_features(features, file)
+    save_features(features, file)
     deserialized_features = load_features(file)
 
     new_scalar1_features = [
@@ -465,7 +464,7 @@ def test_deserializer_uses_common_primitive_instances_with_args(es, tmp_path):
         distance_to_holiday = DistanceToHoliday(
             holiday="Victoria Day", country="Canada"
         )
-        features = ft.dfs(
+        features = dfs(
             entityset=es,
             target_dataframe_name="customers",
             features_only=True,
@@ -483,7 +482,7 @@ def test_deserializer_uses_common_primitive_instances_with_args(es, tmp_path):
         assert all([f.primitive is distance_to_holiday for f in distance_features])
 
         file = os.path.join(tmp_path, "distance_features.json")
-        ft.save_features(distance_features, file)
+        save_features(distance_features, file)
         new_distance_features = load_features(file)
 
         # After deserialization all features that share a primitive should use the same primitive instance
@@ -511,7 +510,7 @@ def test_deserializer_uses_common_primitive_instances_with_args(es, tmp_path):
     assert all([f.primitive is is_in for f in is_in_features])
 
     file = os.path.join(tmp_path, "distance_features.json")
-    ft.save_features(is_in_features, file)
+    save_features(is_in_features, file)
     new_is_in_features = load_features(file)
 
     # After deserialization all features that share a primitive should use the same primitive instance

--- a/featuretools/tests/primitive_tests/test_feature_serialization.py
+++ b/featuretools/tests/primitive_tests/test_feature_serialization.py
@@ -331,7 +331,7 @@ def test_custom_feature_names_retained_during_serialization(pd_es, tmpdir):
     multi_output_trans_feat = Feature(
         pd_es["log"].ww["value"], primitive=MultiCumulative
     )
-    groupby_trans_feat = GroupByTransformFeature(
+    groupby_trans_feat = feature_base.GroupByTransformFeature(
         pd_es["log"].ww["value"],
         primitive=MultiCumulative,
         groupby=pd_es["log"].ww["product_id"],

--- a/featuretools/tests/primitive_tests/test_groupby_transform_primitives.py
+++ b/featuretools/tests/primitive_tests/test_groupby_transform_primitives.py
@@ -3,7 +3,7 @@ import pandas as pd
 from woodwork.column_schema import ColumnSchema
 from woodwork.logical_types import Datetime
 
-import featuretools as ft
+from featuretools import Feature, IdentityFeature, calculate_feature_matrix
 from featuretools.computational_backends.feature_set import FeatureSet
 from featuretools.computational_backends.feature_set_calculator import (
     FeatureSetCalculator,
@@ -141,13 +141,13 @@ class TestCumMin:
 
 
 def test_cum_sum(pd_es):
-    log_value_feat = ft.IdentityFeature(pd_es["log"].ww["value"])
-    dfeat = ft.Feature(
-        ft.IdentityFeature(pd_es["sessions"].ww["device_type"]), dataframe_name="log"
+    log_value_feat = IdentityFeature(pd_es["log"].ww["value"])
+    dfeat = Feature(
+        IdentityFeature(pd_es["sessions"].ww["device_type"]), dataframe_name="log"
     )
-    cum_sum = ft.Feature(log_value_feat, groupby=dfeat, primitive=CumSum)
+    cum_sum = Feature(log_value_feat, groupby=dfeat, primitive=CumSum)
     features = [cum_sum]
-    df = ft.calculate_feature_matrix(
+    df = calculate_feature_matrix(
         entityset=pd_es, features=features, instance_ids=range(15)
     )
     cvalues = df[cum_sum.get_name()].values
@@ -158,14 +158,14 @@ def test_cum_sum(pd_es):
 
 
 def test_cum_min(pd_es):
-    log_value_feat = ft.IdentityFeature(pd_es["log"].ww["value"])
-    cum_min = ft.Feature(
+    log_value_feat = IdentityFeature(pd_es["log"].ww["value"])
+    cum_min = Feature(
         log_value_feat,
-        groupby=ft.IdentityFeature(pd_es["log"].ww["session_id"]),
+        groupby=IdentityFeature(pd_es["log"].ww["session_id"]),
         primitive=CumMin,
     )
     features = [cum_min]
-    df = ft.calculate_feature_matrix(
+    df = calculate_feature_matrix(
         entityset=pd_es, features=features, instance_ids=range(15)
     )
     cvalues = df[cum_min.get_name()].values
@@ -176,14 +176,14 @@ def test_cum_min(pd_es):
 
 
 def test_cum_max(pd_es):
-    log_value_feat = ft.IdentityFeature(pd_es["log"].ww["value"])
-    cum_max = ft.Feature(
+    log_value_feat = IdentityFeature(pd_es["log"].ww["value"])
+    cum_max = Feature(
         log_value_feat,
-        groupby=ft.IdentityFeature(pd_es["log"].ww["session_id"]),
+        groupby=IdentityFeature(pd_es["log"].ww["session_id"]),
         primitive=CumMax,
     )
     features = [cum_max]
-    df = ft.calculate_feature_matrix(
+    df = calculate_feature_matrix(
         entityset=pd_es, features=features, instance_ids=range(15)
     )
     cvalues = df[cum_max.get_name()].values
@@ -194,7 +194,7 @@ def test_cum_max(pd_es):
 
 
 def test_cum_sum_group_on_nan(pd_es):
-    log_value_feat = ft.IdentityFeature(pd_es["log"].ww["value"])
+    log_value_feat = IdentityFeature(pd_es["log"].ww["value"])
     pd_es["log"]["product_id"] = (
         ["coke zero"] * 3
         + ["car"] * 2
@@ -205,13 +205,13 @@ def test_cum_sum_group_on_nan(pd_es):
         + ["coke_zero"] * 2
     )
     pd_es["log"]["value"][16] = 10
-    cum_sum = ft.Feature(
+    cum_sum = Feature(
         log_value_feat,
-        groupby=ft.IdentityFeature(pd_es["log"].ww["product_id"]),
+        groupby=IdentityFeature(pd_es["log"].ww["product_id"]),
         primitive=CumSum,
     )
     features = [cum_sum]
-    df = ft.calculate_feature_matrix(
+    df = calculate_feature_matrix(
         entityset=pd_es, features=features, instance_ids=range(17)
     )
     cvalues = df[cum_sum.get_name()].values
@@ -259,7 +259,7 @@ def test_cum_sum_numpy_group_on_nan(pd_es):
 
             return cum_sum
 
-    log_value_feat = ft.IdentityFeature(pd_es["log"].ww["value"])
+    log_value_feat = IdentityFeature(pd_es["log"].ww["value"])
     pd_es["log"]["product_id"] = (
         ["coke zero"] * 3
         + ["car"] * 2
@@ -270,14 +270,14 @@ def test_cum_sum_numpy_group_on_nan(pd_es):
         + ["coke_zero"] * 2
     )
     pd_es["log"]["value"][16] = 10
-    cum_sum = ft.Feature(
+    cum_sum = Feature(
         log_value_feat,
-        groupby=ft.IdentityFeature(pd_es["log"].ww["product_id"]),
+        groupby=IdentityFeature(pd_es["log"].ww["product_id"]),
         primitive=CumSumNumpy,
     )
     assert cum_sum.get_name() == "CUM_SUM(value) by product_id"
     features = [cum_sum]
-    df = ft.calculate_feature_matrix(
+    df = calculate_feature_matrix(
         entityset=pd_es, features=features, instance_ids=range(17)
     )
     cvalues = df[cum_sum.get_name()].values
@@ -324,31 +324,31 @@ def test_cum_handles_uses_full_dataframe(pd_es):
 
     for primitive in [CumSum, CumMean, CumMax, CumMin]:
         check(
-            ft.Feature(
+            Feature(
                 pd_es["log"].ww["value"],
-                groupby=ft.IdentityFeature(pd_es["log"].ww["session_id"]),
+                groupby=IdentityFeature(pd_es["log"].ww["session_id"]),
                 primitive=primitive,
             )
         )
 
     check(
-        ft.Feature(
+        Feature(
             pd_es["log"].ww["product_id"],
-            groupby=ft.Feature(pd_es["log"].ww["product_id"]),
+            groupby=Feature(pd_es["log"].ww["product_id"]),
             primitive=CumCount,
         )
     )
 
 
 def test_cum_mean(pd_es):
-    log_value_feat = ft.IdentityFeature(pd_es["log"].ww["value"])
-    cum_mean = ft.Feature(
+    log_value_feat = IdentityFeature(pd_es["log"].ww["value"])
+    cum_mean = Feature(
         log_value_feat,
-        groupby=ft.IdentityFeature(pd_es["log"].ww["session_id"]),
+        groupby=IdentityFeature(pd_es["log"].ww["session_id"]),
         primitive=CumMean,
     )
     features = [cum_mean]
-    df = ft.calculate_feature_matrix(
+    df = calculate_feature_matrix(
         entityset=pd_es, features=features, instance_ids=range(15)
     )
     cvalues = df[cum_mean.get_name()].values
@@ -359,13 +359,13 @@ def test_cum_mean(pd_es):
 
 
 def test_cum_count(pd_es):
-    cum_count = ft.Feature(
-        ft.IdentityFeature(pd_es["log"].ww["product_id"]),
-        groupby=ft.IdentityFeature(pd_es["log"].ww["product_id"]),
+    cum_count = Feature(
+        IdentityFeature(pd_es["log"].ww["product_id"]),
+        groupby=IdentityFeature(pd_es["log"].ww["product_id"]),
         primitive=CumCount,
     )
     features = [cum_count]
-    df = ft.calculate_feature_matrix(
+    df = calculate_feature_matrix(
         entityset=pd_es, features=features, instance_ids=range(15)
     )
     cvalues = df[cum_count.get_name()].values
@@ -376,9 +376,9 @@ def test_cum_count(pd_es):
 
 
 def test_rename(pd_es):
-    cum_count = ft.Feature(
-        ft.IdentityFeature(pd_es["log"].ww["product_id"]),
-        groupby=ft.IdentityFeature(pd_es["log"].ww["product_id"]),
+    cum_count = Feature(
+        IdentityFeature(pd_es["log"].ww["product_id"]),
+        groupby=IdentityFeature(pd_es["log"].ww["product_id"]),
         primitive=CumCount,
     )
     copy_feat = cum_count.rename("rename_test")
@@ -394,13 +394,13 @@ def test_rename(pd_es):
 
 
 def test_groupby_no_data(pd_es):
-    cum_count = ft.Feature(
-        ft.IdentityFeature(pd_es["log"].ww["product_id"]),
-        groupby=ft.IdentityFeature(pd_es["log"].ww["product_id"]),
+    cum_count = Feature(
+        IdentityFeature(pd_es["log"].ww["product_id"]),
+        groupby=IdentityFeature(pd_es["log"].ww["product_id"]),
         primitive=CumCount,
     )
-    last_feat = ft.Feature(cum_count, parent_dataframe_name="customers", primitive=Last)
-    df = ft.calculate_feature_matrix(
+    last_feat = Feature(cum_count, parent_dataframe_name="customers", primitive=Last)
+    df = calculate_feature_matrix(
         entityset=pd_es, features=[last_feat], cutoff_time=pd.Timestamp("2011-04-08")
     )
     cvalues = df[last_feat.get_name()].values
@@ -430,13 +430,13 @@ def test_groupby_uses_calc_time(pd_es):
 
     time_since_product = ft.GroupByTransformFeature(
         [
-            ft.IdentityFeature(pd_es["log"].ww["value"]),
-            ft.IdentityFeature(pd_es["log"].ww["datetime"]),
+            IdentityFeature(pd_es["log"].ww["value"]),
+            IdentityFeature(pd_es["log"].ww["datetime"]),
         ],
-        groupby=ft.IdentityFeature(pd_es["log"].ww["product_id"]),
+        groupby=IdentityFeature(pd_es["log"].ww["product_id"]),
         primitive=ProjectedAmountRemaining,
     )
-    df = ft.calculate_feature_matrix(
+    df = calculate_feature_matrix(
         entityset=pd_es,
         features=[time_since_product],
         cutoff_time=pd.Timestamp("2011-04-10 11:10:30"),
@@ -488,10 +488,10 @@ def test_groupby_multi_output_stacking(pd_es):
 
 
 def test_serialization(pd_es):
-    value = ft.IdentityFeature(pd_es["log"].ww["value"])
-    zipcode = ft.IdentityFeature(pd_es["log"].ww["zipcode"])
+    value = IdentityFeature(pd_es["log"].ww["value"])
+    zipcode = IdentityFeature(pd_es["log"].ww["zipcode"])
     primitive = CumSum()
-    groupby = ft.feature_base.GroupByTransformFeature(value, primitive, zipcode)
+    groupby = Feature_base.GroupByTransformFeature(value, primitive, zipcode)
 
     dictionary = {
         "name": None,
@@ -505,7 +505,7 @@ def test_serialization(pd_es):
         value.unique_name(): value,
         zipcode.unique_name(): zipcode,
     }
-    assert groupby == ft.feature_base.GroupByTransformFeature.from_dictionary(
+    assert groupby == Feature_base.GroupByTransformFeature.from_dictionary(
         dictionary, pd_es, dependencies, PrimitivesDeserializer()
     )
 

--- a/featuretools/tests/primitive_tests/test_groupby_transform_primitives.py
+++ b/featuretools/tests/primitive_tests/test_groupby_transform_primitives.py
@@ -3,7 +3,12 @@ import pandas as pd
 from woodwork.column_schema import ColumnSchema
 from woodwork.logical_types import Datetime
 
-from featuretools import Feature, IdentityFeature, calculate_feature_matrix
+from featuretools import (
+    Feature,
+    GroupByTransformFeature,
+    IdentityFeature,
+    calculate_feature_matrix,
+)
 from featuretools.computational_backends.feature_set import FeatureSet
 from featuretools.computational_backends.feature_set_calculator import (
     FeatureSetCalculator,
@@ -428,7 +433,7 @@ def test_groupby_uses_calc_time(pd_es):
         def get_function(self):
             return projected_amount_left
 
-    time_since_product = ft.GroupByTransformFeature(
+    time_since_product = GroupByTransformFeature(
         [
             IdentityFeature(pd_es["log"].ww["value"]),
             IdentityFeature(pd_es["log"].ww["datetime"]),
@@ -491,7 +496,7 @@ def test_serialization(pd_es):
     value = IdentityFeature(pd_es["log"].ww["value"])
     zipcode = IdentityFeature(pd_es["log"].ww["zipcode"])
     primitive = CumSum()
-    groupby = Feature_base.GroupByTransformFeature(value, primitive, zipcode)
+    groupby = GroupByTransformFeature(value, primitive, zipcode)
 
     dictionary = {
         "name": None,
@@ -505,7 +510,7 @@ def test_serialization(pd_es):
         value.unique_name(): value,
         zipcode.unique_name(): zipcode,
     }
-    assert groupby == Feature_base.GroupByTransformFeature.from_dictionary(
+    assert groupby == GroupByTransformFeature.from_dictionary(
         dictionary, pd_es, dependencies, PrimitivesDeserializer()
     )
 

--- a/featuretools/tests/primitive_tests/test_groupby_transform_primitives.py
+++ b/featuretools/tests/primitive_tests/test_groupby_transform_primitives.py
@@ -5,9 +5,9 @@ from woodwork.logical_types import Datetime
 
 from featuretools import (
     Feature,
-    GroupByTransformFeature,
     IdentityFeature,
     calculate_feature_matrix,
+    feature_base,
 )
 from featuretools.computational_backends.feature_set import FeatureSet
 from featuretools.computational_backends.feature_set_calculator import (
@@ -432,7 +432,7 @@ def test_groupby_uses_calc_time(pd_es):
         def get_function(self):
             return projected_amount_left
 
-    time_since_product = GroupByTransformFeature(
+    time_since_product = feature_base.GroupByTransformFeature(
         [
             IdentityFeature(pd_es["log"].ww["value"]),
             IdentityFeature(pd_es["log"].ww["datetime"]),
@@ -495,7 +495,7 @@ def test_serialization(pd_es):
     value = IdentityFeature(pd_es["log"].ww["value"])
     zipcode = IdentityFeature(pd_es["log"].ww["zipcode"])
     primitive = CumSum()
-    groupby = GroupByTransformFeature(value, primitive, zipcode)
+    groupby = feature_base.GroupByTransformFeature(value, primitive, zipcode)
 
     dictionary = {
         "name": "CUM_SUM(value) by zipcode",
@@ -509,7 +509,7 @@ def test_serialization(pd_es):
         value.unique_name(): value,
         zipcode.unique_name(): zipcode,
     }
-    assert groupby == ft.feature_base.GroupByTransformFeature.from_dictionary(
+    assert groupby == feature_base.GroupByTransformFeature.from_dictionary(
         dictionary, pd_es, dependencies, primitive
     )
 

--- a/featuretools/tests/primitive_tests/test_identity_features.py
+++ b/featuretools/tests/primitive_tests/test_identity_features.py
@@ -1,6 +1,7 @@
 import featuretools as ft
-from featuretools.primitives.utils import PrimitivesDeserializer
 from featuretools import IdentityFeature
+from featuretools.primitives.utils import PrimitivesDeserializer
+
 
 def test_relationship_path(es):
     value = IdentityFeature(es["log"].ww["value"])

--- a/featuretools/tests/primitive_tests/test_identity_features.py
+++ b/featuretools/tests/primitive_tests/test_identity_features.py
@@ -1,14 +1,14 @@
 import featuretools as ft
 from featuretools.primitives.utils import PrimitivesDeserializer
-
+from featuretools import IdentityFeature
 
 def test_relationship_path(es):
-    value = ft.IdentityFeature(es["log"].ww["value"])
+    value = IdentityFeature(es["log"].ww["value"])
     assert len(value.relationship_path) == 0
 
 
 def test_serialization(es):
-    value = ft.IdentityFeature(es["log"].ww["value"])
+    value = IdentityFeature(es["log"].ww["value"])
 
     dictionary = {
         "name": None,
@@ -17,6 +17,6 @@ def test_serialization(es):
     }
 
     assert dictionary == value.get_arguments()
-    assert value == ft.IdentityFeature.from_dictionary(
+    assert value == IdentityFeature.from_dictionary(
         dictionary, es, {}, PrimitivesDeserializer
     )

--- a/featuretools/tests/primitive_tests/test_identity_features.py
+++ b/featuretools/tests/primitive_tests/test_identity_features.py
@@ -1,4 +1,3 @@
-import featuretools as ft
 from featuretools import IdentityFeature
 from featuretools.primitives.utils import PrimitivesDeserializer
 

--- a/featuretools/tests/primitive_tests/test_overrides.py
+++ b/featuretools/tests/primitive_tests/test_overrides.py
@@ -1,4 +1,5 @@
 import featuretools as ft
+from featuretools import Feature, calculate_feature_matrix
 from featuretools.primitives import (
     AddNumeric,
     AddNumericScalar,
@@ -30,10 +31,7 @@ from featuretools.primitives import (
     Sum,
 )
 from featuretools.tests.testing_utils import to_pandas
-from featuretools import (
-    calculate_feature_matrix,
-    Feature 
-)
+
 
 def test_overrides(es):
     value = Feature(es["log"].ww["value"])

--- a/featuretools/tests/primitive_tests/test_overrides.py
+++ b/featuretools/tests/primitive_tests/test_overrides.py
@@ -30,11 +30,14 @@ from featuretools.primitives import (
     Sum,
 )
 from featuretools.tests.testing_utils import to_pandas
-
+from featuretools import (
+    calculate_feature_matrix,
+    Feature 
+)
 
 def test_overrides(es):
-    value = ft.Feature(es["log"].ww["value"])
-    value2 = ft.Feature(es["log"].ww["value_2"])
+    value = Feature(es["log"].ww["value"])
+    value2 = Feature(es["log"].ww["value_2"])
 
     feats = [
         AddNumeric,
@@ -49,7 +52,7 @@ def test_overrides(es):
         GreaterThanEqualTo,
         LessThanEqualTo,
     ]
-    assert ft.Feature(value, primitive=Negate).unique_name() == (-value).unique_name()
+    assert Feature(value, primitive=Negate).unique_name() == (-value).unique_name()
 
     compares = [(value, value), (value, value2)]
     overrides = [
@@ -79,17 +82,17 @@ def test_overrides(es):
 
     for left, right in compares:
         for feat in feats:
-            f = ft.Feature([left, right], primitive=feat)
+            f = Feature([left, right], primitive=feat)
             o = overrides.pop(0)
             assert o.unique_name() == f.unique_name()
 
 
 def test_override_boolean(es):
-    count = ft.Feature(
+    count = Feature(
         es["log"].ww["id"], parent_dataframe_name="sessions", primitive=Count
     )
-    count_lo = ft.Feature(count, primitive=GreaterThanScalar(1))
-    count_hi = ft.Feature(count, primitive=LessThanScalar(10))
+    count_lo = Feature(count, primitive=GreaterThanScalar(1))
+    count_hi = Feature(count, primitive=LessThanScalar(10))
 
     to_test = [[True, True, True], [True, True, False], [False, False, True]]
 
@@ -108,7 +111,7 @@ def test_override_boolean(es):
 
 
 def test_scalar_overrides(es):
-    value = ft.Feature(es["log"].ww["value"])
+    value = Feature(es["log"].ww["value"])
 
     feats = [
         AddNumericScalar,
@@ -139,11 +142,11 @@ def test_scalar_overrides(es):
     ]
 
     for feat in feats:
-        f = ft.Feature(value, primitive=feat(2))
+        f = Feature(value, primitive=feat(2))
         o = overrides.pop(0)
         assert o.unique_name() == f.unique_name()
 
-    value2 = ft.Feature(es["log"].ww["value_2"])
+    value2 = Feature(es["log"].ww["value_2"])
 
     reverse_feats = [
         AddNumericScalar,
@@ -172,13 +175,13 @@ def test_scalar_overrides(es):
         2 >= value2,
     ]
     for feat in reverse_feats:
-        f = ft.Feature(value2, primitive=feat(2))
+        f = Feature(value2, primitive=feat(2))
         o = reverse_overrides.pop(0)
         assert o.unique_name() == f.unique_name()
 
 
 def test_override_cmp_from_column(es):
-    count_lo = ft.Feature(es["log"].ww["value"]) > 1
+    count_lo = Feature(es["log"].ww["value"]) > 1
 
     to_test = [False, True, True]
 
@@ -197,10 +200,10 @@ def test_override_cmp_from_column(es):
 
 
 def test_override_cmp(es):
-    count = ft.Feature(
+    count = Feature(
         es["log"].ww["id"], parent_dataframe_name="sessions", primitive=Count
     )
-    _sum = ft.Feature(
+    _sum = Feature(
         es["log"].ww["value"], parent_dataframe_name="sessions", primitive=Sum
     )
     gt_lo = count > 1

--- a/featuretools/tests/primitive_tests/test_overrides.py
+++ b/featuretools/tests/primitive_tests/test_overrides.py
@@ -99,7 +99,7 @@ def test_override_boolean(es):
     features.append(count_lo.AND(count_hi))
     features.append(~(count_lo.AND(count_hi)))
 
-    df = ft.calculate_feature_matrix(
+    df = calculate_feature_matrix(
         entityset=es, features=features, instance_ids=[0, 1, 2]
     )
     df = to_pandas(df, index="id", sort_index=True)
@@ -186,7 +186,7 @@ def test_override_cmp_from_column(es):
     features = [count_lo]
 
     df = to_pandas(
-        ft.calculate_feature_matrix(
+        calculate_feature_matrix(
             entityset=es, features=features, instance_ids=[0, 1, 2]
         ),
         index="id",
@@ -238,7 +238,7 @@ def test_override_cmp(es):
         ne_other,
     ]
 
-    df = ft.calculate_feature_matrix(
+    df = calculate_feature_matrix(
         entityset=es, features=features, instance_ids=[0, 1, 2]
     )
     df = to_pandas(df, index="id", sort_index=True)

--- a/featuretools/tests/primitive_tests/test_overrides.py
+++ b/featuretools/tests/primitive_tests/test_overrides.py
@@ -1,4 +1,3 @@
-import featuretools as ft
 from featuretools import Feature, calculate_feature_matrix
 from featuretools.primitives import (
     AddNumeric,


### PR DESCRIPTION
Further address #1511 by cleaning up the following files, and removing `ft. ` before featuretools functions

* Standardizes all files in `primitive_tests`