### PR TITLE
Update init calls in add_last_time_indexes to use init_with_parital_schema

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -7,15 +7,16 @@ Future Release
 ==============
     * Enhancements
     * Fixes
-        * Fix typo in ``_handle_binary_comparison`` function name and update ``set_feature_names`` docstring (:pr:`2388`) 
+        * Fix typo in ``_handle_binary_comparison`` function name and update ``set_feature_names`` docstring (:pr:`2388`)
     * Changes
         * Iterate only once over ``ignore_columns`` in ``DeepFeatureSynthesis`` init (:pr:`2397`)
+        * Initialize Woodwork with ``init_with_partial_schama`` instead of ``init`` in ``EntitySet.add_last_time_indexes`` (:pr:`2409`)
     * Documentation Changes
         *  Remove unused sections from 1.19.0 notes (:pr:`2396`)
     * Testing Changes
 
    Thanks to the following people for contributing to this release:
-   :user:`rwedge`, :user:`sbadithe`
+   :user:`rwedge`, :user:`sbadithe`, :user: `thehomebrewnerd`
 
 v1.19.0 Dec 9, 2022
 ===================

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -1322,7 +1322,7 @@ class EntitySet(object):
                 # Add the new column to the DataFrame
                 if isinstance(df, dd.DataFrame):
                     new_df = df.merge(lti.reset_index(), on=df.ww.index)
-                    new_df.ww.init(
+                    new_df.ww.init_with_partial_schema(
                         schema=df.ww.schema,
                         logical_types={LTI_COLUMN_NAME: lti_ltype},
                     )
@@ -1333,7 +1333,7 @@ class EntitySet(object):
                     dfs_to_update[df.ww.name] = new_df
                 elif is_instance(df, ps, "DataFrame"):
                     new_df = df.merge(lti, left_on=df.ww.index, right_index=True)
-                    new_df.ww.init(
+                    new_df.ww.init_with_partial_schema(
                         schema=df.ww.schema,
                         logical_types={LTI_COLUMN_NAME: lti_ltype},
                     )


### PR DESCRIPTION
### Update init calls in add_last_time_indexes to use init_with_parital_schema

Fixes #1463 

Note: The current Woodwork `init` call simply calls `init_with_partial_schema` and passes along all the specified kwargs, so this change does not alter any of the existing behavior, but just makes it more clear that we are reusing the existing schema information by calling `init_with_partial_schema`