### PR TITLE
Remove autouse from PrimitiveT.es fixture

### DIFF
--- a/featuretools/tests/primitive_tests/utils.py
+++ b/featuretools/tests/primitive_tests/utils.py
@@ -38,7 +38,7 @@ def get_number_from_offset(offset):
 class PrimitiveT:
     primitive = None
 
-    @pytest.fixture(autouse=True)
+    @pytest.fixture()
     def es(self):
         es = make_ecommerce_entityset()
         return es


### PR DESCRIPTION
The test class's test methods are not making use of autouse so this PR turns off autouse