### PR TITLE
v1.31.0

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,8 +3,18 @@
 Release Notes
 -------------
 
-Future Release
-==============
+.. Future Release
+  ==============
+    * Enhancements
+    * Fixes
+    * Changes
+    * Documentation Changes
+    * Testing Changes
+
+.. Thanks to the following people for contributing to this release:
+
+v1.31.0 May 14, 2024
+====================
     * Enhancements
         * Add support for Python 3.12 (:pr:`2713`)
     * Fixes
@@ -14,7 +24,6 @@ Future Release
         * Remove support for creating ``EntitySets`` from Dask or Pyspark dataframes (:pr:`2705`)
         * Bump minimum versions of ``tqdm`` and ``pip`` in requirements files (:pr:`2716`)
         * Use ``filter`` arg in call to ``tarfile.extractall`` to safely deserialize EntitySets (:pr:`2722`)
-    * Documentation Changes
     * Testing Changes
         * Fix serialization test to work with pytest 8.1.1 (:pr:`2694`)
         * Update to allow minimum dependency checker to run properly (:pr:`2709`)

--- a/featuretools/tests/test_version.py
+++ b/featuretools/tests/test_version.py
@@ -2,4 +2,4 @@ from featuretools import __version__
 
 
 def test_version():
-    assert __version__ == "1.30.0"
+    assert __version__ == "1.31.0"

--- a/featuretools/version.py
+++ b/featuretools/version.py
@@ -1,3 +1,3 @@
-__version__ = "1.30.0"
+__version__ = "1.31.0"
 ENTITYSET_SCHEMA_VERSION = "9.0.0"
 FEATURES_SCHEMA_VERSION = "10.0.0"


### PR DESCRIPTION
**v1.31.0 May 14, 2024**

* Enhancements
    * Add support for Python 3.12 (#2713)
* Fixes
    * Move ``flatten_list`` util function into ``feature_discovery`` module to fix import bug (#2702)
* Changes
    * Temporarily restrict Dask version (#2694)
    * Remove support for creating ``EntitySets`` from Dask or Pyspark dataframes (#2705)
    * Bump minimum versions of ``tqdm`` and ``pip`` in requirements files (#2716)
    * Use ``filter`` arg in call to ``tarfile.extractall`` to safely deserialize EntitySets (#2722)
* Testing Changes
    * Fix serialization test to work with pytest 8.1.1 (#2694)
    * Update to allow minimum dependency checker to run properly (#2709)
    * Update pull request check CI action (#2720)
    * Update release notes updated check CI action (#2726)