### PR TITLE
v1.29.0

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -13,7 +13,7 @@ Release Notes
 
 .. Thanks to the following people for contributing to this release:
 
-v1.29.0 Feb 17, 2024
+v1.29.0 Feb 16, 2024
 ====================
     .. warning::
         This release of Featuretools will not support Python 3.8

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,12 +3,21 @@
 Release Notes
 -------------
 
-Future Release
-==============
+.. Future Release
+  ==============
+    * Enhancements
+    * Fixes
+    * Changes
+    * Documentation Changes
+    * Testing Changes
+
+.. Thanks to the following people for contributing to this release:
+
+v1.29.0 Feb 17, 2024
+====================
     .. warning::
         This release of Featuretools will not support Python 3.8
 
-    * Enhancements
     * Fixes
         * Fix dependency issues (:pr:`2644`, :pr:`2656`)
         * Add workaround for pandas 2.2.0 bug with nunique and unpin pandas deps (:pr:`2657`)

--- a/featuretools/tests/test_version.py
+++ b/featuretools/tests/test_version.py
@@ -2,4 +2,4 @@ from featuretools import __version__
 
 
 def test_version():
-    assert __version__ == "1.28.0"
+    assert __version__ == "1.29.0"

--- a/featuretools/version.py
+++ b/featuretools/version.py
@@ -1,3 +1,3 @@
-__version__ = "1.28.0"
+__version__ = "1.29.0"
 ENTITYSET_SCHEMA_VERSION = "9.0.0"
 FEATURES_SCHEMA_VERSION = "10.0.0"


### PR DESCRIPTION
### v1.29.0 Feb 16, 2024

#### warning:
    This release of Featuretools will not support Python 3.8

* Fixes
    * Fix dependency issues (#2644, #2656)
    * Add workaround for pandas 2.2.0 bug with nunique and unpin pandas deps (#2657)
* Changes
    * Fix deprecation warnings with is_categorical_dtype (#2641)
    * Remove woodwork, pyarrow, numpy, and pandas pins for spark installation (#2661)
* Documentation Changes
    * Update Featuretools logo to display properly in dark mode (#2632)
* Testing Changes
    * Update tests for compatibility with new versions of ``holidays`` (#2636)
    * Update ruff to 0.1.6 and use ruff linter/formatter (#2639)
    * Update ``release.yaml`` to use trusted publisher for PyPI releases (#2646, #2653, #2654)
    * Update dependency checkers and tests to include Dask (#2658)
    * Fix the tests that run with Woodwork main so they can be triggered (#2657)
    * Fix minimum dependency checker action (#2664)
    * Fix Slack alert for tests with Woodwork main branch (#2668)