### PR TITLE
v1.19.0

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,8 +3,18 @@
 Release Notes
 -------------
 
-Future Release
-==============
+.. Future Release
+  ==============
+    * Enhancements
+    * Fixes
+    * Changes
+    * Documentation Changes
+    * Testing Changes
+
+.. Thanks to the following people for contributing to this release:
+
+v1.19.0 Dec 9, 2022
+===================
     * Enhancements
         * Add ``OneDigitPostalCode`` and ``TwoDigitPostalCode`` primitives (:pr:`2365`)
         * Add ``ExpandingCount``, ``ExpandingMin``, ``ExpandingMean``, ``ExpandingMax``, ``ExpandingSTD``, and ``ExpandingTrend`` primitives (:pr:`2343`)
@@ -12,8 +22,6 @@ Future Release
         * Fix DeepFeatureSynthesis to consider the ``base_of_exclude`` family of attributes when creating transform features(:pr:`2380`)
         * Fix bug with negative version numbers in ``test_version`` (:pr:`2389`)
         * Fix bug in ``MultiplyNumericBoolean`` primitive that can cause an error with certain input dtype combinations (:pr:`2393`)
-    * Changes
-    * Documentation Changes
     * Testing Changes
         * Fix version comparison in ``test_holiday_out_of_range`` (:pr:`2382`)
 

--- a/featuretools/tests/test_version.py
+++ b/featuretools/tests/test_version.py
@@ -2,4 +2,4 @@ from featuretools import __version__
 
 
 def test_version():
-    assert __version__ == "1.18.0"
+    assert __version__ == "1.19.0"

--- a/featuretools/version.py
+++ b/featuretools/version.py
@@ -1,3 +1,3 @@
-__version__ = "1.18.0"
+__version__ = "1.19.0"
 ENTITYSET_SCHEMA_VERSION = "9.0.0"
 FEATURES_SCHEMA_VERSION = "9.0.0"


### PR DESCRIPTION
**v1.19.0 Dec 9, 2022**

* Enhancements
    * Add `OneDigitPostalCode` and `TwoDigitPostalCode` primitives (#2365)
    * Add `ExpandingCount`, `ExpandingMin`, `ExpandingMean`, `ExpandingMax`, `ExpandingSTD` and `ExpandingTrend` primitives (#2343)
* Fixes
    * Fix DeepFeatureSynthesis to consider the `base_of_exclude` family of attributes when creating transform features(#2380)
    * Fix bug with negative version numbers in `test_version` (#2389)
    * Fix bug in `MultiplyNumericBoolean` primitive that can cause an error with certain input dtype combinations (#2393)
* Testing Changes
    * Fix version comparison in `test_holiday_out_of_range` (#2382)