### PR TITLE
security: add trusted_source warnings for pickle deserialization and HMAC signing for distributed feature sets

### DIFF
--- a/featuretools/computational_backends/calculate_feature_matrix.py
+++ b/featuretools/computational_backends/calculate_feature_matrix.py
@@ -1,3 +1,5 @@
+import hmac
+import hashlib
 import logging
 import math
 import os
@@ -46,6 +48,11 @@ PBAR_FORMAT = "Elapsed: {elapsed} | Progress: {l_bar}{bar}"
 FEATURE_CALCULATION_PERCENTAGE = (
     0.95  # make total 5% higher to allot time for wrapping up at end
 )
+
+
+class SecurityError(Exception):
+    """Raised when distributed feature set signature verification fails."""
+    pass
 
 
 def calculate_feature_matrix(
@@ -387,7 +394,19 @@ def calculate_chunk(
     schema=None,
 ):
     if not isinstance(feature_set, FeatureSet):
-        feature_set = cloudpickle.loads(feature_set)  # pragma: no cover
+        secret = os.environ.get("FEATURETOOLS_DISTRIBUTED_SECRET")
+        if secret:
+            if not isinstance(feature_set, tuple) or len(feature_set) != 2:
+                raise SecurityError("Invalid signed feature set format")
+            pickled_bytes, signature = feature_set
+            expected = hmac.new(
+                secret.encode(), pickled_bytes, hashlib.sha256,
+            ).hexdigest()
+            if not hmac.compare_digest(expected, signature):
+                raise SecurityError("Feature set signature verification failed")
+            feature_set = cloudpickle.loads(pickled_bytes)  # pragma: no cover
+        else:
+            feature_set = cloudpickle.loads(feature_set)  # pragma: no cover
 
     feature_matrix = []
     if no_unapproximated_aggs and approximate is not None:
@@ -741,6 +760,12 @@ def parallel_calculate_chunks(
 
         # save features to a tempfile and scatter it
         pickled_feats = cloudpickle.dumps(feature_set)
+        secret = os.environ.get("FEATURETOOLS_DISTRIBUTED_SECRET")
+        if secret:
+            signature = hmac.new(
+                secret.encode(), pickled_feats, hashlib.sha256,
+            ).hexdigest()
+            pickled_feats = (pickled_feats, signature)
         _saved_features = client.scatter(pickled_feats)
         client.replicate([_es, _saved_features])
         num_scattered_workers = len(

--- a/featuretools/entityset/deserialize.py
+++ b/featuretools/entityset/deserialize.py
@@ -2,6 +2,7 @@ import json
 import os
 import tarfile
 import tempfile
+import warnings
 from inspect import getfullargspec
 
 import pandas as pd
@@ -24,6 +25,14 @@ def description_to_entityset(description, **kwargs):
     Returns:
         entityset (EntitySet) : Instance of :class:`.EntitySet`.
     """
+    if description.get("format") == "pickle" and not kwargs.get("trusted_source"):
+        warnings.warn(
+            "The EntitySet you are attempting to read contains data serialized using pickle. "
+            "Pickle files can execute arbitrary code during deserialization, which can be a security risk. "
+            "Only pass trusted_source=True if you trust the source of this file.",
+            RuntimeWarning,
+        )
+
     check_schema_version(description, "entityset")
 
     from featuretools.entityset import EntitySet
@@ -138,7 +147,7 @@ def read_data_description(path):
     return description
 
 
-def read_entityset(path, profile_name=None, **kwargs):
+def read_entityset(path, profile_name=None, trusted_source=False, **kwargs):
     """Read entityset from disk, S3 path, or URL.
 
     NOTE: Never attempt to read an archived EntitySet from an untrusted source.
@@ -147,6 +156,8 @@ def read_entityset(path, profile_name=None, **kwargs):
         path (str): Directory on disk, S3 path, or URL to read `data_description.json`.
         profile_name (str, bool): The AWS profile specified to write to S3. Will default to None and search for AWS credentials.
             Set to False to use an anonymous profile.
+        trusted_source (bool): Whether the source of the EntitySet is trusted. Defaults to False. Only set to True if you trust the source,
+            as pickle deserialization can execute arbitrary code.
         kwargs (keywords): Additional keyword arguments to pass as keyword arguments to the underlying deserialization method.
     """
     if _is_url(path) or _is_s3(path) or _is_local_tar(str(path)):
@@ -170,7 +181,21 @@ def read_entityset(path, profile_name=None, **kwargs):
                     )
 
             data_description = read_data_description(tmpdir)
-            return description_to_entityset(data_description, **kwargs)
+            if data_description.get("format") == "pickle" and not trusted_source:
+                warnings.warn(
+                    "The EntitySet you are attempting to read contains data serialized using pickle. "
+                    "Pickle files can execute arbitrary code during deserialization, which can be a security risk. "
+                    "Only pass trusted_source=True if you trust the source of this file.",
+                    RuntimeWarning,
+                )
+            return description_to_entityset(data_description, trusted_source=trusted_source, **kwargs)
     else:
         data_description = read_data_description(path)
-        return description_to_entityset(data_description, **kwargs)
+        if data_description.get("format") == "pickle" and not trusted_source:
+            warnings.warn(
+                "The EntitySet you are attempting to read contains data serialized using pickle. "
+                "Pickle files can execute arbitrary code during deserialization, which can be a security risk. "
+                "Only pass trusted_source=True if you trust the source of this file.",
+                RuntimeWarning,
+            )
+        return description_to_entityset(data_description, trusted_source=trusted_source, **kwargs)

--- a/featuretools/feature_base/features_deserializer.py
+++ b/featuretools/feature_base/features_deserializer.py
@@ -1,4 +1,5 @@
 import json
+import warnings
 
 from featuretools.entityset.deserialize import (
     description_to_entityset as deserialize_es,
@@ -19,7 +20,7 @@ from featuretools.utils.schema_utils import check_schema_version
 from featuretools.utils.wrangle import _is_s3, _is_url
 
 
-def load_features(features, profile_name=None):
+def load_features(features, profile_name=None, trusted_source=False):
     """Loads the features from a filepath, S3 path, URL, an open file, or a JSON formatted string.
 
     Args:
@@ -28,6 +29,10 @@ def load_features(features, profile_name=None):
 
         profile_name (str, bool): The AWS profile specified to write to S3. Will default to None and search for AWS credentials.
             Set to False to use an anonymous profile.
+
+        trusted_source (bool): Whether the source of the features is trusted. If False and the
+            entityset was saved using pickle format, a RuntimeWarning will be raised about the
+            risk of arbitrary code execution. Defaults to False.
 
     Returns:
         features (list[:class:`.FeatureBase`]): Feature definitions list.
@@ -64,7 +69,7 @@ def load_features(features, profile_name=None):
     .. seealso::
         :func:`.save_features`
     """
-    return FeaturesDeserializer.load(features, profile_name).to_list()
+    return FeaturesDeserializer.load(features, profile_name, trusted_source).to_list()
 
 
 class FeaturesDeserializer(object):
@@ -79,10 +84,20 @@ class FeaturesDeserializer(object):
         "FeatureOutputSlice": FeatureOutputSlice,
     }
 
-    def __init__(self, features_dict):
+    def __init__(self, features_dict, trusted_source=False):
         self.features_dict = features_dict
         self._check_schema_version()
-        self.entityset = deserialize_es(features_dict["entityset"])
+        if (
+            features_dict.get("entityset", {}).get("format") == "pickle"
+            and not trusted_source
+        ):
+            warnings.warn(
+                "The entityset was saved using pickle format. Loading pickle files "
+                "from untrusted sources can result in arbitrary code execution. "
+                "Only set trusted_source=True if you trust the source of this file.",
+                RuntimeWarning,
+            )
+        self.entityset = deserialize_es(features_dict["entityset"], trusted_source=trusted_source)
         self._deserialized_features = {}  # name -> feature
         primitive_deserializer = PrimitivesDeserializer()
         primitive_definitions = features_dict["primitive_definitions"]
@@ -92,7 +107,7 @@ class FeaturesDeserializer(object):
         }
 
     @classmethod
-    def load(cls, features, profile_name):
+    def load(cls, features, profile_name, trusted_source=False):
         if isinstance(features, str):
             try:
                 features_dict = json.loads(features)
@@ -108,8 +123,8 @@ class FeaturesDeserializer(object):
                 else:
                     with open(features, "r") as f:
                         features_dict = json.load(f)
-            return cls(features_dict)
-        return cls(json.load(features))
+            return cls(features_dict, trusted_source)
+        return cls(json.load(features), trusted_source)
 
     def to_list(self):
         feature_names = self.features_dict["feature_list"]


### PR DESCRIPTION
Security fix for pickle deserialization warnings and HMAC signing for distributed feature sets.