### PR TITLE
Remove extra calls to `all`, `.values()`, and `.keys()` when constructing `ignore_columns` in `DeepFeatureSynthesis`

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -6,6 +6,7 @@ Release Notes
 Future Release
 ==============
     * Enhancements
+        * Iterate only once over ``ignore_columns`` in ``DeepFeatureSynthesis`` init (:pr:`2397`)
     * Fixes
         * Fix typo in ``_handle_binary_comparison`` function name and update ``set_feature_names`` docstring (:pr:`2388`) 
     * Changes

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -6,10 +6,10 @@ Release Notes
 Future Release
 ==============
     * Enhancements
-        * Iterate only once over ``ignore_columns`` in ``DeepFeatureSynthesis`` init (:pr:`2397`)
     * Fixes
         * Fix typo in ``_handle_binary_comparison`` function name and update ``set_feature_names`` docstring (:pr:`2388`) 
     * Changes
+        * Iterate only once over ``ignore_columns`` in ``DeepFeatureSynthesis`` init (:pr:`2397`)
     * Documentation Changes
         *  Remove unused sections from 1.19.0 notes (:pr:`2396`)
     * Testing Changes

--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -1263,23 +1263,19 @@ def _features_have_same_path(input_features):
 
 
 def _build_ignore_columns(input_dict: Dict[str, List[str]]) -> DefaultDict[str, set]:
-    """Iterates over the input dictionary and builds the ignore_columns data structure"""
+    """Iterates over the input dictionary to build the ignore_columns dictionary.
+    Expects the input_dict's keys to be strings, and values to be lists of strings
+    Throws a TypeError if they are not.
+    """
     ignore_columns = defaultdict(set)
     if input_dict is not None:
         for df_name, cols in input_dict.items():
-            _validate_ignore_columns_entry(df_name, cols)
+            if not isinstance(df_name, str) or not isinstance(cols, list):
+                raise TypeError("ignore_columns should be dict[str -> list]")
+            elif not all(isinstance(c, str) for c in cols):
+                raise TypeError("list in ignore_columns must only have string values")
             ignore_columns[df_name] = set(cols)
     return ignore_columns
-
-
-def _validate_ignore_columns_entry(df_name: str, col: List[str]) -> None:
-    """Check that ignore_columns dictionary maps strings to list of strings,
-    raise a TypeError if it does not.
-    """
-    if not isinstance(df_name, str) or not isinstance(col, list):
-        raise TypeError("ignore_columns should be dict[str -> list]")
-    elif not all(isinstance(c, str) for c in col):
-        raise TypeError("list in ignore_columns must only have string values")
 
 
 def _direct_of_dataframe(feature, parent_dataframe):

--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -1268,7 +1268,8 @@ def _features_have_same_path(input_features):
 
 def _validate_ignore_columns_entry(df_name: str, col: List[str]) -> None:
     """
-    Assert that the ignore_columns dictionary maps strings to list of strings
+    Check that ignore_columns dictionary maps strings to list of strings,
+    raise TypeError if it does not.
     """
     if not isinstance(df_name, str) or not isinstance(col, list):
         raise TypeError("ignore_columns should be dict[str -> list]")

--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -1263,8 +1263,8 @@ def _features_have_same_path(input_features):
 
 
 def _build_ignore_columns(input_dict: Dict[str, List[str]]) -> DefaultDict[str, set]:
-    """Iterates over the input dictionary to build the ignore_columns dictionary.
-    Expects the input_dict's keys to be strings, and values to be lists of strings
+    """Iterates over the input dictionary to build the ignore_columns defaultdict.
+    Expects the input_dict's keys to be strings, and values to be lists of strings.
     Throws a TypeError if they are not.
     """
     ignore_columns = defaultdict(set)

--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -1267,9 +1267,8 @@ def _features_have_same_path(input_features):
 
 
 def _validate_ignore_columns_entry(df_name: str, col: List[str]) -> None:
-    """
-    Check that ignore_columns dictionary maps strings to list of strings,
-    raise TypeError if it does not.
+    """Check that ignore_columns dictionary maps strings to list of strings,
+    raise a TypeError if it does not.
     """
     if not isinstance(df_name, str) or not isinstance(col, list):
         raise TypeError("ignore_columns should be dict[str -> list]")

--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -188,24 +188,14 @@ class DeepFeatureSynthesis(object):
             if not isinstance(ignore_dataframes, list):
                 raise TypeError("ignore_dataframes must be a list")
             assert (
-                target_dataframe_name not in ignore_dataframes
+                    target_dataframe_name not in ignore_dataframes
             ), "Can't ignore target_dataframe!"
             self.ignore_dataframes = set(ignore_dataframes)
 
         self.ignore_columns = defaultdict(set)
         if ignore_columns is not None:
