### PR TITLE
Split primitive descriptions on blank line instead of first line break to avoid truncating descriptions

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -10,6 +10,7 @@ Future Release
         * Update ``Trend`` and ``RollingTrend`` primitives to work with ``IntegerNullable`` inputs (:pr:`2204`)
         * ``camel_and_title_to_snake`` handles snake case strings with numbers (:pr:`2220`)
     * Changes
+        * Change ``_get_description`` to split on blank lines to avoid truncating primitive descriptions (:pr:`2219`)
     * Documentation Changes
         * Add instructions to add new users to featuretools feedstock (:pr:`2215`)
     * Testing Changes
@@ -19,7 +20,7 @@ Future Release
         * Configure codecov to avoid premature PR comments (:pr:`2209`)
 
     Thanks to the following people for contributing to this release:
-    :user:`gsheni`, :user:`rwedge`, :user:`sbadithe`, :user:`thehomebrewnerd`
+    :user:`gsheni`, :user:`rwedge`, :user:`sbadithe`, :user:`tamargrey`, :user:`thehomebrewnerd`
 
 v1.12.0 Jul 19, 2022
 ====================

--- a/featuretools/primitives/utils.py
+++ b/featuretools/primitives/utils.py
@@ -177,7 +177,10 @@ def _get_descriptions(primitives):
     for prim in primitives:
         description = ""
         if prim.__doc__ is not None:
-            description = prim.__doc__.split("\n")[0]
+            # Break on the empty line between the docstring description and the remainder of the docstring
+            description = prim.__doc__.split("\n\n")[0]
+            # remove any excess whitespace from line breaks
+            description = " ".join(description.split())
         descriptions.append(description)
     return descriptions
 

--- a/featuretools/tests/primitive_tests/test_primitive_utils.py
+++ b/featuretools/tests/primitive_tests/test_primitive_utils.py
@@ -100,14 +100,15 @@ def test_get_descriptions_doesnt_truncate_primitive_description():
     # single line
     descr = _get_descriptions([IsNull])
     assert descr[0] == "Determines if a value is null."
+
     # multiple line; one sentence
     descr = _get_descriptions([Diff])
     assert (
         descr[0]
         == "Compute the difference between the value in a list and the previous value in that list."
     )
-    # multiple lines multiple sentences
 
+    # multiple lines; multiple sentences
     class TestPrimitive(TransformPrimitive):
         """This is text that continues on after the line break
             and ends in a period.

--- a/featuretools/tests/primitive_tests/test_primitive_utils.py
+++ b/featuretools/tests/primitive_tests/test_primitive_utils.py
@@ -105,7 +105,7 @@ def test_get_descriptions_doesnt_truncate_primitive_description():
     descr = _get_descriptions([Diff])
     assert (
         descr[0]
-        == "Compute the difference between the value in a list and the previous value in that list."
+        == "Computes the difference between the value in a list and the previous value in that list."
     )
 
     # multiple lines; multiple sentences

--- a/featuretools/tests/primitive_tests/test_primitive_utils.py
+++ b/featuretools/tests/primitive_tests/test_primitive_utils.py
@@ -8,9 +8,11 @@ from featuretools.primitives import (
     Age,
     Count,
     Day,
+    Diff,
     GreaterThan,
     Haversine,
     IsFreeEmailDomain,
+    IsNull,
     Last,
     Max,
     Mean,
@@ -35,6 +37,7 @@ from featuretools.primitives import (
     get_transform_primitives,
 )
 from featuretools.primitives.base import PrimitiveBase
+from featuretools.primitives.base.transform_primitive_base import TransformPrimitive
 from featuretools.primitives.utils import (
     _check_input_types,
     _get_descriptions,
@@ -91,6 +94,53 @@ def test_descriptions():
         GreaterThan: "Determines if values in one list are greater than another list.",
     }
     assert _get_descriptions(list(primitives.keys())) == list(primitives.values())
+
+
+def test_get_descriptions_doesnt_truncate_primitive_description():
+    # single line
+    descr = _get_descriptions([IsNull])
+    assert descr[0] == "Determines if a value is null."
+    # multiple line; one sentence
+    descr = _get_descriptions([Diff])
+    assert (
+        descr[0]
+        == "Compute the difference between the value in a list and the previous value in that list."
+    )
+    # multiple lines multiple sentences
+
+    class TestPrimitive(TransformPrimitive):
+        """This is text that continues on after the line break
+            and ends in a period.
+            This is text on one line without a period
+
+        Examples:
+            >>> absolute = Absolute()
+            >>> absolute([3.0, -5.0, -2.4]).tolist()
+            [3.0, 5.0, 2.4]
+        """
+
+        name = "test_primitive"
+
+    descr = _get_descriptions([TestPrimitive])
+    assert (
+        descr[0]
+        == "This is text that continues on after the line break and ends in a period. This is text on one line without a period"
+    )
+
+    # docstring ends after description
+    class TestPrimitive2(TransformPrimitive):
+        """This is text that continues on after the line break
+        and ends in a period.
+        This is text on one line without a period
+        """
+
+        name = "test_primitive"
+
+    descr = _get_descriptions([TestPrimitive2])
+    assert (
+        descr[0]
+        == "This is text that continues on after the line break and ends in a period. This is text on one line without a period"
+    )
 
 
 def test_get_default_aggregation_primitives():


### PR DESCRIPTION
Fixes https://github.com/alteryx/featuretools/issues/2217
