### PR TITLE
Add unit tests to enforce primitive docstring verb usage

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -13,6 +13,7 @@ Future Release
         * Add create feedstock PR workflow (:pr:`2181`)
         * Limit performance tests to python 3.8 (:pr:`2198`)
         * Add test to ensure primitive docstrings use standardized verbs (:pr:`2200`)
+
     Thanks to the following people for contributing to this release:
     :user:`gsheni`, :user:`rwedge`, :user:`sbadithe`
 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -12,9 +12,9 @@ Future Release
     * Testing Changes
         * Add create feedstock PR workflow (:pr:`2181`)
         * Limit performance tests to python 3.8 (:pr:`2198`)
-
+        * Add test to ensure primitive docstrings use standardized verbs (:pr:`2200`)
     Thanks to the following people for contributing to this release:
-    :user:`gsheni`, :user:`rwedge`
+    :user:`gsheni`, :user:`rwedge`, :user:`sbadithe`
 
 v1.12.0 Jul 19, 2022
 ====================

--- a/featuretools/primitives/standard/binary_transform.py
+++ b/featuretools/primitives/standard/binary_transform.py
@@ -517,7 +517,7 @@ class NotEqualScalar(TransformPrimitive):
 
 
 class AddNumeric(TransformPrimitive):
-    """Computes element-wise addition of two lists.
+    """Performs element-wise addition of two lists.
 
     Description:
         Given a list of values X and a list of values
@@ -580,7 +580,7 @@ class AddNumericScalar(TransformPrimitive):
 
 
 class SubtractNumeric(TransformPrimitive):
-    """Computes element-wise subtraction of two lists.
+    """Performs element-wise subtraction of two lists.
 
     Description:
         Given a list of values X and a list of values
@@ -683,7 +683,7 @@ class ScalarSubtractNumericFeature(TransformPrimitive):
 
 
 class MultiplyNumeric(TransformPrimitive):
-    """Computes element-wise multiplication of two lists.
+    """Performs element-wise multiplication of two lists.
 
     Description:
         Given a list of values X and a list of values
@@ -746,7 +746,7 @@ class MultiplyNumericScalar(TransformPrimitive):
 
 
 class MultiplyBoolean(TransformPrimitive):
-    """Computes element-wise multiplication of two lists of boolean values.
+    """Performs element-wise multiplication of two lists of boolean values.
 
     Description:
         Given a list of boolean values X and a list of boolean
@@ -788,7 +788,7 @@ class MultiplyBoolean(TransformPrimitive):
 
 
 class MultiplyNumericBoolean(TransformPrimitive):
-    """Computes element-wise multiplication of a numeric list with a boolean list.
+    """Performs element-wise multiplication of a numeric list with a boolean list.
 
     Description:
         Given a list of numeric values X and a list of
@@ -852,7 +852,7 @@ class MultiplyNumericBoolean(TransformPrimitive):
 
 
 class DivideNumeric(TransformPrimitive):
-    """Computes element-wise division of two lists.
+    """Performs element-wise division of two lists.
 
     Description:
         Given a list of values X and a list of values
@@ -962,7 +962,7 @@ class DivideByFeature(TransformPrimitive):
 
 
 class ModuloNumeric(TransformPrimitive):
-    """Computes element-wise modulo of two lists.
+    """Performs element-wise modulo of two lists.
 
     Description:
         Given a list of values X and a list of values Y,
@@ -1062,7 +1062,7 @@ class ModuloByFeature(TransformPrimitive):
 
 
 class And(TransformPrimitive):
-    """Computes element-wise logical AND of two lists.
+    """Performs element-wise logical AND of two lists.
 
     Description:
         Given a list of booleans X and a list of booleans Y,
@@ -1104,7 +1104,7 @@ class And(TransformPrimitive):
 
 
 class Or(TransformPrimitive):
-    """Computes element-wise logical OR of two lists.
+    """Performs element-wise logical OR of two lists.
 
     Description:
         Given a list of booleans X and a list of booleans Y,

--- a/featuretools/primitives/standard/binary_transform.py
+++ b/featuretools/primitives/standard/binary_transform.py
@@ -517,7 +517,7 @@ class NotEqualScalar(TransformPrimitive):
 
 
 class AddNumeric(TransformPrimitive):