-            # check if ignore_columns is not {str: list}
-            if not all(isinstance(i, str) for i in ignore_columns.keys()) or not all(
-                isinstance(i, list) for i in ignore_columns.values()
-            ):
-                raise TypeError("ignore_columns should be dict[str -> list]")
-            # check if list values are all of type str
-            elif not all(
-                all(isinstance(v, str) for v in value)
-                for value in ignore_columns.values()
-            ):
-                raise TypeError("list values should be of type str")
             for df_name, cols in ignore_columns.items():
+                _validate_ignore_columns_entry(df_name, cols)
                 self.ignore_columns[df_name] = set(cols)
         self.target_dataframe_name = target_dataframe_name
         self.es = entityset
@@ -359,9 +349,9 @@ class DeepFeatureSynthesis(object):
         def filt(f):
             # remove identity features of the ID field of the target dataframe
             if (
-                isinstance(f, IdentityFeature)
-                and f.dataframe_name == self.target_dataframe_name
-                and f.column_name == self.es[self.target_dataframe_name].ww.index
+                    isinstance(f, IdentityFeature)
+                    and f.dataframe_name == self.target_dataframe_name
+                    and f.column_name == self.es[self.target_dataframe_name].ww.index
             ):
                 return False
 
@@ -477,8 +467,8 @@ class DeepFeatureSynthesis(object):
 
             new_path = relationship_path + sub_relationship_path
             if (
-                self.allowed_paths
-                and tuple(new_path.dataframes()) not in self.allowed_paths
+                    self.allowed_paths
+                    and tuple(new_path.dataframes()) not in self.allowed_paths
             ):
                 continue
 
@@ -659,11 +649,11 @@ class DeepFeatureSynthesis(object):
                     self.where_clauses[dataframe.ww.name].add(feat == val)
 
     def _build_transform_features(
-        self,
-        all_features,
-        dataframe,
-        max_depth=0,
-        require_direct_input=False,
+            self,
+            all_features,
+            dataframe,
+            max_depth=0,
+            require_direct_input=False,
     ):
         """Creates trans_features for all the columns in a dataframe
 
@@ -708,7 +698,7 @@ class DeepFeatureSynthesis(object):
                 if not can_stack_primitive_on_inputs(trans_prim, matching_input):
                     continue
                 if not any(
-                    True for bf in matching_input if bf.number_output_features != 1
+                        True for bf in matching_input if bf.number_output_features != 1
                 ):
                     new_f = TransformFeature(matching_input, primitive=trans_prim)
                     features_to_add.append(new_f)
@@ -831,8 +821,8 @@ class DeepFeatureSynthesis(object):
             def feature_filter(f):
                 # Remove direct features of parent dataframe and features in relationship path.
                 return (
-                    not _direct_of_dataframe(f, parent_dataframe)
-                ) and not self._feature_in_relationship_path(relationship_path, f)
+                           not _direct_of_dataframe(f, parent_dataframe)
+                       ) and not self._feature_in_relationship_path(relationship_path, f)
 
             input_types = agg_prim.input_types
             matching_inputs = self._get_matching_inputs(
@@ -1274,6 +1264,16 @@ def _features_have_same_path(input_features):
             return False
 
     return True
+
+
+def _validate_ignore_columns_entry(df_name: str, col: List[str]) -> None:
+    """
+    Assert that the ignore_columns dictionary maps strings to list of strings
+    """
+    if not isinstance(df_name, str) or not isinstance(df_name, list):
+        raise TypeError("ignore_columns should be dict[str -> list]")
+    elif not all(isinstance(c, str) for c in col):
+        raise TypeError("list in ignore_columns must only have string values")
 
 
 def _direct_of_dataframe(feature, parent_dataframe):

--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -3,7 +3,7 @@ import logging
 import operator
 import warnings
 from collections import defaultdict
-from typing import Any, List
+from typing import Any, DefaultDict, Dict, List
 
 from woodwork.column_schema import ColumnSchema
 from woodwork.logical_types import Boolean, BooleanNullable
@@ -192,11 +192,7 @@ class DeepFeatureSynthesis(object):
             ), "Can't ignore target_dataframe!"
             self.ignore_dataframes = set(ignore_dataframes)
 
-        self.ignore_columns = defaultdict(set)
-        if ignore_columns is not None:
-            for df_name, cols in ignore_columns.items():
-                _validate_ignore_columns_entry(df_name, cols)
-                self.ignore_columns[df_name] = set(cols)
+        self.ignore_columns = _build_ignore_columns(ignore_columns)
         self.target_dataframe_name = target_dataframe_name
         self.es = entityset
 
@@ -1264,6 +1260,16 @@ def _features_have_same_path(input_features):
             return False
 
     return True
+
+
+def _build_ignore_columns(input_dict: Dict[str, List[str]]) -> DefaultDict[str, set]:
+    """Iterates over the input dictionary and builds the ignore_columns data structure"""
+    ignore_columns = defaultdict(set)
+    if input_dict is not None:
+        for df_name, cols in input_dict.items():
+            _validate_ignore_columns_entry(df_name, cols)
+            ignore_columns[df_name] = set(cols)
+    return ignore_columns
 
 
 def _validate_ignore_columns_entry(df_name: str, col: List[str]) -> None:

--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -188,7 +188,7 @@ class DeepFeatureSynthesis(object):
             if not isinstance(ignore_dataframes, list):
                 raise TypeError("ignore_dataframes must be a list")
             assert (
-                    target_dataframe_name not in ignore_dataframes
+                target_dataframe_name not in ignore_dataframes
             ), "Can't ignore target_dataframe!"
             self.ignore_dataframes = set(ignore_dataframes)
 
@@ -349,9 +349,9 @@ class DeepFeatureSynthesis(object):
         def filt(f):
             # remove identity features of the ID field of the target dataframe
             if (
-                    isinstance(f, IdentityFeature)
-                    and f.dataframe_name == self.target_dataframe_name
-                    and f.column_name == self.es[self.target_dataframe_name].ww.index
+                isinstance(f, IdentityFeature)
+                and f.dataframe_name == self.target_dataframe_name
+                and f.column_name == self.es[self.target_dataframe_name].ww.index
             ):
                 return False
 
@@ -467,8 +467,8 @@ class DeepFeatureSynthesis(object):
 
             new_path = relationship_path + sub_relationship_path
             if (
-                    self.allowed_paths
-                    and tuple(new_path.dataframes()) not in self.allowed_paths
+                self.allowed_paths
+                and tuple(new_path.dataframes()) not in self.allowed_paths
             ):
                 continue
 
@@ -649,11 +649,11 @@ class DeepFeatureSynthesis(object):
                     self.where_clauses[dataframe.ww.name].add(feat == val)
 
     def _build_transform_features(
-            self,
-            all_features,
-            dataframe,
-            max_depth=0,
-            require_direct_input=False,
+        self,
+        all_features,
+        dataframe,
+        max_depth=0,
+        require_direct_input=False,
     ):
         """Creates trans_features for all the columns in a dataframe
 
