### PR TITLE
Fix date range in HolidayUtil for compatibility with holidays 0.19.0

### DIFF
--- a/featuretools/primitives/standard/transform/datetime/utils.py
+++ b/featuretools/primitives/standard/transform/datetime/utils.py
@@ -19,7 +19,7 @@ class HolidayUtil:
             error = "must be one of the available countries:\n%s" % available_countries
             raise ValueError(error)
 
-        self.federal_holidays = getattr(holidays, country)(years=range(1950, 2100))
+        self.federal_holidays = getattr(holidays, country)(years=range(1950, 2075))
 
     def to_df(self):
         holidays_df = pd.DataFrame(


### PR DESCRIPTION
Fix date range in HolidayUtil for compatibility with holidays 0.19.0, change upper limit on date range from the year 2100 to 2075.