### PR TITLE
PercentTrue uses False instead of 0 as fill value

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -11,7 +11,7 @@ Future Release
     * Fixes
     * Changes
         * Change default gap for Rolling* primitives from 0 to 1 to prevent accidental leakage (:pr:`2282`)
-        * Updates for pandas 1.5.0 compatibility (:pr:`2290`, :pr:`2291`)
+        * Updates for pandas 1.5.0 compatibility (:pr:`2290`, :pr:`2291`, :pr:`2308`)
         * Exclude documentation files from release workflow (:pr:`2295`)
         * Bump requirements for optional pyspark dependency (:pr:`2299`)
         * Bump ``scipy`` and ``woodwork[spark]`` dependencies (:pr:`2306`)

--- a/featuretools/primitives/standard/aggregation_primitives.py
+++ b/featuretools/primitives/standard/aggregation_primitives.py
@@ -333,7 +333,7 @@ class PercentTrue(AggregationPrimitive):
             return dd.Aggregation(self.name, chunk=chunk, agg=agg, finalize=finalize)
 
         def percent_true(s):
-            return s.fillna(0).mean()
+            return s.fillna(False).mean()
 
         return percent_true
 

--- a/featuretools/tests/primitive_tests/test_agg_primitives.py
+++ b/featuretools/tests/primitive_tests/test_agg_primitives.py
@@ -2,7 +2,12 @@ import numpy as np
 import pandas as pd
 from pandas.core.dtypes.dtypes import CategoricalDtype
 
-from featuretools.primitives import NMostCommon, Trend, get_aggregation_primitives
+from featuretools.primitives import (
+    NMostCommon,
+    PercentTrue,
+    Trend,
+    get_aggregation_primitives,
+)
 
 
 def test_nmostcommon_categorical():
@@ -38,3 +43,9 @@ def test_trend_works_with_different_input_dtypes():
     for dtype in dtypes:
         actual = trend(numeric.astype(dtype), dates)
         assert np.isclose(actual, 1)
+
+
+def test_percent_true_boolean():
+    booleans = pd.Series([True, False, True, pd.NA], dtype="boolean")
+    pct_true = PercentTrue()
+    pct_true(booleans) == 0.5


### PR DESCRIPTION
PercentTrue primitive takes Boolean or BooleanNullable input data.  The primitive function fills missing values using `0` but with Pandas 1.5 that does not seems to be supported for "Boolean" dtype.  This PR changes the fill value to `False`
