### PR TITLE
Update query_by_values instance_vals handling

### DIFF
--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -1470,8 +1470,9 @@ class EntitySet(object):
 
         Args:
             dataframe_name (str): The id of the dataframe to query
-            instance_vals (pd.Dataframe, pd.Series, list[str] or str) :
-                Instance(s) to match.
+            instance_vals (None, pd.Series, or iterable) :
+                Instance(s) to match. Values must be provided as a
+                ``pd.Series`` or an iterable of instance values.
             column_name (str) : Column to query on. If None, query on index.
             columns (list[str]) : Columns to return. Return all columns if None.
             time_last (pd.TimeStamp) : Query data up to and including this
@@ -1681,21 +1682,32 @@ class EntitySet(object):
 
 def _vals_to_series(instance_vals, column_id):
     """
-    instance_vals may be a pd.Dataframe, a pd.Series, a list, a single
-    value, or None. This function always returns a Series or None.
+    instance_vals may be None, a pd.Series, or an iterable of values.
+    This function always returns a Series or None.
     """
     if instance_vals is None:
         return None
 
-    # If this is a single value, make it a list
-    if not hasattr(instance_vals, "__iter__"):
-        instance_vals = [instance_vals]
+    if isinstance(instance_vals, str):
+        raise TypeError(
+            "instance_vals must be a pd.Series or an iterable of values, "
+            "not a string.",
+        )
 
-    # convert iterable to pd.Series
     if isinstance(instance_vals, pd.DataFrame):
-        out_vals = instance_vals[column_id]
-    else:
+        raise TypeError(
+            "instance_vals must be a pd.Series or an iterable of values, "
+            "not a pd.DataFrame.",
+        )
+
+    if isinstance(instance_vals, pd.Series):
+        out_vals = instance_vals
+    elif hasattr(instance_vals, "__iter__"):
         out_vals = pd.Series(instance_vals)
+    else:
+        raise TypeError(
+            "instance_vals must be a pd.Series or an iterable of values.",
+        )
 
     # no duplicates or NaN values
     out_vals = out_vals.drop_duplicates().dropna()

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -346,16 +346,25 @@ def test_query_by_id(es):
     assert df["id"].values[0] == 0
 
 
-def test_query_by_single_value(es):
-    df = es.query_by_values("log", instance_vals=0)
+def test_query_by_series(es):
+    df = es.query_by_values("log", instance_vals=pd.Series([0]))
     assert df["id"].values[0] == 0
 
 
-def test_query_by_df(es):
-    instance_df = pd.DataFrame({"id": [1, 3], "vals": [0, 1]})
-    df = es.query_by_values("log", instance_vals=instance_df)
+def test_query_by_single_value_rejected(es):
+    with pytest.raises(TypeError, match="instance_vals must be a pd.Series"):
+        es.query_by_values("log", instance_vals=0)
 
-    assert np.array_equal(df["id"], [1, 3])
+
+def test_query_by_string_rejected(es):
+    with pytest.raises(TypeError, match="instance_vals must be a pd.Series"):
+        es.query_by_values("log", instance_vals="0")
+
+
+def test_query_by_df_rejected(es):
+    instance_df = pd.DataFrame({"id": [1, 3], "vals": [0, 1]})
+    with pytest.raises(TypeError, match="instance_vals must be a pd.Series"):
+        es.query_by_values("log", instance_vals=instance_df)
 
 
 def test_query_by_id_with_time(es):


### PR DESCRIPTION
## Summary

Restricts `EntitySet.query_by_values` to accept `None`, `pd.Series`, or iterable instance values. Scalar, string, and DataFrame inputs now raise a clear `TypeError`.

## Motivation

Featuretools only calls `query_by_values` with a `pd.Series` during normal operation. Removing support for unused input types simplifies the codebase and test suite.

## Changes

- Updated `_vals_to_series()` to reject `str`, `pd.DataFrame`, and scalar inputs
- Updated docstring for `instance_vals` parameter
- Added tests for `pd.Series` support and rejection of invalid types
- Removed obsolete scalar/DataFrame success tests

## Testing

```bash
pytest featuretools/tests/entityset_tests/test_es.py -k "query_by"
```

All 12 related tests pass.

Fixes #1272