### PR TITLE
To access a value by position, use ser.iloc[pos]

### DIFF
--- a/featuretools/primitives/standard/transform/time_series/expanding/expanding_count.py
+++ b/featuretools/primitives/standard/transform/time_series/expanding/expanding_count.py
@@ -69,7 +69,7 @@ class ExpandingCount(TransformPrimitive):
                 min_periods=self.min_periods,
             ).count()
             num_nans = self.gap + self.min_periods - 1
-            count_series[range(num_nans)] = np.nan
+            count_series.iloc[range(num_nans)] = np.nan
             return count_series
 
         return expanding_count

--- a/featuretools/tests/computational_backend/test_feature_set_calculator.py
+++ b/featuretools/tests/computational_backend/test_feature_set_calculator.py
@@ -517,7 +517,7 @@ def test_make_3_stacked_agg_feats(df):
     feature_set = FeatureSet([sum_3])
     calculator = FeatureSetCalculator(es, time_last=None, feature_set=feature_set)
     df = calculator.run(np.array(["z"]))
-    v = df[sum_3.get_name()][0]
+    v = df[sum_3.get_name()].iloc[0]
     assert v == 5
 
 
@@ -635,7 +635,7 @@ def test_deep_agg_feat_chain(es):
     calculator = FeatureSetCalculator(es, time_last=None, feature_set=feature_set)
     df = calculator.run(np.array(["United States"]))
 
-    v = df[region_avg_feat.get_name()][0]
+    v = df[region_avg_feat.get_name()].iloc[0]
     assert v == 17 / 3.0
 
 
@@ -696,7 +696,7 @@ def test_direct_squared(es):
     calculator = FeatureSetCalculator(es, time_last=None, feature_set=feature_set)
     df = calculator.run(np.array([0, 1, 2]))
     for i, row in df.iterrows():
-        assert (row[0] * row[0]) == row[1]
+        assert (row.iloc[0] * row.iloc[0]) == row.iloc[1]
 
 
 def test_agg_empty_child(es):

--- a/featuretools/tests/primitive_tests/transform_primitive_tests/test_expanding_primitives.py
+++ b/featuretools/tests/primitive_tests/transform_primitive_tests/test_expanding_primitives.py
@@ -28,7 +28,7 @@ def test_expanding_count_series(window_series, min_periods, gap):
     test = window_series.shift(gap)
     expected = test.expanding(min_periods=min_periods).count()
     num_nans = gap + min_periods - 1
-    expected[range(num_nans)] = np.nan
+    expected.iloc[range(num_nans)] = np.nan
     primitive_instance = ExpandingCount(min_periods=min_periods, gap=gap).get_function()
     actual = primitive_instance(window_series.index)
     pd.testing.assert_series_equal(pd.Series(actual), expected)
@@ -47,7 +47,7 @@ def test_expanding_count_date_range(window_date_range, min_periods, gap):
     test = _apply_gap_for_expanding_primitives(gap=gap, x=window_date_range)
     expected = test.expanding(min_periods=min_periods).count()
     num_nans = gap + min_periods - 1
-    expected[range(num_nans)] = np.nan
+    expected.iloc[range(num_nans)] = np.nan
     primitive_instance = ExpandingCount(min_periods=min_periods, gap=gap).get_function()
     actual = primitive_instance(window_date_range)
     pd.testing.assert_series_equal(pd.Series(actual), expected)


### PR DESCRIPTION
### Pull Request Description

This PR removes the warnings:

`FutureWarning: Series.__getitem__ treating keys as positions is deprecated. In a future version, integer keys will always be treated as labels (consistent with DataFrame behavior). To access a value by position, use ser.iloc[pos].`

release_notes_updated #2751 

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request.*
