### PR TITLE
Add back code coverage runs with specific Python version

### DIFF
--- a/.github/workflows/unit_tests_with_latest_deps.yaml
+++ b/.github/workflows/unit_tests_with_latest_deps.yaml
@@ -45,18 +45,18 @@ jobs:
           JAVA_HOME="/usr/lib/jvm/java-11-openjdk-amd64"
           python -m pip install -e unpacked_sdist/[spark]
           python -m pip install -e unpacked_sdist/[test]
-      - if: ${{ matrix.libraries != 'spark' }}
+      - if: ${{ matrix.libraries != '3.8' || matrix.libraries != 'spark' }}
         name: Run unit tests (no code coverage)
         run: |
           cd unpacked_sdist
           pytest featuretools/ -n 2
-      - if: ${{ matrix.libraries == 'spark' }}
+      - if: ${{ matrix.libraries == '3.8' || matrix.libraries == 'spark' }}
         name: Run unit tests with code coverage
         run: |
           cd unpacked_sdist/
           coverage erase
           pytest featuretools/ -n 2 --cov=featuretools --cov-config=../pyproject.toml --cov-report=xml:../coverage.xml
-      - if: ${{ matrix.libraries == 'spark' }}
+      - if: ${{ matrix.libraries == '3.8' || matrix.libraries == 'spark' }}
         name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -12,6 +12,7 @@ Future Release
         * Add periods parameter to ``Diff`` and add ``DiffDatetime`` primitive (:pr:`2155`)
     * Fixes
         * Resolves Woodwork integration test failure and removes Python version check for codecov (:pr:`2182`)
+        * Add back code coverage runs with specific Python version (:pr:`2184`)
     * Changes
         * Drop Python 3.7 support (:pr:`2169`)
         * Add pre-commit hooks for linting (:pr:`2177`)


### PR DESCRIPTION
- We run out unit tests with code coverage in the lowest Python version and with Spark installed.