### PR TITLE
Update MultiplyNumericBoolean to work with more inputs

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -10,6 +10,7 @@ Future Release
         * Add ``ExpandingCount``, ``ExpandingMin``, ``ExpandingMean``, ``ExpandingMax``, ``ExpandingSTD``, and ``ExpandingTrend`` primitives (:pr:`2343`)
     * Fixes
         * Fix DeepFeatureSynthesis to consider the ``base_of_exclude`` family of attributes when creating transform features(:pr:`2380`)
+        * Fix bug in ``MultiplyNumericBoolean`` primitive that cause error with certain input dtype combinations (:pr:`2393`)
     * Changes
     * Documentation Changes
     * Testing Changes

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -10,7 +10,7 @@ Future Release
         * Add ``ExpandingCount``, ``ExpandingMin``, ``ExpandingMean``, ``ExpandingMax``, ``ExpandingSTD``, and ``ExpandingTrend`` primitives (:pr:`2343`)
     * Fixes
         * Fix DeepFeatureSynthesis to consider the ``base_of_exclude`` family of attributes when creating transform features(:pr:`2380`)
-        * Fix bug in ``MultiplyNumericBoolean`` primitive that cause error with certain input dtype combinations (:pr:`2393`)
+        * Fix bug in ``MultiplyNumericBoolean`` primitive that can cause and error with certain input dtype combinations (:pr:`2393`)
     * Changes
     * Documentation Changes
     * Testing Changes

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -10,7 +10,7 @@ Future Release
         * Add ``ExpandingCount``, ``ExpandingMin``, ``ExpandingMean``, ``ExpandingMax``, ``ExpandingSTD``, and ``ExpandingTrend`` primitives (:pr:`2343`)
     * Fixes
         * Fix DeepFeatureSynthesis to consider the ``base_of_exclude`` family of attributes when creating transform features(:pr:`2380`)
-        * Fix bug in ``MultiplyNumericBoolean`` primitive that can cause and error with certain input dtype combinations (:pr:`2393`)
+        * Fix bug in ``MultiplyNumericBoolean`` primitive that can cause an error with certain input dtype combinations (:pr:`2393`)
     * Changes
     * Documentation Changes
     * Testing Changes

--- a/featuretools/primitives/standard/transform/binary/multiply_numeric_boolean.py
+++ b/featuretools/primitives/standard/transform/binary/multiply_numeric_boolean.py
@@ -1,5 +1,3 @@
-import numpy as np
-import pandas as pd
 import pandas.api.types as pdtypes
 from woodwork.column_schema import ColumnSchema
 from woodwork.logical_types import Boolean, BooleanNullable
@@ -60,8 +58,6 @@ class MultiplyNumericBoolean(TransformPrimitive):
                 bools = ser2
                 vals = ser1
             result = vals * bools.astype("Int64")
-            # Replace all pd.NA with np.nan to avoid WW init error
-            result = result.replace({pd.NA: np.nan})
             return result
 
         return multiply_numeric_boolean

--- a/featuretools/primitives/standard/transform/binary/multiply_numeric_boolean.py
+++ b/featuretools/primitives/standard/transform/binary/multiply_numeric_boolean.py
@@ -47,7 +47,7 @@ class MultiplyNumericBoolean(TransformPrimitive):
         ],
     ]
     return_type = ColumnSchema(semantic_tags={"numeric"})
-    compatibility = [Library.PANDAS]
+    compatibility = [Library.PANDAS, Library.DASK]
     commutative = True
     description_template = "the product of {} and {}"
 

--- a/featuretools/tests/primitive_tests/test_transform_features.py
+++ b/featuretools/tests/primitive_tests/test_transform_features.py
@@ -1841,7 +1841,6 @@ def test_multiply_numeric_boolean_multiple_dtypes_with_nulls():
     vals = pd.Series([np.nan, 2, 3])
     bools = pd.Series([True, False, pd.NA], dtype="boolean")
     multiply_numeric_boolean = MultiplyNumericBoolean()
-    multiply_numeric_boolean = MultiplyNumericBoolean()
     numeric_dtypes = ["float64", "Int64"]
 
     for numeric_dtype in numeric_dtypes:

--- a/featuretools/tests/primitive_tests/test_transform_features.py
+++ b/featuretools/tests/primitive_tests/test_transform_features.py
@@ -1808,7 +1808,7 @@ def test_multiply_numeric_boolean():
 
     multiply_numeric_boolean = MultiplyNumericBoolean()
     for input in test_cases:
-        vals = pd.Series(input["val"])
+        vals = pd.Series(input["val"]).astype("Int64")
         mask = pd.Series(input["mask"])
         actual = multiply_numeric_boolean(vals, mask).tolist()[0]
         expected = input["expected"]
@@ -1816,6 +1816,38 @@ def test_multiply_numeric_boolean():
             assert pd.isnull(actual)
         else:
             assert actual == input["expected"]
+
+
+def test_multiply_numeric_boolean_multiple_dtypes_no_nulls():
+    # Test without null values
+    vals = pd.Series([1, 2, 3])
+    bools = pd.Series([True, False, True])
+    multiply_numeric_boolean = MultiplyNumericBoolean()
+    numeric_dtypes = ["float64", "int64", "Int64"]
+    boolean_dtypes = ["bool", "boolean"]
+
+    for numeric_dtype in numeric_dtypes:
+        for boolean_dtype in boolean_dtypes:
+            actual = multiply_numeric_boolean(
+                vals.astype(numeric_dtype),
+                bools.astype(boolean_dtype),
+            )
+            expected = pd.Series([1, 0, 3])
+            pd.testing.assert_series_equal(actual, expected, check_dtype=False)
+
+
+def test_multiply_numeric_boolean_multiple_dtypes_with_nulls():
+    # Test with null values
+    vals = pd.Series([np.nan, 2, 3])
+    bools = pd.Series([True, False, pd.NA], dtype="boolean")
+    multiply_numeric_boolean = MultiplyNumericBoolean()
+    multiply_numeric_boolean = MultiplyNumericBoolean()
+    numeric_dtypes = ["float64", "Int64"]
+
+    for numeric_dtype in numeric_dtypes:
+        actual = multiply_numeric_boolean(vals.astype(numeric_dtype), bools)
+        expected = pd.Series([np.nan, 0, np.nan])
+        pd.testing.assert_series_equal(actual, expected, check_dtype=False)
 
 
 def test_feature_multiplication(es):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "distributed >= 2022.2.0, !=2022.10.1",
     "holidays >= 0.13",
     "numpy >= 1.21.0",
-    "packaging >= 20.0",
+    "packaging >= 20.0, <22.0",
     "pandas >= 1.4.0",
     "psutil >= 5.6.6",
     "scipy >= 1.4.0",


### PR DESCRIPTION
### Update MultiplyNumericBoolean to work with more inputs

Certain combination of input dtypes would result in errors with newer pandas versions. This PR refactors the calculation in `MultiplyNumericBoolean` to resolve this issue.

Fixes #2390 