### PR TITLE
Update requirements based on woodwork 0.18 req

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -13,6 +13,7 @@ Future Release
         * Updates for pandas 1.5.0 compatibility (:pr:`2290`, :pr:`2291`)
         * Exclude documentation files from release workflow (:pr:`2295`)
         * Bump requirements for optional pyspark dependency (:pr:`2299`)
+        * Bump ``scipy`` and ``woodwork[spark]`` dependencies (:pr:`2306`)
     * Documentation Changes
         * Add documentation describing how to use ``featuretools_sql`` with ``featuretools`` (:pr:`2262`)
         * Remove ``featuretools_sql`` as a docs requirement (:pr:`2302`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ test = [
     "urllib3 >= 1.26.5",
 ]
 spark = [
-    "woodwork[spark] >= 0.16.2",
+    "woodwork[spark] >= 0.18.0",
     "pyspark >= 3.2.2",
 ]
 updater = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "packaging >= 20.0",
     "pandas >= 1.4.0",
     "psutil >= 5.6.6",
-    "scipy >= 1.3.3",
+    "scipy >= 1.4.0",
     "tqdm >= 4.32.0",
     "woodwork[dask] >= 0.18.0",
 ]


### PR DESCRIPTION
Woodwork 0.18 requires `scipy>=1.4.0`, this PR updates the featuretools scipy requirements to match that
