### PR TITLE
Use filter arg in tarfile.extractall to prevent unsafe unarchival operations

### DIFF
--- a/.github/workflows/release_notes_updated.yaml
+++ b/.github/workflows/release_notes_updated.yaml
@@ -10,6 +10,8 @@ jobs:
       - name: Check for development branch
         id: branch
         shell: python
+        env:
+          REF: ${{ github.event.pull_request.head.ref }}
         run: |
           from re import compile
           main = '^main$'
@@ -19,7 +21,7 @@ jobs:
           min_dep_update = '^min-dep-update-[a-f0-9]{7}$'
           regex = main, release, backport, dep_update, min_dep_update
           patterns = list(map(compile, regex))
-          ref = "${{ github.event.pull_request.head.ref }}"
+          ref = "$REF"
           is_dev = not any(pattern.match(ref) for pattern in patterns)
           print('::set-output name=is_dev::' + str(is_dev))
       - if: ${{ steps.branch.outputs.is_dev == 'true' }}

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -13,6 +13,7 @@ Future Release
         * Temporarily restrict Dask version (:pr:`2694`)
         * Remove support for creating ``EntitySets`` from Dask or Pyspark dataframes (:pr:`2705`)
         * Bump minimum versions of ``tqdm`` and ``pip`` in requirements files (:pr:`2716`)
+        * Use ``filter`` arg in call to ``tarfile.extractall`` to safely deserialize EntitySets (:pr:`2722`)
     * Documentation Changes
     * Testing Changes
         * Fix serialization test to work with pytest 8.1.1 (:pr:`2694`)

--- a/featuretools/entityset/deserialize.py
+++ b/featuretools/entityset/deserialize.py
@@ -141,7 +141,7 @@ def read_data_description(path):
 def read_entityset(path, profile_name=None, **kwargs):
     """Read entityset from disk, S3 path, or URL.
 
-    NOTE: Never attempt to read an archived entityset from an untrusted source.
+    NOTE: Never attempt to read an archived EntitySet from an untrusted source.
 
     Args:
         path (str): Directory on disk, S3 path, or URL to read `data_description.json`.

--- a/featuretools/tests/entityset_tests/test_serialization.py
+++ b/featuretools/tests/entityset_tests/test_serialization.py
@@ -2,7 +2,7 @@ import json
 import logging
 import os
 import tempfile
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 from urllib.request import urlretrieve
 
 import boto3
@@ -290,6 +290,18 @@ def test_deserialize_local_tar(es):
         urlretrieve(URL, filename=temp_tar_filepath)
         new_es = deserialize.read_entityset(temp_tar_filepath)
         assert es.__eq__(new_es, deep=True)
+
+
+@patch("featuretools.entityset.deserialize.getfullargspec")
+def test_deserialize_errors_if_python_version_unsafe(mock_inspect, es):
+    mock_response = MagicMock()
+    mock_response.kwonlyargs = []
+    mock_inspect.return_value = mock_response
+    with tempfile.TemporaryDirectory() as tmp_path:
+        temp_tar_filepath = os.path.join(tmp_path, TEST_FILE)
+        urlretrieve(URL, filename=temp_tar_filepath)
+        with pytest.raises(RuntimeError, match=""):
+            deserialize.read_entityset(temp_tar_filepath)
 
 
 def test_deserialize_url_csv(es):


### PR DESCRIPTION
Closes #2723 

The filter argument was added in these Python versions: 3.9.17, 3.10.12, 3.11.4, 3.12.0. If the user is running an older Python version an error will be thrown and they will need to upgrade to one of these patch releases (or newer) to extract the archive.
