### PR TITLE
Allow boolean columns to be included in remove_highly_correlated_features

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -18,7 +18,7 @@ Future Release
         * Update development requirements and use latest for documentation (:pr:`2225`)
 
     Thanks to the following people for contributing to this release:
-    :user:`gsheni`, :user:`ozzieD`, user:`sbadithe`, :user:`tamargrey`
+    :user:`gsheni`, :user:`ozzieD`, :user:`sbadithe`, :user:`tamargrey`
 
 v1.12.1 Aug 4, 2022
 ===================

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -7,6 +7,7 @@ Future Release
 ==============
     * Enhancements
     * Fixes
+        * Allow boolean columns to be included in remove_highly_correlated_features (:pr:`2231`)
     * Changes
         * Refactor schema version checking to use `packaging` method (:pr:`2230`)
         * Extract duplicated logic for Rolling primitives into a general utility function (:pr:`2218`)

--- a/featuretools/selection/selection.py
+++ b/featuretools/selection/selection.py
@@ -1,3 +1,4 @@
+import pandas as pd
 from woodwork.logical_types import Boolean, BooleanNullable
 
 
@@ -169,9 +170,17 @@ def remove_highly_correlated_features(
         more_complex_name = columns_to_check[i]
         more_complex_col = fm_to_check[more_complex_name]
 
+        # Convert boolean column to be float64
+        if pd.api.types.is_bool_dtype(more_complex_col):
+            more_complex_col = more_complex_col.astype("float64")
+
         for j in range(i - 1, -1, -1):
             less_complex_name = columns_to_check[j]
             less_complex_col = fm_to_check[less_complex_name]
+
+            # Convert boolean column to be float64
+            if pd.api.types.is_bool_dtype(less_complex_col):
+                less_complex_col = less_complex_col.astype("float64")
 
             if abs(more_complex_col.corr(less_complex_col)) >= pct_corr_threshold:
                 dropped.add(more_complex_name)

--- a/featuretools/tests/selection/test_selection.py
+++ b/featuretools/tests/selection/test_selection.py
@@ -333,7 +333,7 @@ def test_multi_output_selection():
             assert f_name in matrix_columns
 
 
-def test_remove_highly_correlatied_features_on_boolean_cols():
+def test_remove_highly_correlated_features_on_boolean_cols():
     correlated_df = pd.DataFrame(
         {
             "id": [0, 1, 2, 3],

--- a/featuretools/tests/selection/test_selection.py
+++ b/featuretools/tests/selection/test_selection.py
@@ -1,7 +1,8 @@
 import numpy as np
 import pandas as pd
 import pytest
-from woodwork.logical_types import NaturalLanguage
+from woodwork.column_schema import ColumnSchema
+from woodwork.logical_types import Boolean, BooleanNullable, NaturalLanguage
 
 from featuretools import EntitySet, Feature, dfs
 from featuretools.selection import (
@@ -330,3 +331,42 @@ def test_multi_output_selection():
     for f in unsliced_features:
         for f_name in f.get_feature_names():
             assert f_name in matrix_columns
+
+
+def test_remove_highly_correlatied_features_on_boolean_cols():
+    correlated_df = pd.DataFrame(
+        {
+            "id": [0, 1, 2, 3],
+            "diff_ints": [34, 11, 29, 91],
+            "corr_words": [4, 24, 7, 3],
+            "bools": [True, True, False, True],
+        },
+    )
+
+    es = EntitySet(
+        "data",
+        {"correlated": (correlated_df, "id", None, {"bools": Boolean})},
+    )
+
+    feature_matrix, features = dfs(
+        entityset=es,
+        target_dataframe_name="correlated",
+        trans_primitives=["equal"],
+        agg_primitives=[],
+        max_depth=1,
+        return_types=[
+            ColumnSchema(logical_type=BooleanNullable),
+            ColumnSchema(logical_type=Boolean),
+        ],
+    )
+    # Confirm both boolean logical types are included so that we know we're checking the correct types
+    assert {
+        ltype.type_string for ltype in feature_matrix.ww.logical_types.values()
+    } == {Boolean.type_string, BooleanNullable.type_string}
+
+    to_keep = remove_highly_correlated_features(
+        feature_matrix=feature_matrix,
+        features=features,
+        pct_corr_threshold=0.3,
+    )
+    assert len(to_keep[0].columns) < len(feature_matrix.columns)


### PR DESCRIPTION
Fixes #2229 

Converts boolean columns to `float64` in `remove_highly_correlated_features` to avoid the error that comes from calling `corr` on boolean columns
