### PR TITLE
TST: add test to confirm primitive input_types (#2086)

### DIFF
--- a/featuretools/tests/entry_point_tests/test_primitives.py
+++ b/featuretools/tests/entry_point_tests/test_primitives.py
@@ -1,6 +1,4 @@
-import pytest
-import featuretools as ft
-from featuretools.primitives import MultiplyNumericScalar, Year
+
 
 from featuretools.tests.entry_point_tests.utils import (
     _import_featuretools,
@@ -32,15 +30,3 @@ primitive_test_data = [
     (Year(), ["2020-01-01", "2019-12-31"], int)
 ]
 
-@pytest.mark.parametrize("primitive, values, expected_dtype", primitive_test_data)
-def test_primitive_input_types(primitive, values, expected_dtype):
-    es = ft.demo.load_retail(nrows=5)
-    fm, features = ft.dfs(
-        entityset=es,
-        target_dataframe_name="orders",
-        trans_primitives=[primitive],
-        max_depth=1,
-    )
-    col = features[-1].name
-    dtype = fm[col].dtype
-    assert expected_dtype in str(dtype), f"{primitive} returned dtype {dtype}"

--- a/featuretools/tests/entry_point_tests/test_primitives.py
+++ b/featuretools/tests/entry_point_tests/test_primitives.py
@@ -1,3 +1,7 @@
+import pytest
+import featuretools as ft
+from featuretools.primitives import MultiplyNumericScalar, Year
+
 from featuretools.tests.entry_point_tests.utils import (
     _import_featuretools,
     _install_featuretools_primitives,
@@ -21,3 +25,22 @@ def test_entry_point():
     existing_primitive += 'ignored primitive "Sum" from "featuretools_primitives.existing_primitive" because a primitive '
     existing_primitive += 'with that name already exists in "featuretools.primitives.standard.aggregation.sum_primitive"'
     assert existing_primitive in featuretools_log
+
+
+primitive_test_data = [
+    (MultiplyNumericScalar(2), [1, 2.5, -3], float),
+    (Year(), ["2020-01-01", "2019-12-31"], int)
+]
+
+@pytest.mark.parametrize("primitive, values, expected_dtype", primitive_test_data)
+def test_primitive_input_types(primitive, values, expected_dtype):
+    es = ft.demo.load_retail(nrows=5)
+    fm, features = ft.dfs(
+        entityset=es,
+        target_dataframe_name="orders",
+        trans_primitives=[primitive],
+        max_depth=1,
+    )
+    col = features[-1].name
+    dtype = fm[col].dtype
+    assert expected_dtype in str(dtype), f"{primitive} returned dtype {dtype}"

--- a/featuretools/tests/primitive_tests/test_primitive_input_types.py
+++ b/featuretools/tests/primitive_tests/test_primitive_input_types.py
@@ -1,0 +1,19 @@
+import pytest
+import featuretools as ft
+from featuretools.primitives import MultiplyNumericScalar, Year
+
+@pytest.mark.parametrize("primitive, expected_dtype", [
+    (MultiplyNumericScalar(2), "float"),
+    (Year(), "int")
+])
+def test_primitive_input_types(primitive, expected_dtype):
+    es = ft.demo.load_retail(nrows=10)
+    fm, features = ft.dfs(
+        entityset=es,
+        target_dataframe_name="orders",
+        trans_primitives=[primitive],
+        max_depth=1,
+    )
+    col = features[-1].get_name()
+    dtype = fm[col].dtype
+    assert expected_dtype in str(dtype), f"{primitive} returned dtype {dtype}"


### PR DESCRIPTION
## What does this PR do?

Adds a test under `featuretools\tests\primitive_tests\test_primitive_input_types.py` to confirm that primitives in FeatureTools behave correctly regarding their `input_types`.

### What’s Covered?

- ✅ Parametrized tests for `MultiplyNumericScalar` and `Year` primitives.
- ✅ Checks expected dtype in feature matrix output.

### Why?

Helps detect future regressions in how primitives declare and validate input types.

### How to Run?

```bash
pytest featuretools/tests/test_primitive_input_types.py
