### PR TITLE
Add featuretools-sklearn-transformer back as an optional install

### DIFF
--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -32,7 +32,7 @@ Wrappers
 ~~~~~~~~
 .. currentmodule:: featuretools
 
-Scikit-learn (BETA)
+scikit-learn (BETA)
 -------------------
 .. autosummary::
     :toctree: generated/

--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -28,6 +28,17 @@ Deep Feature Synthesis
     dfs
     get_valid_primitives
 
+Wrappers
+~~~~~~~~
+.. currentmodule:: featuretools
+
+Scikit-learn (BETA)
+-------------------
+.. autosummary::
+    :toctree: generated/
+
+    wrappers.DFSTransformer
+
 Timedelta
 ~~~~~~~~~
 .. currentmodule:: featuretools

--- a/docs/source/install.md
+++ b/docs/source/install.md
@@ -51,7 +51,11 @@ $ python -m pip install "featuretools[updater]"
 ```
 ```{tab} SQL
 ```console
-$ python -m pip install "featuretools[sql]" 
+$ python -m pip install "featuretools[sql]"
+```
+```{tab} scikit-learn transformer
+```console
+$ python -m pip install "featuretools[sklearn]"
 ```
 ````
 ````{tab} Conda
@@ -83,6 +87,7 @@ $ conda install -c conda-forge alteryx-open-src-update-checker
 - **AutoNormalize**: Automated creation of normalized `EntitySet` from denormalized data
 - **Update Checker**: Receive automatic notifications of new Featuretools releases
 - **SQL**: Automated `EntitySet` creation from relational data stored in a SQL database
+- **scikit-learn Transformer**: Featuretools' DFS as a scikit-learn transformer
 
 ## Installing Graphviz
 

--- a/docs/source/install.md
+++ b/docs/source/install.md
@@ -53,7 +53,7 @@ $ python -m pip install "featuretools[updater]"
 ```console
 $ python -m pip install "featuretools[sql]"
 ```
-```{tab} scikit-learn transformer
+```{tab} scikit-learn Transformer
 ```console
 $ python -m pip install "featuretools[sklearn]"
 ```

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,15 +2,18 @@
 
 Release Notes
 -------------
-.. Future Release
-  ==============
+
+Future Release
+==============
     * Enhancements
+        * Add featuretools-sklearn-transformer as an extra installation option (:pr:`2335`)
     * Fixes
     * Changes
     * Documentation Changes
     * Testing Changes
 
-.. Thanks to the following people for contributing to this release:
+    Thanks to the following people for contributing to this release:
+    :user:`rwedge`
 
 v1.16.0 Oct 24, 2022
 ====================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,9 +92,10 @@ autonormalize = [
 sql = [
     "featuretools_sql >= 0.0.1",
 ]
-
+sklearn = [
+    "featuretools-sklearn-transformer >= 1.0.0",
+]
 docs = [
-    "scikit-learn >=0.20.0, !=0.22",
     "ipython == 8.4.0",
     "jupyter == 1.0.0",
     "matplotlib == 3.5.2",
@@ -107,25 +108,17 @@ docs = [
     "myst-parser == 0.18.0",
     "nlp_primitives >= 2.3.0",
     "autonormalize >= 2.0.1",
-    "featuretools[spark]",
-    "featuretools[test]",
+    "featuretools[sklearn, spark, test]",
 ]
 dev = [
     "flake8 == 5.0.4",
     "isort == 5.10.1",
     "black[jupyter] == 22.6.0",
     "pre-commit == 2.20.0",
-    "featuretools[docs]",
-    "featuretools[spark]",
-    "featuretools[test]",
+    "featuretools[docs, spark, test]",
 ]
 complete = [
-    "featuretools[tsfresh]",
-    "featuretools[updater]",
-    "featuretools[nlp]",
-    "featuretools[spark]",
-    "featuretools[autonormalize]",
-    "featuretools[sql]",
+    "featuretools[autonormalize, nlp, sklearn, spark, sql, tsfresh, updater]",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Fixes #1606 

Adds the `featuretools[sklearn]` optional install configuration and adds documentation about it
