### PR TITLE
Fixes for min dependency checker

### DIFF
--- a/.github/workflows/tests_with_latest_deps.yaml
+++ b/.github/workflows/tests_with_latest_deps.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Install featuretools with test requirements
         run: |
           python -m pip install -e unpacked_sdist/
-          python -m pip install -e unpacked_sdist/[test]
+          python -m pip install -e unpacked_sdist/[test,dask]
       - if: ${{ matrix.python_version == 3.9 }}
         name: Generate coverage args
         run: echo "coverage_args=--cov=featuretools --cov-config=../pyproject.toml --cov-report=xml:../coverage.xml" >> $GITHUB_ENV
@@ -98,7 +98,7 @@ jobs:
           conda config --add channels conda-forge
           conda install -q -y -c conda-forge python-graphviz graphviz
           python -m pip install --upgrade pip
-          python -m pip install .[test]
+          python -m pip install .[test,dask]
       - name: Run unit tests
         run: |
           . $env:USERPROFILE\Miniconda3\shell\condabin\conda-hook.ps1

--- a/.github/workflows/tests_with_woodwork_main_branch.yaml
+++ b/.github/workflows/tests_with_woodwork_main_branch.yaml
@@ -26,7 +26,7 @@ jobs:
           sudo apt update && sudo apt install -y graphviz
       - name: Install Woodwork & Featuretools - test requirements
         run: |
-          python -m pip install -e unpacked_sdist/[test]
+          python -m pip install -e unpacked_sdist/[test,dask]
           python -m pip uninstall -y woodwork
           python -m pip install https://github.com/alteryx/woodwork/archive/main.zip
       - name: Log test run info

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -14,6 +14,7 @@ Future Release
     * Documentation Changes
     * Testing Changes
         * Fix serialization test to work with pytest 8.1.1 (:pr:`2694`)
+        * Update to allow minimum dependency checker to run properly (:pr:`2709`)
 
     Thanks to the following people for contributing to this release:
     :user:`thehomebrewnerd`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,6 @@ test = [
     "smart-open >= 5.0.0",
     "urllib3 >= 1.26.18",
     "pytest-timeout >= 2.1.0",
-    "featuretools[dask]"
 ]
 dask = [
     "dask[dataframe] >= 2023.2.0",


### PR DESCRIPTION
Removes dask from the test extra to fix issue with min dependency checker not knowing what to do with an entry without a version specifier.

Closes #2708 