### PR TITLE
Fixed query_by_values so that it only accepts series and lists.

### DIFF
--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -1470,7 +1470,7 @@ class EntitySet(object):
 
         Args:
             dataframe_name (str): The id of the dataframe to query
-            instance_vals (pd.Dataframe, pd.Series, list[str] or str) :
+            instance_vals (pd.Series) :
                 Instance(s) to match.
             column_name (str) : Column to query on. If None, query on index.
             columns (list[str]) : Columns to return. Return all columns if None.
@@ -1501,7 +1501,7 @@ class EntitySet(object):
         if instance_vals is None:
             df = dataframe.copy()
 
-        elif isinstance(instance_vals, pd.Series) and instance_vals.empty:
+        elif instance_vals.empty:
             df = dataframe.head(0)
 
         else:
@@ -1681,21 +1681,12 @@ class EntitySet(object):
 
 def _vals_to_series(instance_vals, column_id):
     """
-    instance_vals may be a pd.Dataframe, a pd.Series, a list, a single
-    value, or None. This function always returns a Series or None.
+    instance_vals may be a pd.Series, a list, or None. This function always returns a Series or None.
     """
     if instance_vals is None:
         return None
-
-    # If this is a single value, make it a list
-    if not hasattr(instance_vals, "__iter__"):
-        instance_vals = [instance_vals]
-
-    # convert iterable to pd.Series
-    if isinstance(instance_vals, pd.DataFrame):
-        out_vals = instance_vals[column_id]
-    else:
-        out_vals = pd.Series(instance_vals)
+    
+    out_vals = pd.Series(instance_vals)
 
     # no duplicates or NaN values
     out_vals = out_vals.drop_duplicates().dropna()


### PR DESCRIPTION
…o changed _vals_to_series

### Pull Request Description
I edited the query_by_values and vals_to_series methods so that they don't handle the parameter instance_vals of types pd.DataFrame or str. I did this by removing conversion from these types to pd.Series. 

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request.*