-    """Element-wise addition of two lists.
+    """Computes element-wise addition of two lists.
 
     Description:
         Given a list of values X and a list of values
@@ -548,7 +548,7 @@ class AddNumeric(TransformPrimitive):
 
 
 class AddNumericScalar(TransformPrimitive):
-    """Add a scalar to each value in the list.
+    """Adds a scalar to each value in the list.
 
     Description:
         Given a list of numeric values and a scalar, add
@@ -580,7 +580,7 @@ class AddNumericScalar(TransformPrimitive):
 
 
 class SubtractNumeric(TransformPrimitive):
-    """Element-wise subtraction of two lists.
+    """Computes element-wise subtraction of two lists.
 
     Description:
         Given a list of values X and a list of values
@@ -618,7 +618,7 @@ class SubtractNumeric(TransformPrimitive):
 
 
 class SubtractNumericScalar(TransformPrimitive):
-    """Subtract a scalar from each element in the list.
+    """Subtracts a scalar from each element in the list.
 
     Description:
         Given a list of numeric values and a scalar, subtract
@@ -650,7 +650,7 @@ class SubtractNumericScalar(TransformPrimitive):
 
 
 class ScalarSubtractNumericFeature(TransformPrimitive):
-    """Subtract each value in the list from a given scalar.
+    """Subtracts each value in the list from a given scalar.
 
     Description:
         Given a list of numeric values and a scalar, subtract
@@ -683,7 +683,7 @@ class ScalarSubtractNumericFeature(TransformPrimitive):
 
 
 class MultiplyNumeric(TransformPrimitive):
-    """Element-wise multiplication of two lists.
+    """Computes element-wise multiplication of two lists.
 
     Description:
         Given a list of values X and a list of values
@@ -714,7 +714,7 @@ class MultiplyNumeric(TransformPrimitive):
 
 
 class MultiplyNumericScalar(TransformPrimitive):
-    """Multiply each element in the list by a scalar.
+    """Multiplies each element in the list by a scalar.
 
     Description:
         Given a list of numeric values and a scalar, multiply
@@ -746,7 +746,7 @@ class MultiplyNumericScalar(TransformPrimitive):
 
 
 class MultiplyBoolean(TransformPrimitive):
-    """Element-wise multiplication of two lists of boolean values.
+    """Computes element-wise multiplication of two lists of boolean values.
 
     Description:
         Given a list of boolean values X and a list of boolean
@@ -788,7 +788,7 @@ class MultiplyBoolean(TransformPrimitive):
 
 
 class MultiplyNumericBoolean(TransformPrimitive):
-    """Element-wise multiplication of a numeric list with a boolean list.
+    """Computes element-wise multiplication of a numeric list with a boolean list.
 
     Description:
         Given a list of numeric values X and a list of
@@ -852,7 +852,7 @@ class MultiplyNumericBoolean(TransformPrimitive):
 
 
 class DivideNumeric(TransformPrimitive):
-    """Element-wise division of two lists.
+    """Computes element-wise division of two lists.
 
     Description:
         Given a list of values X and a list of values
@@ -893,7 +893,7 @@ class DivideNumeric(TransformPrimitive):
 
 
 class DivideNumericScalar(TransformPrimitive):
-    """Divide each element in the list by a scalar.
+    """Divides each element in the list by a scalar.
 
     Description:
         Given a list of numeric values and a scalar, divide
@@ -927,7 +927,7 @@ class DivideNumericScalar(TransformPrimitive):
 
 
 class DivideByFeature(TransformPrimitive):
-    """Divide a scalar by each value in the list.
+    """Divides a scalar by each value in the list.
 
     Description:
         Given a list of numeric values and a scalar, divide
@@ -962,7 +962,7 @@ class DivideByFeature(TransformPrimitive):
 
 
 class ModuloNumeric(TransformPrimitive):
-    """Element-wise modulo of two lists.
+    """Computes element-wise modulo of two lists.
 
     Description:
         Given a list of values X and a list of values Y,
@@ -992,7 +992,7 @@ class ModuloNumeric(TransformPrimitive):
 
 
 class ModuloNumericScalar(TransformPrimitive):
-    """Return the modulo of each element in the list by a scalar.
+    """Computes the modulo of each element in the list by a given scalar.
 
     Description:
         Given a list of numeric values and a scalar, return
