### PR TITLE
Make CI min dependency tests not fail fast

### DIFF
--- a/.github/workflows/unit_tests_with_minimum_deps.yaml
+++ b/.github/workflows/unit_tests_with_minimum_deps.yaml
@@ -11,6 +11,7 @@ jobs:
     name: Unit Tests - 3.8 Minimum Dependencies
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         libraries: ["core", "spark - misc", "spark - computational", "spark - entityset_1", "spark - entityset_2", "spark - primitives"]
     steps:

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -11,6 +11,7 @@ Future Release
     * Documentation Changes
     * Testing Changes
         * Fix test compatibility with composeml 0.10 (:pr:`2439`)
+        * Minimum dependency unit test jobs do not abort if one job fails (:pr:`2437`)
 
     Thanks to the following people for contributing to this release:
     :user:`rwedge`


### PR DESCRIPTION
Prevent CI from stopping other minimum dependency unit test jobs if one fails
