### PR TITLE
Configure codecov to comment only after getting all reports

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,3 @@
+codecov:
+    notify:
+        after_n_builds: 5

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -14,6 +14,7 @@ Future Release
         * Add create feedstock PR workflow (:pr:`2181`)
         * Add performance tests for python 3.9 and 3.10 (:pr:`2198`, :pr:`2208`)
         * Add test to ensure primitive docstrings use standardized verbs (:pr:`2200`)
+        * Configure codecov to avoid premature PR comments (:pr:`2209`)
 
     Thanks to the following people for contributing to this release:
     :user:`gsheni`, :user:`rwedge`, :user:`sbadithe`, :user:`thehomebrewnerd`


### PR DESCRIPTION
This PR adds a configuration file that tells codecov not to comment on PRs until 5 reports have been processed.  This will stop codecov from commenting early with a failed status