@@ -698,7 +698,7 @@ class DeepFeatureSynthesis(object):
                 if not can_stack_primitive_on_inputs(trans_prim, matching_input):
                     continue
                 if not any(
-                        True for bf in matching_input if bf.number_output_features != 1
+                    True for bf in matching_input if bf.number_output_features != 1
                 ):
                     new_f = TransformFeature(matching_input, primitive=trans_prim)
                     features_to_add.append(new_f)
@@ -821,8 +821,8 @@ class DeepFeatureSynthesis(object):
             def feature_filter(f):
                 # Remove direct features of parent dataframe and features in relationship path.
                 return (
-                           not _direct_of_dataframe(f, parent_dataframe)
-                       ) and not self._feature_in_relationship_path(relationship_path, f)
+                    not _direct_of_dataframe(f, parent_dataframe)
+                ) and not self._feature_in_relationship_path(relationship_path, f)
 
             input_types = agg_prim.input_types
             matching_inputs = self._get_matching_inputs(
@@ -1270,7 +1270,7 @@ def _validate_ignore_columns_entry(df_name: str, col: List[str]) -> None:
     """
     Assert that the ignore_columns dictionary maps strings to list of strings
     """
-    if not isinstance(df_name, str) or not isinstance(df_name, list):
+    if not isinstance(df_name, str) or not isinstance(col, list):
         raise TypeError("ignore_columns should be dict[str -> list]")
     elif not all(isinstance(c, str) for c in col):
         raise TypeError("list in ignore_columns must only have string values")

--- a/featuretools/tests/synthesis/test_deep_feature_synthesis.py
+++ b/featuretools/tests/synthesis/test_deep_feature_synthesis.py
@@ -240,7 +240,7 @@ def test_ignore_columns_input_type(es):
 
 
 def test_ignore_columns_with_nonstring_values(es):
-    error_msg = "list values should be of type str"
+    error_msg = "list in ignore_columns must only have string values"
     wrong_input_list = {"log": ["a", "b", 3]}
     with pytest.raises(TypeError, match=error_msg):
         DeepFeatureSynthesis(


### PR DESCRIPTION
- In the `init` method for `DeepFeatureSynthesis`, we perform a type check on `ignore_columns` to make sure it maps strings to list of strings 
- Currently, we iterate multiple times over the input to perform this type checking, then iterate again to create the `ignore_columns` data structure. 
- By refactoring, we can reduce this to iterating once over the input. This reduces code complexity and computation required 