### PR TITLE
Remove featuretools_sql from docs requirements

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -32,24 +32,7 @@ Before starting major work, you should touch base with the maintainers of Featur
   cd featuretools
   git remote add upstream https://github.com/alteryx/featuretools
   ```
-* In order to install the requirements for the `featuretools_sql` add-on library which is needed for building the documentation,
-you need to have Postgres installed. If you do not already have it installed, you can install via the following commands:
-
-  **macOS** (use [Homebrew](https://brew.sh/)):
-    ```console
-    brew install postgresql@14
-    ```
-  **Ubuntu**:
-    ```console
-    sudo apt install -y postgresql postgresql-contrib postgresql-client
-    ```
-  **Amazon Linux**:
-    ```console
-    sudo amazon-linux-extras enable postgresql14
-    sudo yum install postgresql postgresql-server
-    ```
-
-* Once you have obtained a copy of the code, you should create a development environment that is separate from your existing Python environment so that you can make and test changes without compromising your own work environment. You can run the following steps to create a separate virtual environment, and install Featuretools in editable mode. 
+* Once you have obtained a copy of the code, you should create a development environment that is separate from your existing Python environment so that you can make and test changes without compromising your own work environment. You can run the following steps to create a separate virtual environment, and install Featuretools in editable mode.
   ```bash
   python -m venv venv
   source venv/bin/activate

--- a/contributing.md
+++ b/contributing.md
@@ -32,7 +32,23 @@ Before starting major work, you should touch base with the maintainers of Featur
   cd featuretools
   git remote add upstream https://github.com/alteryx/featuretools
   ```
-* Once you have obtained a copy of the code, you should create a development environment that is separate from your existing Python environment so that you can make and test changes without compromising your own work environment. You can run the following steps to create a separate virtual environment, and install Featuretools in editable mode.
+* In order to install the requirements for the `featuretools_sql` add-on library which is needed for building the documents,
+you need to have Postgres installed. If you do not already have it installed, you can install via the following commands:
+  **macOS** (use [Homebrew](https://brew.sh/)):
+    ```console
+    brew install postgresql@14
+    ```
+
+  **Ubuntu**:
+    ```console
+    sudo apt install -y postgresql postgresql-contrib postgresql-client
+    ```
+  **Amazon Linux**:
+    ```console
+    sudo amazon-linux-extras enable postgresql14
+    sudo yum install postgresql postgresql-server
+    ```
+* Once you have obtained a copy of the code, you should create a development environment that is separate from your existing Python environment so that you can make and test changes without compromising your own work environment. You can run the following steps to create a separate virtual environment, and install Featuretools in editable mode. 
   ```bash
   python -m venv venv
   source venv/bin/activate

--- a/contributing.md
+++ b/contributing.md
@@ -32,13 +32,13 @@ Before starting major work, you should touch base with the maintainers of Featur
   cd featuretools
   git remote add upstream https://github.com/alteryx/featuretools
   ```
-* In order to install the requirements for the `featuretools_sql` add-on library which is needed for building the documents,
+* In order to install the requirements for the `featuretools_sql` add-on library which is needed for building the documentation,
 you need to have Postgres installed. If you do not already have it installed, you can install via the following commands:
+
   **macOS** (use [Homebrew](https://brew.sh/)):
     ```console
     brew install postgresql@14
     ```
-
   **Ubuntu**:
     ```console
     sudo apt install -y postgresql postgresql-contrib postgresql-client
@@ -48,6 +48,7 @@ you need to have Postgres installed. If you do not already have it installed, yo
     sudo amazon-linux-extras enable postgresql14
     sudo yum install postgresql postgresql-server
     ```
+
 * Once you have obtained a copy of the code, you should create a development environment that is separate from your existing Python environment so that you can make and test changes without compromising your own work environment. You can run the following steps to create a separate virtual environment, and install Featuretools in editable mode. 
   ```bash
   python -m venv venv

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -13,7 +13,8 @@ Future Release
         * Exclude documentation files from release workflow (:pr:`2295`)
         * Bump requirements for optional pyspark dependency (:pr:`2299`)
     * Documentation Changes
-        * Add documentation describing how to use `featuretools_sql` with `featuretools` (:pr:`2262`)
+        * Add documentation describing how to use ``featuretools_sql`` with ``featuretools`` (:pr:`2262`)
+        * Add Postgres install steps to ``contributing.md`` (:pr:`2302`)
     * Testing Changes
         * Remove graphviz version restrictions in Windows CI tests (:pr:`2285`)
         * Run CI tests with ``pytest -n auto`` (:pr:`2298`)

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -14,7 +14,7 @@ Future Release
         * Bump requirements for optional pyspark dependency (:pr:`2299`)
     * Documentation Changes
         * Add documentation describing how to use ``featuretools_sql`` with ``featuretools`` (:pr:`2262`)
-        * Add Postgres install steps to ``contributing.md`` (:pr:`2302`)
+        * Remove ``featuretools_sql`` as a docs requirement (:pr:`2302`)
     * Testing Changes
         * Remove graphviz version restrictions in Windows CI tests (:pr:`2285`)
         * Run CI tests with ``pytest -n auto`` (:pr:`2298`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,6 @@ docs = [
     "myst-parser == 0.18.0",
     "nlp_primitives >= 2.3.0",
     "autonormalize >= 2.0.1",
-    "featuretools_sql >= 0.0.1",
     "featuretools[spark]",
     "featuretools[test]",
 ]


### PR DESCRIPTION
### Remove featuretools_sql from docs requirements

`featuretools_sql` was listed as a `docs` requirement in `pyproject.toml`, but there is no code executed during the docs build that actually requires `featuretools_sql` to be installed. Having this as a requirement means that users needed to have Postgres installed before running `make installdeps`, otherwise the installation of `psycopg2` would fail. This PR removes this requirement so that users can run `make installdeps` without having Postgres installed.