### PR TITLE
Use packaging library to compare versions in test_holiday_out_of_range

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,14 +3,17 @@
 Release Notes
 -------------
 
-.. Future Release
-  ==============
+Future Release
+==============
     * Enhancements
     * Fixes
     * Changes
     * Documentation Changes
     * Testing Changes
-.. Thanks to the following people for contributing to this release:
+        * Fix version comparison in ``test_holiday_out_of_range`` (:pr:`2382`)
+
+    Thanks to the following people for contributing to this release:
+    :user:`thehomebrewnerd`
 
 v1.18.0 Nov 15, 2022
 ====================

--- a/featuretools/tests/primitive_tests/test_distancetoholiday_primitive.py
+++ b/featuretools/tests/primitive_tests/test_distancetoholiday_primitive.py
@@ -4,6 +4,7 @@ import holidays
 import numpy as np
 import pandas as pd
 import pytest
+from packaging.version import parse
 
 from featuretools.primitives import DistanceToHoliday
 
@@ -35,9 +36,13 @@ def test_holiday_out_of_range():
             datetime(2020, 12, 31),
         ],
     )
-    days_to_boxing_day = -157 if float(holidays.__version__) >= 0.15 else 209
-    edge_case_first_day_of_year = -6 if float(holidays.__version__) >= 0.17 else np.nan
-    edge_case_last_day_of_year = -5 if float(holidays.__version__) >= 0.17 else np.nan
+    days_to_boxing_day = -157 if parse(holidays.__version__) >= parse("0.15.0") else 209
+    edge_case_first_day_of_year = (
+        -6 if parse(holidays.__version__) >= parse("0.17.0") else np.nan
+    )
+    edge_case_last_day_of_year = (
+        -5 if parse(holidays.__version__) >= parse("0.17.0") else np.nan
+    )
     answer = pd.Series(
         [
             edge_case_first_day_of_year,


### PR DESCRIPTION
Update  `test_holiday_out_of_range` to use packaging to compare version numbers instead of trying to directly convert version number to float.