### PR TITLE
Fix for numpy 1.24.0

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -9,10 +9,10 @@ Future Release
     * Fixes
         * Fix typo in ``_handle_binary_comparison`` function name and update ``set_feature_names`` docstring (:pr:`2388`)
         * Only allow Datetime time index as input to ``RateOfChange`` primitive (:pr:`2408`)
-        * Fix ``IsFreeEmailDomain`` to work with numpy 1.24.0 (:pr:`2414`)
     * Changes
         * Iterate only once over ``ignore_columns`` in ``DeepFeatureSynthesis`` init (:pr:`2397`)
         * Initialize Woodwork with ``init_with_partial_schama`` instead of ``init`` in ``EntitySet.add_last_time_indexes`` (:pr:`2409`)
+        * Updates for compatibility with numpy 1.24.0 (:pr:`2414`)
     * Documentation Changes
         *  Remove unused sections from 1.19.0 notes (:pr:`2396`)
     * Testing Changes

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -9,6 +9,7 @@ Future Release
     * Fixes
         * Fix typo in ``_handle_binary_comparison`` function name and update ``set_feature_names`` docstring (:pr:`2388`)
         * Only allow Datetime time index as input to ``RateOfChange`` primitive (:pr:`2408`)
+        * Fix ``IsFreeEmailDomain`` to work with numpy 1.24.0 (:pr:`2414`)
     * Changes
         * Iterate only once over ``ignore_columns`` in ``DeepFeatureSynthesis`` init (:pr:`2397`)
         * Initialize Woodwork with ``init_with_partial_schama`` instead of ``init`` in ``EntitySet.add_last_time_indexes`` (:pr:`2409`)

--- a/featuretools/primitives/standard/transform/email/is_free_email_domain.py
+++ b/featuretools/primitives/standard/transform/email/is_free_email_domain.py
@@ -54,7 +54,7 @@ class IsFreeEmailDomain(TransformPrimitive):
             # if there are any NaN domain values, change the series type to allow for
             # both bools and NaN values and set is_free to NaN for the NaN domains
             if emails_df["domain"].isnull().values.any():
-                emails_df["is_free"] = emails_df["is_free"].astype(np.object)
+                emails_df["is_free"] = emails_df["is_free"].astype("object")
                 emails_df.loc[emails_df["domain"].isnull(), "is_free"] = np.nan
             return emails_df.is_free.values
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ test = [
 spark = [
     "woodwork[spark] >= 0.18.0",
     "pyspark >= 3.2.2",
-    "numpy <= 1.24.0",
+    "numpy < 1.24.0",
 ]
 updater = [
     "alteryx-open-src-update-checker >= 2.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ test = [
 spark = [
     "woodwork[spark] >= 0.18.0",
     "pyspark >= 3.2.2",
+    "numpy <= 1.24.0",
 ]
 updater = [
     "alteryx-open-src-update-checker >= 2.1.0"


### PR DESCRIPTION
### Fix for numpy 1.24.0

Use `"object"` string instead of `np.object` which has been removed.