### PR TITLE
Resolve test failures after `holidays` 0.17 release 

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -13,6 +13,7 @@ Future Release
         * Sets ``uses_full_dataframe`` for ``Rolling*`` and ``Exponential*`` primitives (:pr:`2354`)
         * Updates for compatibility with upcoming Woodwork release 0.21.0 (:pr:`2363`)
         * Updates demo dataset location to use new links (:pr:`2366`)
+        * Fix ``test_holiday_out_of_range`` after ``holidays`` release 0.17 (:pr:`2373`)
     * Changes
         * Remove click and CLI functions (``list-primitives``, ``info``) (:pr:`2353`, :pr:`2358`)
     * Documentation Changes

--- a/featuretools/tests/primitive_tests/test_distancetoholiday_primitive.py
+++ b/featuretools/tests/primitive_tests/test_distancetoholiday_primitive.py
@@ -36,7 +36,16 @@ def test_holiday_out_of_range():
         ],
     )
     days_to_boxing_day = -157 if float(holidays.__version__) >= 0.15 else 209
-    answer = pd.Series([-6, days_to_boxing_day, 148, -5])
+    edge_case_first_day_of_year = -6 if float(holidays.__version__) >= 0.17 else np.nan
+    edge_case_last_day_of_year = -5 if float(holidays.__version__) >= 0.17 else np.nan
+    answer = pd.Series(
+        [
+            edge_case_first_day_of_year,
+            days_to_boxing_day,
+            148,
+            edge_case_last_day_of_year,
+        ],
+    )
     pd.testing.assert_series_equal(date_to_holiday(array), answer, check_names=False)
 
 

--- a/featuretools/tests/primitive_tests/test_distancetoholiday_primitive.py
+++ b/featuretools/tests/primitive_tests/test_distancetoholiday_primitive.py
@@ -36,7 +36,7 @@ def test_holiday_out_of_range():
         ],
     )
     days_to_boxing_day = -157 if float(holidays.__version__) >= 0.15 else 209
-    answer = pd.Series([np.nan, days_to_boxing_day, 148, np.nan])
+    answer = pd.Series([-6, days_to_boxing_day, 148, -5])
     pd.testing.assert_series_equal(date_to_holiday(array), answer, check_names=False)
 
 

--- a/featuretools/tests/requirement_files/latest_requirements.txt
+++ b/featuretools/tests/requirement_files/latest_requirements.txt
@@ -1,7 +1,7 @@
 cloudpickle==2.2.0
 dask==2022.10.2
 distributed==2022.10.2
-holidays==0.16
+holidays==0.17
 numpy==1.23.4
 pandas==1.5.1
 psutil==5.9.4


### PR DESCRIPTION
- Updates `test_holiday_out_of_range` to resolve test failures after latest `holidays` release 