### PR TITLE
Restrict 2022.10.1 for dask and distributed

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -11,7 +11,7 @@ Future Release
     * Fixes
     * Changes
         * Restructure primitives directory to use individual primitives files (:pr:`2331`)
-        * Restrict upper limit of dask and distributed (:pr:`2347`)
+        * Restrict 2022.10.1 for dask and distributed (:pr:`2347`)
     * Documentation Changes
         * Add Featuretools-SQL to Install page on documentation (:pr:`2337`)
         * Fixes broken link in Featuretools documentation (:pr:`2339`)

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -11,6 +11,7 @@ Future Release
     * Fixes
     * Changes
         * Restructure primitives directory to use individual primitives files (:pr:`2331`)
+        * Restrict upper limit of dask and distributed (:pr:`2347`)
     * Documentation Changes
         * Add Featuretools-SQL to Install page on documentation (:pr:`2337`)
         * Fixes broken link in Featuretools documentation (:pr:`2339`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,8 +38,8 @@ requires-python = ">=3.8,<4"
 dependencies = [
     "click >= 7.0.0",
     "cloudpickle >= 1.5.0",
-    "dask[dataframe] >= 2022.2.0, <2022.10.1",
-    "distributed >= 2022.2.0, <2022.10.1",
+    "dask[dataframe] >= 2022.2.0, !=2022.10.1",
+    "distributed >= 2022.2.0, !=2022.10.1",
     "holidays >= 0.13",
     "numpy >= 1.21.0",
     "packaging >= 20.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,8 +38,8 @@ requires-python = ">=3.8,<4"
 dependencies = [
     "click >= 7.0.0",
     "cloudpickle >= 1.5.0",
-    "dask[dataframe] >= 2022.2.0",
-    "distributed >= 2022.2.0",
+    "dask[dataframe] >= 2022.2.0, <2022.10.1",
+    "distributed >= 2022.2.0, <2022.10.1",
     "holidays >= 0.13",
     "numpy >= 1.21.0",
     "packaging >= 20.0",


### PR DESCRIPTION
- Dask has a fix for this issue (https://github.com/dask/distributed/pull/7230)
- So I imagine the next release will not have this issue. 