### PR TITLE
Refactor building groupby features if `require_direct_input`  

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -9,6 +9,7 @@ Future Release
     * Fixes
         * Fix typo in ``_handle_binary_comparison`` function name and update ``set_feature_names`` docstring (:pr:`2388`) 
     * Changes
+        * Refactor ``_all_direct_and_same_path`` by deleting call to ``_features_have_same_path`` (:pr:`2400`)
     * Documentation Changes
         *  Remove unused sections from 1.19.0 notes (:pr:`2396`)
     * Testing Changes

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -10,10 +10,11 @@ Future Release
         * Fix typo in ``_handle_binary_comparison`` function name and update ``set_feature_names`` docstring (:pr:`2388`) 
     * Changes
     * Documentation Changes
+        *  Remove unused sections from 1.19.0 notes (:pr:`2396`)
     * Testing Changes
 
    Thanks to the following people for contributing to this release:
-   :user:`sbadithe`
+   :user:`rwedge`, :user:`sbadithe`
 
 v1.19.0 Dec 9, 2022
 ===================
@@ -24,8 +25,6 @@ v1.19.0 Dec 9, 2022
         * Fix DeepFeatureSynthesis to consider the ``base_of_exclude`` family of attributes when creating transform features(:pr:`2380`)
         * Fix bug with negative version numbers in ``test_version`` (:pr:`2389`)
         * Fix bug in ``MultiplyNumericBoolean`` primitive that can cause an error with certain input dtype combinations (:pr:`2393`)
-    * Changes
-    * Documentation Changes
     * Testing Changes
         * Fix version comparison in ``test_holiday_out_of_range`` (:pr:`2382`)
 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,15 +3,17 @@
 Release Notes
 -------------
 
-.. Future Release
-  ==============
+Future Release
+==============
     * Enhancements
     * Fixes
+        * Fix typo in ``_handle_binary_comparison`` function name and update ``set_feature_names`` docstring (:pr:`2388`) 
     * Changes
     * Documentation Changes
     * Testing Changes
 
-.. Thanks to the following people for contributing to this release:
+   Thanks to the following people for contributing to this release:
+   :user:`sbadithe`
 
 v1.19.0 Dec 9, 2022
 ===================
@@ -22,6 +24,8 @@ v1.19.0 Dec 9, 2022
         * Fix DeepFeatureSynthesis to consider the ``base_of_exclude`` family of attributes when creating transform features(:pr:`2380`)
         * Fix bug with negative version numbers in ``test_version`` (:pr:`2389`)
         * Fix bug in ``MultiplyNumericBoolean`` primitive that can cause an error with certain input dtype combinations (:pr:`2393`)
+    * Changes
+    * Documentation Changes
     * Testing Changes
         * Fix version comparison in ``test_holiday_out_of_range`` (:pr:`2382`)
 

