### PR TITLE
Temporarily restrict Woodwork max version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "psutil >= 5.6.6",
     "scipy >= 1.10.0",
     "tqdm >= 4.32.0",
-    "woodwork >= 0.23.0",
+    "woodwork >= 0.23.0,<0.26.0",
 ]
 
 [project.urls]
@@ -68,10 +68,10 @@ test = [
 dask = [
     "dask[dataframe] >= 2022.11.1",
     "distributed >= 2022.11.1",
-    "woodwork[dask] >= 0.23.0",
+    "woodwork[dask] >= 0.23.0,<0.26.0",
 ]
 spark = [
-    "woodwork[spark] >= 0.23.0",
+    "woodwork[spark] >= 0.23.0,<0.26.0",
     "pyspark >= 3.2.2",
     "numpy < 1.24.0",
     "pandas < 2.0.0",


### PR DESCRIPTION
### Pull Request Description
Temporarily restrict Woodwork max version to `<0.26.0`

Closes #2608 
