### PR TITLE
Resolve Pyarrow Warning on Import

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -8,6 +8,7 @@ Future Release
     * Enhancements
     * Fixes
         * Fix typo in ``_handle_binary_comparison`` function name and update ``set_feature_names`` docstring (:pr:`2388`) 
+        * Resolve PyArrow warning (:pr:`2404`)
     * Changes
         * Iterate only once over ``ignore_columns`` in ``DeepFeatureSynthesis`` init (:pr:`2397`)
     * Documentation Changes

--- a/featuretools/__init__.py
+++ b/featuretools/__init__.py
@@ -37,6 +37,8 @@ import logging
 import pkg_resources
 import sys
 import traceback
+import warnings
+from woodwork import list_logical_types, list_semantic_tags
 
 
 logger = logging.getLogger("featuretools")

--- a/featuretools/__init__.py
+++ b/featuretools/__init__.py
@@ -1,4 +1,11 @@
 # flake8: noqa
+import os
+
+# Silence "WARNING:root:'PYARROW_IGNORE_TIMEZONE' environment variable was not set"
+# on import
+if not os.getenv("PYARROW_IGNORE_TIMEZONE"):
+    os.environ["PYARROW_IGNORE_TIMEZONE"] = "1"
+
 from featuretools.version import __version__
 from featuretools.config_init import config
 from featuretools.entityset.api import *
@@ -30,8 +37,7 @@ import logging
 import pkg_resources
 import sys
 import traceback
-import warnings
-from woodwork import list_logical_types, list_semantic_tags
+
 
 logger = logging.getLogger("featuretools")
 


### PR DESCRIPTION
- Resolves this warning: `WARNING:root:'PYARROW_IGNORE_TIMEZONE' environment variable was not set. It is required to set this environment variable to '1' in both driver and executor sides if you use pyarrow>=2.0.0. pandas-on-Spark will set it for you but it does not work if there is a Spark context already launched.
`
- Makes sure the user has not set this env variable, if they have, it doesn't touch it