--- a/featuretools/feature_base/feature_base.py
+++ b/featuretools/feature_base/feature_base.py
@@ -114,9 +114,10 @@ class FeatureBase(object):
 
     def set_feature_names(self, names):
         """Set new values for the feature column names, overriding the default values.
-        Number of names provided much match the number of output columns defined for
-        the feature. Only works for features that have more than one output column. Use
-        ``Feature.rename`` to change the column name for single output features.
+        Number of names provided must match the number of output columns defined for
+        the feature, and all provided names should be unique. Only works for features
+        that have more than one output column. Use ``Feature.rename`` to change the column
+        name for single output features.
 
         Args:
             names (list[str]): List of names to use for the output feature columns. Provided
@@ -275,7 +276,7 @@ class FeatureBase(object):
             "arguments": self.get_arguments(),
         }
 
-    def _handle_binary_comparision(self, other, Primitive, PrimitiveScalar):
+    def _handle_binary_comparison(self, other, Primitive, PrimitiveScalar):
         if isinstance(other, FeatureBase):
             return Feature([self, other], primitive=Primitive)
 
@@ -283,7 +284,7 @@ class FeatureBase(object):
 
     def __eq__(self, other):
         """Compares to other by equality"""
-        return self._handle_binary_comparision(
+        return self._handle_binary_comparison(
             other,
             primitives.Equal,
             primitives.EqualScalar,
@@ -291,7 +292,7 @@ class FeatureBase(object):
 
     def __ne__(self, other):
         """Compares to other by non-equality"""
-        return self._handle_binary_comparision(
+        return self._handle_binary_comparison(
             other,
             primitives.NotEqual,
             primitives.NotEqualScalar,
@@ -299,7 +300,7 @@ class FeatureBase(object):
 
     def __gt__(self, other):
         """Compares if greater than other"""
-        return self._handle_binary_comparision(
+        return self._handle_binary_comparison(
             other,
             primitives.GreaterThan,
             primitives.GreaterThanScalar,
@@ -307,7 +308,7 @@ class FeatureBase(object):
 
     def __ge__(self, other):
         """Compares if greater than or equal to other"""
-        return self._handle_binary_comparision(
+        return self._handle_binary_comparison(
             other,
             primitives.GreaterThanEqualTo,
             primitives.GreaterThanEqualToScalar,
@@ -315,7 +316,7 @@ class FeatureBase(object):
 
     def __lt__(self, other):
         """Compares if less than other"""
-        return self._handle_binary_comparision(
+        return self._handle_binary_comparison(
             other,
             primitives.LessThan,
             primitives.LessThanScalar,
@@ -323,7 +324,7 @@ class FeatureBase(object):
 
     def __le__(self, other):
         """Compares if less than or equal to other"""
-        return self._handle_binary_comparision(
+        return self._handle_binary_comparison(
             other,
             primitives.LessThanEqualTo,
             primitives.LessThanEqualToScalar,
@@ -331,7 +332,7 @@ class FeatureBase(object):
 
     def __add__(self, other):
         """Add other"""
-        return self._handle_binary_comparision(
+        return self._handle_binary_comparison(
             other,
             primitives.AddNumeric,
             primitives.AddNumericScalar,
@@ -342,7 +343,7 @@ class FeatureBase(object):
 
     def __sub__(self, other):
         """Subtract other"""
-        return self._handle_binary_comparision(
+        return self._handle_binary_comparison(
             other,
             primitives.SubtractNumeric,
             primitives.SubtractNumericScalar,
@@ -353,7 +354,7 @@ class FeatureBase(object):
 
     def __div__(self, other):
         """Divide by other"""
-        return self._handle_binary_comparision(
+        return self._handle_binary_comparison(
             other,
             primitives.DivideNumeric,
             primitives.DivideNumericScalar,
@@ -394,7 +395,7 @@ class FeatureBase(object):
                     [self, other],
                     primitive=primitives.MultiplyNumericBoolean,
                 )
-        return self._handle_binary_comparision(
+        return self._handle_binary_comparison(
             other,
             primitives.MultiplyNumeric,
             primitives.MultiplyNumericScalar,
@@ -405,7 +406,7 @@ class FeatureBase(object):
 
     def __mod__(self, other):
         """Take modulus of other"""
-        return self._handle_binary_comparision(
+        return self._handle_binary_comparison(
             other,
             primitives.ModuloNumeric,
             primitives.ModuloNumericScalar,

--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -1272,6 +1272,7 @@ def _all_direct_and_same_path(input_features) -> bool:
             return False
     return True
 
+
 def _direct_of_dataframe(feature, parent_dataframe):
     return (
         isinstance(feature, DirectFeature)

--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -744,12 +744,12 @@ class DeepFeatureSynthesis(object):
                 any_direct_in_matching_input = None
                 all_direct_and_same_path_in_matching_input = None
                 if require_direct_input:
-                    any_direct_in_matching_input = any(
+                    if any_direct_in_matching_input := any(
                         isinstance(bf, DirectFeature) for bf in matching_input
-                    )
-                    all_direct_and_same_path_in_matching_input = (
-                        _all_direct_and_same_path(matching_input)
-                    )
+                    ):
+                        all_direct_and_same_path_in_matching_input = (
+                            _all_direct_and_same_path(matching_input)
+                        )
                 if any(True for bf in matching_input if bf.number_output_features != 1):
                     continue
                 for groupby in groupby_matches:

--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -8,7 +8,7 @@ from typing import Any, DefaultDict, Dict, List
 from woodwork.column_schema import ColumnSchema
 from woodwork.logical_types import Boolean, BooleanNullable
 
-from featuretools import primitives, FeatureBase
+from featuretools import primitives
 from featuretools.entityset.entityset import LTI_COLUMN_NAME
 from featuretools.entityset.relationship import RelationshipPath
 from featuretools.feature_base import (
@@ -1246,7 +1246,7 @@ def check_primitive(
     return primitive
 
 
-def _all_direct_and_same_path(input_features: List[FeatureBase]) -> bool:
+def _all_direct_and_same_path(input_features: List) -> bool:
     """Given a list of features, returns True if they are all
     DirectFeatures with the same relationship_path, and False if not
     """

--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -761,14 +761,12 @@ class DeepFeatureSynthesis(object):
                         #         and groupby is not a DirectFeature
                         # (2) --> All of the matching input and groupby are DirectFeatures
                         #         with the same relationship path
-                        groupby_is_not_direct = not isinstance(groupby, DirectFeature)
+                        groupby_is_direct = not isinstance(groupby, DirectFeature)
                         # Checks case (1)
-                        if not any_direct_in_matching_input and groupby_is_not_direct:
+                        if not any_direct_in_matching_input and not groupby_is_direct:
                             continue
                         elif all_direct_and_same_path_in_matching_input:
-                            if groupby_is_not_direct:
-                                continue
-                            else:
+                            if groupby_is_direct:
                                 # since matching_input all have the same path, we just
                                 # need to check that the first input in matching_input has
                                 # the same relationship path as groupby. If they do,

--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -748,15 +748,18 @@ class DeepFeatureSynthesis(object):
                 ):
                     for groupby in groupby_matches:
                         input_features = matching_input + (groupby,)
-                        if require_direct_input and (
-                            _all_direct_and_same_path(input_features)
-                            or not any(
-                                True
-                                for feature in (input_features)
-                                if isinstance(feature, DirectFeature)
-                            )
-                        ):
-                            continue
+                        if require_direct_input:
+                            path = input_features[0].relationship_path
+                            found_direct = False
+                            same_paths = True
+                            for feature in input_features:
+                                if isinstance(feature, DirectFeature):
+                                    found_direct = True
+                                    if feature.relationship_path != path:
+                                        same_paths = False
+                                        break
+                            if not found_direct or not same_paths:
+                                continue
                         new_f = GroupByTransformFeature(
                             list(matching_input),
                             groupby=groupby[0],

--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -762,7 +762,7 @@ class DeepFeatureSynthesis(object):
                         # (2) --> All of the matching input and groupby are DirectFeatures
                         #         with the same relationship path
                         groupby_is_not_direct = not isinstance(groupby, DirectFeature)
-                        # fulfills case (1)
+                        # Checks case (1)
                         if not any_direct_in_matching_input and groupby_is_not_direct:
                             continue
                         elif all_direct_and_same_path_in_matching_input:
@@ -774,7 +774,7 @@ class DeepFeatureSynthesis(object):
                                 # the same relationship path as groupby. If they do,
                                 # we skip adding Features for this groupby as per the rules above
 
-                                # fulfills case (2)
+                                # Checks case (2)
                                 if (
                                     groupby.relationship_path
                                     == matching_input[0].relationship_path

--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -1266,9 +1266,7 @@ def _all_direct_and_same_path(input_features) -> bool:
     """
     path = input_features[0].relationship_path
     for f in input_features:
