### PR TITLE
Update create feedstock PR forked repo to use

### DIFF
--- a/.github/workflows/create_feedstock_pr.yaml
+++ b/.github/workflows/create_feedstock_pr.yaml
@@ -20,13 +20,12 @@ jobs:
       - name: Pull latest from upstream for user forked feedstock
         run: |
           gh auth status
-          gh repo fork conda-forge/featuretools-feedstock --clone
-          gh repo sync machineAYX/featuretools-feedstock --branch main --source conda-forge/featuretools-feedstock --force
+          gh repo sync alteryx/featuretools-feedstock --branch main --source conda-forge/featuretools-feedstock --force
         env:
           GITHUB_TOKEN: ${{ secrets.AUTO_APPROVE_TOKEN }}
       - uses: actions/checkout@v3
         with:
-          repository: machineAYX/featuretools-feedstock
+          repository: alteryx/featuretools-feedstock
           ref: main
           path: "./featuretools-feedstock"
           fetch-depth: '0'

--- a/.github/workflows/create_feedstock_pr.yaml
+++ b/.github/workflows/create_feedstock_pr.yaml
@@ -53,4 +53,4 @@ jobs:
           git push origin conda-autocreate-${{ github.event.inputs.pypi_version }}
       - name: Adding URL to job output
         run: |
-          echo "Conda Feedstock Pull Request: https://github.com/machineAYX/featuretools-feedstock/pull/new/conda-autocreate-${{ github.event.inputs.pypi_version }}" >> $GITHUB_STEP_SUMMARY
+          echo "Conda Feedstock Pull Request: https://github.com/alteryx/featuretools-feedstock/pull/new/conda-autocreate-${{ github.event.inputs.pypi_version }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/create_feedstock_pr.yaml
+++ b/.github/workflows/create_feedstock_pr.yaml
@@ -46,7 +46,7 @@ jobs:
           git config --unset-all http.https://github.com/.extraheader
           git config --global user.email "machineOSS@alteryx.com"
           git config --global user.name "machineAYX Bot"
-          git remote set-url origin https://${{ secrets.AUTO_APPROVE_TOKEN }}@github.com/machineAYX/featuretools-feedstock
+          git remote set-url origin https://${{ secrets.AUTO_APPROVE_TOKEN }}@github.com/alteryx/featuretools-feedstock
           git checkout -b conda-autocreate-${{ github.event.inputs.pypi_version }}
           git add recipe/meta.yaml
           git commit -m "auto commit"

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,16 +3,18 @@
 Release Notes
 -------------
 
-.. Future Release
-  ==============
+Future Release
+==============
     * Enhancements
     * Fixes
     * Changes
     * Documentation Changes
     * Testing Changes
+        * Update create feedstock PR forked repo to use (:pr:`2223`)
 
-.. Thanks to the following people for contributing to this release:
-
+    Thanks to the following people for contributing to this release:
+    :user:`gsheni`
+    
 v1.12.1 Aug 4, 2022
 ===================
     * Fixes

--- a/release.md
+++ b/release.md
@@ -88,9 +88,10 @@ In order to release on conda-forge, you can either wait for a bot to create a PR
 1. Go to this GitHub Action: https://github.com/alteryx/featuretools/actions/workflows/create_feedstock_pr.yaml
 2. Input the released version with the v prefix (e.g. v0.13.3)
 3. Kickoff the GitHub action, and monitor the Job Summary.
-4. At the completion of the job, you should see summary output, with a URL. You will need to visit this URL, and create a PR.
-    * You can also just go to: https://github.com/machineAYX/featuretools-feedstock/pull/new/conda-autocreate-v0.13.3 
-    * *Change the last part to the released version*
+4. At the completion of the job, you should see summary output, with a URL. 
+    * You will need to visit this URL, and create a PR.
+    * You can also create the PR by clicking the branch name (ex - `conda-autocreate-v0.13.3`): 
+      - https://github.com/alteryx/featuretools-feedstock/branches
 5. Verify the `requirements['run']` (in __recipe/meta.yml__) match the `install_requires` in __featuretools/setup.cfg__.
     * Verify the `test['requires']` (in __recipe/meta.yml__) match the test requirements in `[options.extras_require]` in __featuretools/setup.cfg__
 


### PR DESCRIPTION
- The just released v3 bumps the build version to 0 (https://github.com/alteryx/create-feedstock-meta-yaml/commit/40e0f8e3b198e3fe01cc8673cb8cb958c58aef94)
- Use forked repo on alteryx org