### PR TITLE
Pin fsspec

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -9,6 +9,7 @@ Future Release
         * Refactor build_features to speed up long running DFS calls by 50% (:pr:`2224`)
     * Fixes
         * Fix compatibility issues with holidays 0.15 (:pr:`2254`)
+        * Pin fsspec to avoid dask errors (:pr:`2271`)
     * Changes
         * Update release notes to make clear conda release portion (:pr:`2249`)
         * Use pyproject.toml only (move away from setup.cfg) (:pr:`2260`, :pr:`2263`, :pr:`2265`)
@@ -18,7 +19,7 @@ Future Release
         * Add tests/profiling/dfs_profile.py (:pr:`2224`)
 
     Thanks to the following people for contributing to this release:
-    :user:`cp2boston`, :user:`gsheni`, :user:`thehomebrewnerd`
+    :user:`cp2boston`, :user:`gsheni`, :user:`rwedge`, :user:`thehomebrewnerd`
 
 
 v1.13.0 Aug 18, 2022

--- a/featuretools/tests/requirement_files/minimum_core_requirements.txt
+++ b/featuretools/tests/requirement_files/minimum_core_requirements.txt
@@ -2,6 +2,7 @@ click==7.0.0
 cloudpickle==1.5.0
 dask[dataframe]==2022.2.0
 distributed==2022.2.0
+fsspec==0.6.0
 holidays==0.13
 numpy==1.21.0
 packaging==20.0

--- a/featuretools/tests/requirement_files/minimum_spark_requirements.txt
+++ b/featuretools/tests/requirement_files/minimum_spark_requirements.txt
@@ -2,6 +2,7 @@ click==7.0.0
 cloudpickle==1.5.0
 dask[dataframe]==2022.2.0
 distributed==2022.2.0
+fsspec==0.6.0
 holidays==0.13
 numpy==1.21.0
 packaging==20.0

--- a/featuretools/tests/requirement_files/minimum_test_requirements.txt
+++ b/featuretools/tests/requirement_files/minimum_test_requirements.txt
@@ -4,6 +4,7 @@ cloudpickle==1.5.0
 composeml==0.8.0
 dask[dataframe]==2022.2.0
 distributed==2022.2.0
+fsspec==0.6.0
 graphviz==0.8.4
 holidays==0.13
 moto[all]==3.0.7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "cloudpickle >= 1.5.0",
     "dask[dataframe] >= 2022.2.0, <2022.8.0",
     "distributed >= 2022.2.0, <2022.8.0",
+    "fsspec<2022.8.0",
     "holidays >= 0.13",
     "numpy >= 1.21.0",
     "packaging >= 20.0",


### PR DESCRIPTION
Pin fsspec since recent release is causing dask-related CI errors