-        if not isinstance(f, DirectFeature):
-            return False
-        if f.relationship_path != path:
+        if not isinstance(f, DirectFeature) or f.relationship_path != path:
             return False
     return True
 

--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -1,6 +1,8 @@
-from typing import Any, DefaultDict, Dict, List, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, DefaultDict, Dict, List
+
 if TYPE_CHECKING:
     from featuretools import FeatureBase
+
 import functools
 import logging
 import operator

--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -1,8 +1,3 @@
-from typing import TYPE_CHECKING, Any, DefaultDict, Dict, List
-
-if TYPE_CHECKING:
-    from featuretools import FeatureBase
-
 import functools
 import logging
 import operator
@@ -36,6 +31,7 @@ from featuretools.primitives.options_utils import (
     ignore_dataframe_for_primitive,
 )
 from featuretools.utils.gen_utils import Library, camel_and_title_to_snake
+from typing import Any, DefaultDict, Dict, List
 
 logger = logging.getLogger("featuretools")
 
@@ -1250,7 +1246,7 @@ def check_primitive(
     return primitive
 
 
-def _all_direct_and_same_path(input_features: List["FeatureBase"]) -> bool:
+def _all_direct_and_same_path(input_features: List) -> bool:
     """Given a list of features, returns True if they are all
     DirectFeatures with the same relationship_path, and False if not
     """

--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -1260,21 +1260,17 @@ def check_primitive(
     return primitive
 
 
-def _all_direct_and_same_path(input_features):
-    return all(
-        isinstance(f, DirectFeature) for f in input_features
-    ) and _features_have_same_path(input_features)
-
-
-def _features_have_same_path(input_features):
+def _all_direct_and_same_path(input_features) -> bool:
+    """Given a list of features, returns True if they are all
+    DirectFeatures with the same relationship_path, and False if not
+    """
     path = input_features[0].relationship_path
-
-    for f in input_features[1:]:
+    for f in input_features:
+        if not isinstance(f, DirectFeature):
+            return False
         if f.relationship_path != path:
             return False
-
     return True
-
 
 def _direct_of_dataframe(feature, parent_dataframe):
     return (

--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -764,7 +764,7 @@ class DeepFeatureSynthesis(object):
                         #         and groupby is not a DirectFeature
                         # (2) --> All of the matching input and groupby are DirectFeatures
                         #         with the same relationship path
-                        groupby_is_direct = not isinstance(groupby, DirectFeature)
+                        groupby_is_direct = not isinstance(groupby[0], DirectFeature)
                         # Checks case (1)
                         if not any_direct_in_matching_input and not groupby_is_direct:
                             continue
@@ -772,7 +772,7 @@ class DeepFeatureSynthesis(object):
                             # Checks case (2)
                             if (
                                 groupby_is_direct
-                                and groupby.relationship_path
+                                and groupby[0].relationship_path
                                 == matching_input[0].relationship_path
                             ):
                                 # since matching_input all have the same path, we just

--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -741,8 +741,6 @@ class DeepFeatureSynthesis(object):
             for matching_input in matching_inputs:
                 if not can_stack_primitive_on_inputs(groupby_prim, matching_input):
                     continue
-                any_direct_in_matching_input = None
-                all_direct_and_same_path_in_matching_input = None
                 if require_direct_input:
                     if any_direct_in_matching_input := any(
                         isinstance(bf, DirectFeature) for bf in matching_input
@@ -766,8 +764,9 @@ class DeepFeatureSynthesis(object):
                         #         with the same relationship path
                         groupby_is_direct = isinstance(groupby[0], DirectFeature)
                         # Checks case (1)
-                        if not any_direct_in_matching_input and not groupby_is_direct:
-                            continue
+                        if not any_direct_in_matching_input:
+                            if not groupby_is_direct:
+                                continue
                         elif all_direct_and_same_path_in_matching_input:
                             # Checks case (2)
                             if (
@@ -775,10 +774,6 @@ class DeepFeatureSynthesis(object):
                                 and groupby[0].relationship_path
                                 == matching_input[0].relationship_path
                             ):
-                                # since matching_input all have the same path, we just
-                                # need to check that the first input in matching_input has
-                                # the same relationship path as groupby. If they do,
-                                # we skip adding Features for this groupby as per the rules above
                                 continue
                     new_f = GroupByTransformFeature(
                         list(matching_input),

--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -764,7 +764,7 @@ class DeepFeatureSynthesis(object):
                         #         and groupby is not a DirectFeature
                         # (2) --> All of the matching input and groupby are DirectFeatures
                         #         with the same relationship path
-                        groupby_is_direct = not isinstance(groupby[0], DirectFeature)
+                        groupby_is_direct = isinstance(groupby[0], DirectFeature)
                         # Checks case (1)
                         if not any_direct_in_matching_input and not groupby_is_direct:
                             continue

--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -1,9 +1,11 @@
+from typing import Any, DefaultDict, Dict, List, TYPE_CHECKING
+if TYPE_CHECKING:
+    from featuretools import FeatureBase
 import functools
 import logging
 import operator
 import warnings
 from collections import defaultdict
-from typing import Any, DefaultDict, Dict, List
 
 from woodwork.column_schema import ColumnSchema
 from woodwork.logical_types import Boolean, BooleanNullable
@@ -1246,7 +1248,7 @@ def check_primitive(
     return primitive
 
 
-def _all_direct_and_same_path(input_features: List) -> bool:
+def _all_direct_and_same_path(input_features: List["FeatureBase"]) -> bool:
     """Given a list of features, returns True if they are all
     DirectFeatures with the same relationship_path, and False if not
     """

--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -3,6 +3,7 @@ import logging
 import operator
 import warnings
 from collections import defaultdict
+from typing import Any, DefaultDict, Dict, List
 
 from woodwork.column_schema import ColumnSchema
 from woodwork.logical_types import Boolean, BooleanNullable
@@ -31,7 +32,6 @@ from featuretools.primitives.options_utils import (
     ignore_dataframe_for_primitive,
 )
 from featuretools.utils.gen_utils import Library, camel_and_title_to_snake
-from typing import Any, DefaultDict, Dict, List
 
 logger = logging.getLogger("featuretools")
 

--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -8,7 +8,7 @@ from typing import Any, List
 from woodwork.column_schema import ColumnSchema
 from woodwork.logical_types import Boolean, BooleanNullable
 
-from featuretools import primitives
+from featuretools import primitives, FeatureBase
 from featuretools.entityset.entityset import LTI_COLUMN_NAME
 from featuretools.entityset.relationship import RelationshipPath
 from featuretools.feature_base import (
@@ -1260,7 +1260,7 @@ def check_primitive(
     return primitive
 
 
-def _all_direct_and_same_path(input_features) -> bool:
+def _all_direct_and_same_path(input_features: List[FeatureBase]) -> bool:
     """Given a list of features, returns True if they are all
     DirectFeatures with the same relationship_path, and False if not
     """

--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -741,6 +741,8 @@ class DeepFeatureSynthesis(object):
             for matching_input in matching_inputs:
                 if not can_stack_primitive_on_inputs(groupby_prim, matching_input):
                     continue
+                if any(True for bf in matching_input if bf.number_output_features != 1):
+                    continue
                 if require_direct_input:
                     if any_direct_in_matching_input := any(
                         isinstance(bf, DirectFeature) for bf in matching_input
@@ -748,8 +750,6 @@ class DeepFeatureSynthesis(object):
                         all_direct_and_same_path_in_matching_input = (
                             _all_direct_and_same_path(matching_input)
                         )
-                if any(True for bf in matching_input if bf.number_output_features != 1):
-                    continue
                 for groupby in groupby_matches:
                     if require_direct_input:
                         # If require_direct_input, require a DirectFeature in input or as a


### PR DESCRIPTION
- We were looping over the `input_features` twice because of the call to `_features_have_same_path`, but I think one traversal should do the trick
- Since the checks for being a DirectFeature and having the same path are so tightly coupled (this function is still doing exactly what it was before), I think it should be okay to move it into one function, but I'm open to ideas here
- Helps reduce complexity, and we can delete the `_features_have_same_path` function
- In `_build_transform_features`, removes function call and iterates once over the input_features. This reduces from three traversals to one (closes #2402) 