### PR TITLE
Fix minimum dependency generator

### DIFF
--- a/.github/workflows/minimum_dependency_checker.yaml
+++ b/.github/workflows/minimum_dependency_checker.yaml
@@ -34,7 +34,7 @@ jobs:
         uses: alteryx/minimum-dependency-generator@v3
         with:
           paths: 'pyproject.toml'
-          options: 'install_requires'
+          options: 'dependencies'
           extras_require: 'spark'
           output_filepath: featuretools/tests/requirement_files/minimum_spark_requirements.txt
       - name: Create Pull Request

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -11,7 +11,7 @@ Future Release
         * Fix compatibility issues with holidays 0.15 (:pr:`2254`)
     * Changes
         * Update release notes to make clear conda release portion (:pr:`2249`)
-        * Use pyproject.toml only (move away from setup.cfg) (:pr:`2260`)
+        * Use pyproject.toml only (move away from setup.cfg) (:pr:`2260`,:pr:`2263`)
     * Documentation Changes
         * Fix to remove warning from Using Spark EntitySets Guide (:pr:`2258`)
     * Testing Changes


### PR DESCRIPTION
- Fixes
```
  File "/minimum_dependency_generator/minimum_dependency_generator.py", line 134, in parse_pyproject_toml
    requirements += toml_dict["project"][option]
KeyError: 'install_requires'
```