@@ -1027,7 +1027,7 @@ class ModuloNumericScalar(TransformPrimitive):
 
 
 class ModuloByFeature(TransformPrimitive):
-    """Return the modulo of a scalar by each element in the list.
+    """Computes the modulo of a scalar by each element in a list.
 
     Description:
         Given a list of numeric values and a scalar, return the
@@ -1062,7 +1062,7 @@ class ModuloByFeature(TransformPrimitive):
 
 
 class And(TransformPrimitive):
-    """Element-wise logical AND of two lists.
+    """Computes element-wise logical AND of two lists.
 
     Description:
         Given a list of booleans X and a list of booleans Y,
@@ -1104,7 +1104,7 @@ class And(TransformPrimitive):
 
 
 class Or(TransformPrimitive):
-    """Element-wise logical OR of two lists.
+    """Computes element-wise logical OR of two lists.
 
     Description:
         Given a list of booleans X and a list of booleans Y,

--- a/featuretools/primitives/standard/datetime_transform_primitives.py
+++ b/featuretools/primitives/standard/datetime_transform_primitives.py
@@ -823,7 +823,7 @@ class TimeSince(TransformPrimitive):
 
 
 class TimeSincePrevious(TransformPrimitive):
-    """Compute the time since the previous entry in a list.
+    """Computes the time since the previous entry in a list.
 
     Args:
         unit (str): Defines the unit of time to count from.

--- a/featuretools/primitives/standard/transform_primitive.py
+++ b/featuretools/primitives/standard/transform_primitive.py
@@ -241,7 +241,7 @@ class IsIn(TransformPrimitive):
 
 
 class Diff(TransformPrimitive):
-    """Compute the difference between the value in a list and the
+    """Computes the difference between the value in a list and the
     previous value in that list.
 
     Args:
@@ -284,7 +284,7 @@ class Diff(TransformPrimitive):
 
 
 class DiffDatetime(Diff):
-    """Compute the timedelta between a datetime in a list and the
+    """Computes the timedelta between a datetime in a list and the
     previous datetime in that list.
 
     Args:

--- a/featuretools/tests/primitive_tests/test_all_primitive_docstrings.py
+++ b/featuretools/tests/primitive_tests/test_all_primitive_docstrings.py
@@ -1,0 +1,37 @@
+from lib2to3.pgen2.pgen import DFAState
+
+import numpy as np
+import pandas as pd
+
+from featuretools.primitives import get_aggregation_primitives, get_transform_primitives
+
+
+def docstring_is_uniform(primitive):
+    docstring = primitive.__doc__
+    valid_verbs = [
+        "Calculates",
+        "Determines",
+        "Transforms",
+        "Computes",
+        "Counts",
+        "Negates",
+        "Adds",
+        "Subtracts",
+        "Multiplies",
+        "Divides",
+        "Returns",
+        "Shifts",
+        "Extracts",
+        "Applies",
+    ]
+    return any(docstring.startswith(s) for s in valid_verbs)
+
+
+def test_transform_primitive_docstrings():
+    for primitive in get_transform_primitives().values():
+        assert docstring_is_uniform(primitive)
+
+
+def test_aggregation_primitive_docstrings():
+    for primitive in get_aggregation_primitives().values():
+        assert docstring_is_uniform(primitive)

--- a/featuretools/tests/primitive_tests/test_all_primitive_docstrings.py
+++ b/featuretools/tests/primitive_tests/test_all_primitive_docstrings.py
@@ -14,6 +14,7 @@ def docstring_is_uniform(primitive):
         "Subtracts",
         "Multiplies",
         "Divides",
+        "Performs",
         "Returns",
         "Shifts",
         "Extracts",

--- a/featuretools/tests/primitive_tests/test_all_primitive_docstrings.py
+++ b/featuretools/tests/primitive_tests/test_all_primitive_docstrings.py
@@ -1,8 +1,3 @@
-from lib2to3.pgen2.pgen import DFAState
-
-import numpy as np
-import pandas as pd
-
 from featuretools.primitives import get_aggregation_primitives, get_transform_primitives
 
 


### PR DESCRIPTION
Fixes #2199 

-- Adds unit test that checks if primitive's docstring begins with verb in set of `valid_verbs`.
-- Rewords docstrings for primitives that would fail test above.