### PR TITLE
v1.25.0

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,22 +3,19 @@
 Release Notes
 -------------
 
-Future Release
-==============
+v1.24.0 Apr 13, 2023
+====================
     * Enhancements
         * Add ``MaxCount``, ``MedianCount``, ``MaxMinDelta``, ``NUniqueDays``, ``NMostCommonFrequency``,
             ``NUniqueDaysOfCalendarYear``, ``NUniqueDaysOfMonth``, ``NUniqueMonths``,
             ``NUniqueWeeks``, ``IsFirstWeekOfMonth`` (:pr:`2533`)
         * Add ``HasNoDuplicates``, ``NthWeekOfMonth``, ``IsMonotonicallyDecreasing``, ``IsMonotonicallyIncreasing``,
             ``IsUnique`` (:pr:`2537`)
-    * Fixes
     * Changes
         * Restrict pandas to < 2.0.0 (:pr:`2533`)
         * Upgrade minimum pandas to 1.5.0 (:pr:`2537`)
         * Removed the ``Correlation`` and ``AutoCorrelation`` primitive as these could lead to data leakage (:pr:`2537`)
         * Remove IntegerNullable support for ``Kurtosis`` primitive  (:pr:`2537`)
-    * Documentation Changes
-    * Testing Changes
 
     Thanks to the following people for contributing to this release:
     :user:`gsheni`

--- a/featuretools/tests/test_version.py
+++ b/featuretools/tests/test_version.py
@@ -2,4 +2,4 @@ from featuretools import __version__
 
 
 def test_version():
-    assert __version__ == "1.24.0"
+    assert __version__ == "1.25.0"

--- a/featuretools/version.py
+++ b/featuretools/version.py
@@ -1,3 +1,3 @@
-__version__ = "1.24.0"
+__version__ = "1.25.0"
 ENTITYSET_SCHEMA_VERSION = "9.0.0"
 FEATURES_SCHEMA_VERSION = "10.0.0"


### PR DESCRIPTION
v1.24.0 Apr 13, 2023
===============

* Enhancements
    * Add ``MaxCount``, ``MedianCount``, ``MaxMinDelta``, ``NUniqueDays``, ``NMostCommonFrequency``,
        ``NUniqueDaysOfCalendarYear``, ``NUniqueDaysOfMonth``, ``NUniqueMonths``,
        ``NUniqueWeeks``, ``IsFirstWeekOfMonth`` (#2533)
    * Add ``HasNoDuplicates``, ``NthWeekOfMonth``, ``IsMonotonicallyDecreasing``, ``IsMonotonicallyIncreasing``,
        ``IsUnique`` (#2537)
* Changes
    * Restrict pandas to < 2.0.0 (#2533)
    * Upgrade minimum pandas to 1.5.0 (#2537)
    * Removed the ``Correlation`` and ``AutoCorrelation`` primitive as these could lead to data leakage (#2537)
    * Remove IntegerNullable support for ``Kurtosis`` primitive  (#2537)