### PR TITLE
Exclude documentation files from release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    - name: Remove docs before release
+      run: rm -rf docs/
     - name: PyPI Upload
       uses: FeatureLabs/gh-action-pypi-upload@v2
       env:

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -10,13 +10,14 @@ Future Release
     * Changes
         * Change default gap for Rolling* primitives from 0 to 1 to prevent accidental leakage (:pr:`2282`)
         * Temporarily limit pandas version to less than 1.5.0 (:pr:`2290`)
+        * Exclude documentation files from release workflow (:pr:`2295`)
     * Documentation Changes
         * Add documentation describing how to use `featuretools_sql` with `featuretools` (:pr:`2262`)
     * Testing Changes
         * Remove graphviz version restrictions in Windows CI tests (:pr:`2285`)
 
     Thanks to the following people for contributing to this release:
-    :user:`sbadithe`, :user:`thehomebrewnerd`
+    :user:`gsheni`, :user:`sbadithe`, :user:`thehomebrewnerd`
 
     .. warning::
         This default behavior of the ``Rolling*`` primitives has changed in this release. If this primitive

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 description = "a framework for automated feature engineering"
 dynamic = ["version"]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Science/Research",
     "Intended Audience :: Developers",
     "Topic :: Software Development",


### PR DESCRIPTION
- I noticed while browsing (https://pypi-browser.org/package/featuretools/featuretools-1.14.0-py3-none-any.whl), that some of our docs files are being included with distribution.