### PR TITLE
Exclude doc files from source distribution and wheel file

### DIFF
--- a/.github/workflows/test_without_test_dependencies.yaml
+++ b/.github/workflows/test_without_test_dependencies.yaml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      matrix:
+        python_version: ["3.8", "3.10"]
     steps:
-      - name: Set up python 3.10
-        uses: actions/setup-python@v4
+      - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
-      - name: Checkout repository
-        uses: actions/checkout@v3
+          python-version: ${{ matrix.python_version }}
+      - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}

--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,6 @@ featuretools/tests/integration_data/stores.gzip
 *.dirlock
 *.~lock*
 unpacked_sdist/
-featuretools-[0-9]*.[0-9]*.[0-9]*/*
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ featuretools/tests/integration_data/stores.gzip
 *.dirlock
 *.~lock*
 unpacked_sdist/
+featuretools-[0-9]*.[0-9]*.[0-9]*/*
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -10,13 +10,14 @@ Future Release
     * Changes
         * Change default gap for Rolling* primitives from 0 to 1 to prevent accidental leakage (:pr:`2282`)
         * Temporarily limit pandas version to less than 1.5.0 (:pr:`2290`)
+        * Exclude documentation files from source distribution and wheel file (:pr:`2294`)
     * Documentation Changes
         * Add documentation describing how to use `featuretools_sql` with `featuretools` (:pr:`2262`)
     * Testing Changes
         * Remove graphviz version restrictions in Windows CI tests (:pr:`2285`)
 
     Thanks to the following people for contributing to this release:
-    :user:`sbadithe`, :user:`thehomebrewnerd`
+    :user:`gsheni`, :user:`sbadithe`, :user:`thehomebrewnerd`
 
     .. warning::
         This default behavior of the ``Rolling*`` primitives has changed in this release. If this primitive

--- a/featuretools/primitives/base/primitive_base.py
+++ b/featuretools/primitives/base/primitive_base.py
@@ -3,7 +3,11 @@ from inspect import signature
 
 import numpy as np
 import pandas as pd
-from importlib_resources import files
+
+try:
+    from importlib.resources import files
+except ImportError:
+    from importlib_resources import files
 
 from featuretools import config
 from featuretools.utils.description_utils import convert_to_nth

--- a/featuretools/primitives/base/primitive_base.py
+++ b/featuretools/primitives/base/primitive_base.py
@@ -3,6 +3,7 @@ from inspect import signature
 
 import numpy as np
 import pandas as pd
+from importlib_resources import files
 
 from featuretools import config
 from featuretools.utils.description_utils import convert_to_nth
@@ -69,7 +70,7 @@ class PrimitiveBase(object):
         raise NotImplementedError("Subclass must implement")
 
     def get_filepath(self, filename):
-        return os.path.join(config.get("primitive_data_folder"), filename)
+        return files("featuretools.primitives.data").joinpath(filename)
 
     def get_args_string(self):
         strings = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,3 @@
-[build-system]
-requires = [
-    "setuptools >= 61.0.0",
-    "wheel"
-]
-build-backend = "setuptools.build_meta"
-
 [project]
 name = "featuretools"
 readme = "README.md"
