### PR TITLE
v1.20.0

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,9 +3,18 @@
 Release Notes
 -------------
 
+.. Future Release
+  ==============
+    * Enhancements
+    * Fixes
+    * Changes
+    * Documentation Changes
+    * Testing Changes
 
-Future Release
-==============
+.. Thanks to the following people for contributing to this release:
+
+Jan 5, 2023
+===========
     * Enhancements
         * Add ``TimeSinceLastFalse``, ``TimeSinceLastMax``, ``TimeSinceLastMin``, and ``TimeSinceLastTrue`` primitives (:pr:`2418`)
         * Add ``MaxConsecutiveFalse``, ``MaxConsecutiveNegatives``, ``MaxConsecutivePositives``, ``MaxConsecutiveTrue``, ``MaxConsecutiveZeros``, ``NumConsecutiveGreaterMean``, ``NumConsecutiveLessMean`` (:pr:`2420`)
@@ -24,10 +33,9 @@ Future Release
         * Resolve empty Pandas series warnings (:pr:`2403`)
         * Initialize Woodwork with ``init_with_partial_schama`` instead of ``init`` in ``EntitySet.add_last_time_indexes`` (:pr:`2409`)
         * Updates for compatibility with numpy 1.24.0 (:pr:`2414`)
-        * The `delimiter_regex` parameter for ``TotalWordLength`` has been renamed to `do_not_count` (:pr:`2423`)
+        * The ``delimiter_regex`` parameter for ``TotalWordLength`` has been renamed to ``do_not_count`` (:pr:`2423`)
     * Documentation Changes
         *  Remove unused sections from 1.19.0 notes (:pr:`2396`)
-    * Testing Changes
 
    Thanks to the following people for contributing to this release:
    :user:`gsheni`, :user:`rwedge`, :user:`sbadithe`, :user:`thehomebrewnerd`
@@ -35,7 +43,7 @@ Future Release
 
 Breaking Changes
 ++++++++++++++++
-* The `delimiter_regex` parameter for ``TotalWordLength`` has been renamed to `do_not_count`.
+* The ``delimiter_regex`` parameter for ``TotalWordLength`` has been renamed to ``do_not_count``.
   Old saved features that had a non-default value for the parameter will no longer load.
 * Support for ``Datetime`` and ``Ordinal`` inputs has been removed from the ``LessThanScalar``,
   ``GreaterThanScalar``, ``LessThanEqualToScalar`` and ``GreaterThanEqualToScalar`` primitives.

--- a/featuretools/tests/test_version.py
+++ b/featuretools/tests/test_version.py
@@ -2,4 +2,4 @@ from featuretools import __version__
 
 
 def test_version():
-    assert __version__ == "1.19.0"
+    assert __version__ == "1.20.0"

--- a/featuretools/version.py
+++ b/featuretools/version.py
@@ -1,3 +1,3 @@
-__version__ = "1.19.0"
+__version__ = "1.20.0"
 ENTITYSET_SCHEMA_VERSION = "9.0.0"
 FEATURES_SCHEMA_VERSION = "10.0.0"


### PR DESCRIPTION

**Jan 5, 2023**

* Enhancements
    * Add ``TimeSinceLastFalse``, ``TimeSinceLastMax``, ``TimeSinceLastMin``, and ``TimeSinceLastTrue`` primitives (#2418)
    * Add ``MaxConsecutiveFalse``, ``MaxConsecutiveNegatives``, ``MaxConsecutivePositives``, ``MaxConsecutiveTrue``, ``MaxConsecutiveZeros``, ``NumConsecutiveGreaterMean``, ``NumConsecutiveLessMean`` (#2420)
* Fixes
    * Fix typo in ``_handle_binary_comparison`` function name and update ``set_feature_names`` docstring (#2388)
    * Only allow Datetime time index as input to ``RateOfChange`` primitive (#2408)
    * Prevent catastrophic backtracking in regex for ``NumberOfWordsInQuotes`` (#2413)
    * Fix to eliminate fragmentation ``PerformanceWarning`` in ``feature_set_calculator.py`` (#2424)
    * Fix serialization of ``NumberOfCommonWords`` feature with custom word_set (#2432)
    * Improve edge case handling in NaturalLanguage primitives by standardizing delimiter regex (#2423)
    * Remove support for ``Datetime`` and ``Ordinal`` inputs in several primitives to prevent creation of Features that cannot be calculated (#2434)
* Changes
    * Refactor ``_all_direct_and_same_path`` by deleting call to ``_features_have_same_path`` (#2400)
    * Refactor ``_build_transform_features`` by iterating over ``input_features`` once (#2400)
    * Iterate only once over ``ignore_columns`` in ``DeepFeatureSynthesis`` init (#2397)
    * Resolve empty Pandas series warnings (#2403)
    * Initialize Woodwork with ``init_with_partial_schama`` instead of ``init`` in ``EntitySet.add_last_time_indexes`` (#2409)
    * Updates for compatibility with numpy 1.24.0 (#2414)
    * The ``delimiter_regex`` parameter for ``TotalWordLength`` has been renamed to ``do_not_count`` (#2423)
* Documentation Changes
    *  Remove unused sections from 1.19.0 notes (#2396)