### PR TITLE
Remove 24th hour from and add 0th hour to PartOfDay

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,15 +2,18 @@
 
 Release Notes
 -------------
-.. Future Release
-  ==============
+Future Release
+==============
     * Enhancements
     * Fixes
+        * Remove 24th hour from PartOfDay primitive and add 0th hour (:pr:`2167`)
     * Changes
     * Documentation Changes
     * Testing Changes
 
-.. Thanks to the following people for contributing to this release:
+    Thanks to the following people for contributing to this release:
+    :user:`tamargrey`
+
 
 v1.11.0 Jun 30, 2022
 ====================

--- a/featuretools/primitives/standard/datetime_transform_primitives.py
+++ b/featuretools/primitives/standard/datetime_transform_primitives.py
@@ -618,7 +618,7 @@ class PartOfDay(TransformPrimitive):
             tdict[hour] = "evening"
         for hour in [20, 21, 22]:
             tdict[hour] = "night"
-        for hour in [23, 24, 1, 2, 3]:
+        for hour in [23, 0, 1, 2, 3]:
             tdict[hour] = "midnight"
         return tdict
 

--- a/featuretools/tests/primitive_tests/test_transform_primitive.py
+++ b/featuretools/tests/primitive_tests/test_transform_primitive.py
@@ -181,6 +181,7 @@ def test_part_of_day():
     pod = PartOfDay()
     dates = pd.Series(
         [
+            datetime(2020, 1, 11, 0, 2, 1),
             datetime(2020, 1, 11, 1, 2, 1),
             datetime(2021, 3, 31, 4, 2, 1),
             datetime(2020, 3, 4, 6, 2, 1),
@@ -195,6 +196,7 @@ def test_part_of_day():
     actual = pod(dates)
     expected = pd.Series(
         [
+            "midnight",
             "midnight",
             "dawn",
             "early morning",


### PR DESCRIPTION
Fixes bug where any timestamps from the 0th hour of a day wouldn't get transformed correctly to `midnight`