@@ -131,14 +124,24 @@ complete = [
 [project.scripts]
 featuretools = "featuretools.__main__:cli"
 
+[build-system]
+requires = [
+    "setuptools >= 62.3.0",
+    "wheel"
+]
+build-backend = "setuptools.build_meta"
+
 [tool.setuptools]
-include-package-data = false
+platforms = ["any"]
+zip-safe  = false
+include-package-data = true
 license-files = [
     "LICENSE",
     "featuretools/primitives/data/free_email_provider_domains_license"
 ]
 
 [tool.setuptools.packages.find]
+namespaces = false
 include = [
     "README.md",
     "featuretools/primitives/data/**",
@@ -147,7 +150,7 @@ include = [
     "featuretools*",
 ]
 exclude = [
-    "docs"
+    "docs*",
 ]
 
 [tool.setuptools.exclude-package-data]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "scipy >= 1.3.3",
     "tqdm >= 4.32.0",
     "woodwork >= 0.16.2",
-    "importlib-resources >= 5.9.0"
+    "importlib-resources >= 5.9.0; python_version <= '3.9'"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,7 +157,9 @@ where = ["."]
 "*" = [
     "* __pycache__",
     "*.py[co]",
-    "docs/*"
+    "docs/*",
+    "docs/**",
+    "docs/*.py",
 ]
 
 [tool.setuptools.dynamic]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,9 +154,7 @@ namespaces = true
 "*" = [
     "* __pycache__",
     "*.py[co]",
-    "docs/*"
-    "docs/*.py"
-    "docs/source/*.py"
+    "docs/*.*",
 ]
 
 [tool.setuptools.dynamic]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,8 +142,7 @@ license-files = [
 include = [
     "README.md",
     "featuretools*",
-    "featuretools/primitives/data/*.csv",
-    "featuretools/primitives/data/*.txt"
+    "featuretools.primitives.data*",
 ]
 exclude = [
     "docs"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,7 +145,6 @@ where = ["."]
 
 [tool.setuptools.package-data]
 "*" = [
-    "*.txt",
     "README.md",
 ]
 "featuretools" = [
@@ -157,10 +156,9 @@ where = ["."]
 "*" = [
     "* __pycache__",
     "*.py[co]",
-    "docs/*",
-    "docs/**",
-    "docs/*.py",
+    "/docs/*",
 ]
+"docs" = ['*', '*.py']
 
 [tool.setuptools.dynamic]
 version = {attr = "featuretools.version.__version__"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,15 +141,16 @@ license-files = [
 ]
 
 [tool.setuptools.packages.find]
-namespaces = false
-exclude = [
-    "docs*",
-]
+where = ["."]
 
-[tool.setuptools.exclude-package-data]
+[tool.setuptools.package-data]
 "*" = [
-    "* __pycache__",
-    "*.py[co]",
+    "*.txt",
+    "README.md",
+]
+"featuretools" = [
+    "primitives/data/*.csv",
+    "primitives/data/*.txt",
 ]
 
 [tool.setuptools.dynamic]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,6 +153,13 @@ where = ["."]
     "primitives/data/*.txt",
 ]
 
+[tool.setuptools.exclude-package-data]
+"*" = [
+    "* __pycache__",
+    "*.py[co]",
+    "docs/*"
+]
+
 [tool.setuptools.dynamic]
 version = {attr = "featuretools.version.__version__"}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "scipy >= 1.3.3",
     "tqdm >= 4.32.0",
     "woodwork >= 0.16.2",
+    "importlib-resources >= 5.9.0"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,34 +132,29 @@ complete = [
 featuretools = "featuretools.__main__:cli"
 
 [tool.setuptools]
-include-package-data = true
+include-package-data = false
 license-files = [
     "LICENSE",
     "featuretools/primitives/data/free_email_provider_domains_license"
 ]
 
 [tool.setuptools.packages.find]
-namespaces = true
-
-[tool.setuptools.package-data]
-"*" = [
+include = [
     "README.md",
+    "featuretools*",
 ]
-"featuretools" = [
-    "primitives/data/*.csv",
-    "primitives/data/*.txt",
+exclude = [
+    "docs"
 ]
 
 [tool.setuptools.exclude-package-data]
 "*" = [
     "* __pycache__",
     "*.py[co]",
-    "docs/*.*",
 ]
 
 [tool.setuptools.dynamic]
 version = {attr = "featuretools.version.__version__"}
-
 
 [tool.pytest.ini_options]
 addopts = "--doctest-modules --ignore=featuretools/tests/entry_point_tests/add-ons"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,6 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
 platforms = ["any"]
-zip-safe  = false
 include-package-data = true
 license-files = [
     "LICENSE",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,9 +148,6 @@ include = [
     "featuretools/primitives/data/*.txt",
     "featuretools*",
 ]
-exclude = [
-    "docs*",
-]
 
 [tool.setuptools.exclude-package-data]
 "*" = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,8 +141,8 @@ license-files = [
 [tool.setuptools.packages.find]
 include = [
     "README.md",
+    "featuretools/primitives/data/**",
     "featuretools*",
-    "featuretools.primitives.data*",
 ]
 exclude = [
     "docs"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,6 +142,8 @@ license-files = [
 include = [
     "README.md",
     "featuretools*",
+    "featuretools/primitives/data/*.csv",
+    "featuretools/primitives/data/*.txt"
 ]
 exclude = [
     "docs"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,14 +140,9 @@ license-files = [
 ]
 
 [tool.setuptools.packages.find]
-where = ["."]
 namespaces = false
-include = [
-    "README.md",
-    "featuretools/primitives/data*",
-    "featuretools/primitives/data/*.csv",
-    "featuretools/primitives/data/*.txt",
-    "featuretools*",
+exclude = [
+    "docs*",
 ]
 
 [tool.setuptools.exclude-package-data]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,10 +140,11 @@ license-files = [
 ]
 
 [tool.setuptools.packages.find]
+where = ["."]
 namespaces = false
 include = [
     "README.md",
-    "featuretools/primitives/data/**",
+    "featuretools/primitives/data*",
     "featuretools/primitives/data/*.csv",
     "featuretools/primitives/data/*.txt",
     "featuretools*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,6 +142,8 @@ license-files = [
 include = [
     "README.md",
     "featuretools/primitives/data/**",
+    "featuretools/primitives/data/*.csv",
+    "featuretools/primitives/data/*.txt",
     "featuretools*",
 ]
 exclude = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,6 @@ namespaces = true
 
 [tool.setuptools.package-data]
 "*" = [
-    "*.txt",
     "README.md",
 ]
 "featuretools" = [
@@ -156,6 +155,8 @@ namespaces = true
     "* __pycache__",
     "*.py[co]",
     "docs/*"
+    "docs/*.py"
+    "docs/source/*.py"
 ]
 
 [tool.setuptools.dynamic]


### PR DESCRIPTION
- I noticed while browsing (https://pypi-browser.org/package/featuretools/featuretools-1.14.0-py3-none-any.whl), that some of our docs files are being included with distribution.