### PR TITLE
v1.28.0

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,9 +3,18 @@
 Release Notes
 -------------
 
-Future Release
-==============
+.. Future Release
+  ==============
     * Enhancements
+    * Fixes
+    * Changes
+    * Documentation Changes
+    * Testing Changes
+
+.. Thanks to the following people for contributing to this release:
+
+v1.28.0 Oct 26, 2023
+====================
     * Fixes
         * Fix bug with default value in ``PercentTrue`` primitive (:pr:`2627`)
     * Changes
@@ -22,7 +31,7 @@ Future Release
         * Removed old performance testing workflow (:pr:`2620`)
 
     Thanks to the following people for contributing to this release:
-    :user:`gsheni`, :user:`thehomebrewnerd`, :user:`petejanuszewski1`, :user:`tosemml`
+    :user:`gsheni`, :user:`petejanuszewski1`, :user:`thehomebrewnerd`, :user:`tosemml`
 
 v1.27.0 Jul 24, 2023
 ====================

--- a/featuretools/tests/test_version.py
+++ b/featuretools/tests/test_version.py
@@ -2,4 +2,4 @@ from featuretools import __version__
 
 
 def test_version():
-    assert __version__ == "1.27.0"
+    assert __version__ == "1.28.0"

--- a/featuretools/version.py
+++ b/featuretools/version.py
@@ -1,3 +1,3 @@
-__version__ = "1.27.0"
+__version__ = "1.28.0"
 ENTITYSET_SCHEMA_VERSION = "9.0.0"
 FEATURES_SCHEMA_VERSION = "10.0.0"


### PR DESCRIPTION
**v1.28.0 Oct 26, 2023**

* Fixes
    * Fix bug with default value in `PercentTrue` primitive (#2627)
* Changes
    * Refactor `featuretools/tests/primitive_tests/utils.py` to leverage list comprehensions for improved Pythonic quality (#2607)
    * Refactor `can_stack_primitive_on_inputs` (#2522)
    * Update s3 bucket for docs image (#2593)
    * Temporarily restrict pandas max version to `<2.1.0` and pyarrow to `<13.0.0` (#2609)
    * Update for compatibility with pandas version `2.1.0` and remove pandas upper version restriction (#2616)
* Documentation Changes
    * Fix badge on README for tests (#2598)
    * Update readthedocs config to use build.os (#2601)
* Testing Changes
    * Update airflow looking glass performance tests workflow (#2615)
    * Removed old performance testing workflow (#2620)
